### PR TITLE
disable pyro initialization for webui.

### DIFF
--- a/shinken/daemons/webuidaemon.py
+++ b/shinken/daemons/webuidaemon.py
@@ -183,7 +183,7 @@ class Webui(Daemon):
                 self.log.log(line)
 
             self.load_config_file()
-            self.do_daemon_init_and_start()
+            self.do_daemon_init_and_start(use_pyro=False)
 
             ## And go for the main loop
             self.do_mainloop()


### PR DESCRIPTION
this prevent Pyro to bind socket shinken-webui daemon.port just before bottle bind the same port for the WSGI daemon.
