### PR TITLE
Retrait des <br> par des <div>

### DIFF
--- a/shinken/webui/plugins/eltdetail/views/eltdetail.tpl
+++ b/shinken/webui/plugins/eltdetail/views/eltdetail.tpl
@@ -79,10 +79,15 @@ Invalid element name
 	%# canvas line here or we got problem!"
 	<center><canvas id="canvas" width="200" height="200"  style="border: 1px solid black;"></canvas></center>
 
-	  <br>
-	  <img title="By keeping a left click pressed and drawing a check, you will launch an acknowledgement." src="/static/eltdetail/images/gesture-check.png"/> Acknowledge<br>
-	  <img title="By keeping a left click pressed and drawing a check, you will launch an recheck." src="/static/eltdetail/images/gesture-circle.png"/> Recheck<br>
-	  <img title="By keeping a left click pressed and drawing a check, you will launch a try to fix command." src="/static/eltdetail/images/gesture-zigzag.png"/> Fix<br>
+		<div class="gesture_button">
+          	<img title="By keeping a left click pressed and drawing a check, you will launch an acknowledgement." src="/static/eltdetail/images/gesture-check.png"/> Acknowledge
+		</div>
+		<div class="gesture_button">
+          	<img title="By keeping a left click pressed and drawing a check, you will launch an recheck." src="/static/eltdetail/images/gesture-circle.png"/> Recheck
+		</div>
+		<div class="gesture_button">
+          	<img title="By keeping a left click pressed and drawing a check, you will launch a try to fix command." src="/static/eltdetail/images/gesture-zigzag.png"/> Fix
+		</div>
 	</div>
   </div>
 </div>


### PR DESCRIPTION
J'ai remplacer les <br> par des <div>, ce qui est mieux je pense et permet d'appliquer des styles plus finement.

Ça résout également le problème du même nom pour la classe et l'id css.

I've modify <br> by <div>, I think it's better and can more accurately apply css styles.
It also solves the problem of the same name for the class and id css.

For screenshot, look on #70 Pull
