### PR TITLE
J'ai centré les boutons d'acquittement & co 

### DIFF
--- a/shinken/webui/htdocs/css/layout.css
+++ b/shinken/webui/htdocs/css/layout.css
@@ -732,6 +732,9 @@ overall status */
 /***                 OPACITY        ******/
 #opacity_hover { opacity : 0.5;}
 
+.opacity_hover {
+        text-align: center;
+}
 
 form {
     clear: both;


### PR DESCRIPTION
J'ai centré les boutons d'acquittement & co car là ils étaient collés à gauche, ce qui différe de l'overview.

Par contre, l'id #opacity_hover n'est utilisé nulle part...
