### PR TITLE
PB affichage bouton de recherche

### DIFF
--- a/shinken/webui/htdocs/css/nav.css
+++ b/shinken/webui/htdocs/css/nav.css
@@ -223,7 +223,7 @@ div div.tac_col_3{
 	margin-right:0px;
 	padding-top:0px;
 	padding-bottom:0px;
-	padding-left:0px;
+	padding-left:5px;
 	padding-right:0px;
 }
 


### PR DESCRIPTION
Le bouton pour la recherche empiète sur le textarea.
J'ai donc simplement espacé via un padding-left le bouton.

Je suis sous Xubuntu 11.10 avec Firefox 7.0.1
