### PR TITLE
Man pages updates

### DIFF
--- a/doc/man/shinken-admin.8shinken
+++ b/doc/man/shinken-admin.8shinken
@@ -1,4 +1,4 @@
-.TH shinken-admin 8 "October 12, 2011" "Shinken User Manuals"
+.TH shinken-admin 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
 shinken-admin - Shinken admin shell
@@ -7,7 +7,7 @@ shinken-admin - Shinken admin shell
 shinken-admin
 .SH DESCRIPTION
 .PP
-Shinken admin shell.
+Shinken admin shell
 .PP
 Invokes a simple shell interface for interacting with shinken-arbiter
 .SH AUTHORS

--- a/doc/man/shinken-arbiter.8shinken
+++ b/doc/man/shinken-arbiter.8shinken
@@ -1,23 +1,30 @@
-.TH shinken-arbiter 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-arbiter 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-arbiter - Shinken arbiter command.
+shinken-arbiter - Shinken arbiter daemon
 .SH SYNOPSIS
 .PP
-shinken-arbiter [\f[I]options\f[]] \&...
+shinken-arbiter [-dr] [-c \f[I]CONFIGFILE\f[]] [\[em]debugfile
+\f[I]DEBUGFILE\f[]] shinken-arbiter -v [-c \f[I]CONFIGFILE\f[]]
 .SH DESCRIPTION
 .PP
-Shinken arbiter daemon.
+Shinken arbiter daemon
 .PP
-Reads the configuration, cuts it into parts (N schedulers = N parts),
-and then send them to all others elements.
-It also manages the high availability feature : if an element dies, it
-re-routes the configuration managed by this falling element to a spare
-one.
-Its other role is to receive input from users (like external commands
-from nagios.cmd) and sends them to other elements.
-There can be only one active arbiter in the architecture.
+The shinken-arbiter daemon reads the configuration, divides it into
+parts (N schedulers = N parts), and distributes them to the appropriate
+Shinken daemons.
+Additionally, it manages the high availability features: if a particular
+daemon dies, it re-routes the configuration managed by this failed
+daemon to the configured spare.
+Finally, it receives input from users (such as external commands from
+nagios.cmd) and routes them to the appropriate daemon.
+There can only be one active arbiter in the architecture.
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -39,8 +46,13 @@ Print detailed help screen.
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]DEBUGFILE\f[]
+Enable debug logging to \f[I]DEBUGFILE\f[]
+.RS
+.RE
+.TP
+.B -v, --verify-config
+Verify config file and exit
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-broker.8shinken
+++ b/doc/man/shinken-broker.8shinken
@@ -1,21 +1,31 @@
-.TH shinken-broker 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-broker 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-broker - Shinken broker command.
+shinken-broker - Shinken broker daemon
 .SH SYNOPSIS
 .PP
-shinken-broker [\f[I]options\f[]] \&...
+shinken-broker [-dr] [-c \f[I]CONFIGFILE\f[]] [\[em]debugfile
+\f[I]DEBUGFILE\f[]]
 .SH DESCRIPTION
 .PP
-Shinken receiver daemon.
+Shinken broker daemon.
 .PP
-Its role is to get data from schedulers (like status) and manage it
-(like storing it in database).
+The shinken-broker's role is to export and manage data from schedulers
+(such as status).
 The management itself is done by modules.
-Different modules exists : export into ndo database (MySQL and Oracle
-backend), export to merlin database (MySQL), service-perfdata export and
-a couchdb export, or a mix of them (why not?).
+.PP
+The following management modules are included: * export into an NDO
+(Nagios Data Out) database (MySQL or Oracle backend) * export to MERLIN
+(Module for Effortless Redundancy and Loadbalancing In Nagios) database
+(MySQL backend) * service-perfdata export * export to CouchDB
+.PP
+Multiple modules can be enabled simultaneously
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -23,17 +33,22 @@ Config file
 .RE
 .TP
 .B -d, --daemon
-Run in daemon mode.
+Run in daemon mode
+.RS
+.RE
+.TP
+.B -r, --replace
+Replace previously running broker
 .RS
 .RE
 .TP
 .B -h, --help
-Print detailed help screen.
+Print detailed help screen
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]DEBUGFILE\f[]
+Enable debug logging to \f[I]DEBUGFILE\f[]
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-discovery.8shinken
+++ b/doc/man/shinken-discovery.8shinken
@@ -1,54 +1,58 @@
-.TH shinken-discovery 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-discovery 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-discovery - Shinken discovery command.
+shinken-discovery - Shinken discovery command
 .SH SYNOPSIS
 .PP
-shinken-discovery [\f[I]options\f[]] \&...
+shinken-discovery [-w] [-c \f[I]CONFIGFILE\f[]] [-o
+\f[I]OUTPUT_PATH\f[]] [-r \f[I]RUNNER\f[][,\f[I]RUNNER,\&...]]
+[-m\f[]MACRO* [\f[I]MACRO\f[] \&...]]
 .SH DESCRIPTION
 .PP
-Shinken discovery daemon.
+Shinken discovery command
 .PP
-Until now, there are two discovery modules : * Standard network one,
-that uses the nmap tool * VMware one, that uses the
+There are two discovery modules included: * Standard network discovery
+which uses the nmap tool * VMware discovery which uses the
 \f[I]check_esx3.pl\f[] script and a vcenter installation.
 .PP
-It's better to do the whole discovery in one pass, because one module
-can use data from the other.
+It is best to do the whole discovery in one pass because one module can
+use data from the other.
 .SH OPTIONS
 .TP
-.B -c \f[I]CONFIGFILE\f[], --cfg-config \f[I]CONFIGGILE\f[]
-Configuration file.
+.B -- version
+Show the version and exit
 .RS
 .RE
 .TP
-.B -o \f[I]DIRECTORY\f[], --dir-output \f[I]DIRECTORY\f[]
-output directory.
+.B -c \f[I]CONFIGFILE\f[], --cfg-input \f[I]CONFIGGILE\f[]
+Discovery configuration file
 .RS
 .RE
 .TP
-.B -w, --overwrite
-Allow overwriting existing files.
+.B -o \f[I]OUTPUT_PATH\f[], --dir-output \f[I]OUTPUT_PATH\f[]
+Directory output for results
 .RS
 .RE
 .TP
-.B -r \f[I]PATH\f[]
-Indicate path to the nmap binary.
+.B -w, --overright
+Allow overwriting existing files (disabled by default)
 .RS
 .RE
 .TP
-.B -m \f[I]NETWORK\f[]
-Indicate lan to scan.
+.B -r \f[I]RUNNERS\f[]
+Comma-separated list of discovery runner modules to use
+.RS
+.RE
+.TP
+.B -m \f[I]MACROS\f[]
+List of macros to pass to discovery runner modules.
+Must be the last argument.
+Ex: NMAPTARGETS=192.168.0.0/24
 .RS
 .RE
 .TP
 .B -h, --help
 Print detailed help screen.
-.RS
-.RE
-.TP
-.B --debug \f[I]FILE\f[]
-Debug File.
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-poller.8shinken
+++ b/doc/man/shinken-poller.8shinken
@@ -1,15 +1,22 @@
-.TH shinken-poller 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-poller 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-poller - Shinken poller command.
+shinken-poller - Shinken poller daemon
 .SH SYNOPSIS
 .PP
-shinken-poller [\f[I]options\f[]] \&...
+shinken-poller [-dr] [-c \f[I]CONFIGFILE\f[]] [\[em]debugfile
+\f[I]DEBUGFILE\f[]]
 .SH DESCRIPTION
 .PP
-Daemon in charge of launching plugins as requested by schedulers.
+The shinken-poller daemon is in charge of launching plugins as requested
+by schedulers.
 When the check is finished it returns the result to the schedulers.
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -31,8 +38,8 @@ Print detailed help screen.
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]DEBUGFILE\f[]
+Enable debug logging to \f[I]DEBUGFILE\f[]
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-reactionner.8shinken
+++ b/doc/man/shinken-reactionner.8shinken
@@ -1,14 +1,24 @@
-.TH shinken-reactionner 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-reactionner 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-reactionner - Shinken reactionner command.
+shinken-reactionner - Shinken reactionner daemon
 .SH SYNOPSIS
 .PP
-shinken-reactionner [\f[I]options\f[]] \&...
+shinken-reactionner [-dr] [-c \f[I]CONFIGFILE\f[]] [\[em]debugfile
+\f[I]DEBUGFILE\f[]]
 .SH DESCRIPTION
 .PP
-Shinken reactionner Daemon.
+Shinken reactionner daemon
+.PP
+The shinken-reactionner is similar to shinken-poller but handles actions
+such as notifications and event-handlers from the schedulers rather than
+checks.
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -16,22 +26,22 @@ Config file
 .RE
 .TP
 .B -d, --daemon
-Run in daemon mode.
+Run in daemon mode
 .RS
 .RE
 .TP
 .B -r, --replace
-Replace previous running arbiter.
+Replace previous running reactionner
 .RS
 .RE
 .TP
 .B -h, --help
-Print detailed help screen.
+Print detailed help screen
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]DEBUGFILE\f[]
+Enable debug logging to \f[I]DEBUGFILE\f[]
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-receiver.8shinken
+++ b/doc/man/shinken-receiver.8shinken
@@ -1,14 +1,22 @@
-.TH shinken-receiver 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-receiver 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-receiver - Shinken receiver command.
+shinken-receiver - Shinken receiver daemon
 .SH SYNOPSIS
 .PP
 shinken-receiver [\f[I]options\f[]] \&...
 .SH DESCRIPTION
 .PP
 Shinken receiver daemon
+.PP
+The shinken-receiver daemon manages passive information and serves as a
+buffer that will be read from by the shinken-arbiter to dispatch data.
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -20,13 +28,18 @@ Run in daemon mode.
 .RS
 .RE
 .TP
+.B -r, --replace
+Replace previous running arbiter.
+.RS
+.RE
+.TP
 .B -h, --help
 Print detailed help screen.
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]FILE\f[]
+Enable debug logging to \f[I]FILE\f[]
 .RS
 .RE
 .SH AUTHORS

--- a/doc/man/shinken-scheduler.8shinken
+++ b/doc/man/shinken-scheduler.8shinken
@@ -1,14 +1,24 @@
-.TH shinken-scheduler 8 "September 14, 2011" "Shinken User Manuals"
+.TH shinken-scheduler 8 "December 29, 2011" "Shinken User Manuals"
 .SH NAME
 .PP
-shinken-scheduler - Shinken scheduler command.
+shinken-scheduler - Shinken scheduler daemon
 .SH SYNOPSIS
 .PP
-shinken-scheduler [\f[I]options\f[]] \&...
+shinken-scheduler [-dr] [-c \f[I]CONFIGFILE\f[]] [\[em]debugfile
+\f[I]DEBUGFILE\f[]]
 .SH DESCRIPTION
 .PP
-Shinken scheduler daemon.
+Shinken scheduler daemon
+.PP
+The shinken-scheduler manages the dispatching of checks and actions sent
+to shinken-reactionner and shinken-poller based on configuration sent to
+it by shinken-arbiter.
 .SH OPTIONS
+.TP
+.B --version
+Show version number and exit
+.RS
+.RE
 .TP
 .B -c \f[I]CONFIGFILE\f[], --config \f[I]CONFIGFILE\f[]
 Config file
@@ -30,8 +40,8 @@ Print detailed help screen.
 .RS
 .RE
 .TP
-.B --debug \f[I]FILE\f[]
-Debug File.
+.B --debugfile \f[I]DEBUGFILE\f[]
+Enable debug logging to \f[I]DEBUGFILE\f[]
 .RS
 .RE
 .SH AUTHORS

--- a/doc/manpages/markdown/shinken-admin.8.md
+++ b/doc/manpages/markdown/shinken-admin.8.md
@@ -1,7 +1,6 @@
 % shinken-admin(8) Shinken User Manuals
 % David Hannequin
-% October 12, 2011
-
+% December 29, 2011
 
 # NAME
 
@@ -13,6 +12,6 @@ shinken-admin
 
 # DESCRIPTION
 
-Shinken admin shell.
+Shinken admin shell
 
 Invokes a simple shell interface for interacting with shinken-arbiter

--- a/doc/manpages/markdown/shinken-arbiter.8.md
+++ b/doc/manpages/markdown/shinken-arbiter.8.md
@@ -1,29 +1,32 @@
 % shinken-arbiter(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
-
+% December 29, 2011
 
 # NAME
 
-shinken-arbiter - Shinken arbiter command.
+shinken-arbiter - Shinken arbiter daemon
 
 # SYNOPSIS
 
-shinken-arbiter [*options*] ...
+shinken-arbiter [-dr] [-c *CONFIGFILE*] [--debugfile *DEBUGFILE*]
+shinken-arbiter -v [-c *CONFIGFILE*]
 
 # DESCRIPTION
 
-Shinken arbiter daemon.
+Shinken arbiter daemon
 
-Reads the configuration, cuts it into parts (N schedulers = N parts), and
-then send them to all others elements. It also manages the high
-availability feature : if an element dies, it re-routes the configuration
-managed by this falling element to a spare one. Its other role is to
-receive input from users (like external commands from nagios.cmd) and
-sends them to other elements. There can be only one active arbiter in the
+The shinken-arbiter daemon reads the configuration, divides it into parts
+(N schedulers = N parts), and distributes them to the appropriate Shinken daemons.
+Additionally, it manages the high availability features: if a particular daemon dies,
+it re-routes the configuration managed by this failed  daemon to the configured spare.
+Finally, it receives input from users (such as external commands from nagios.cmd) and
+routes them to the appropriate daemon. There can only be one active arbiter in the
 architecture.
 
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
@@ -37,7 +40,8 @@ architecture.
 -h, \--help
 :   Print detailed help screen.
 
-\--debug *FILE*
-:   Debug File.
+\--debugfile *DEBUGFILE*
+:   Enable debug logging to *DEBUGFILE*
 
-
+-v, \--verify-config
+:   Verify config file and exit

--- a/doc/manpages/markdown/shinken-broker.8.md
+++ b/doc/manpages/markdown/shinken-broker.8.md
@@ -1,37 +1,47 @@
 % shinken-broker(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
+% December 29, 2011
 
 # NAME
 
-shinken-broker - Shinken broker command.
+shinken-broker - Shinken broker daemon
 
 # SYNOPSIS
 
-shinken-broker  [*options*] ...
+shinken-broker [-dr] [-c *CONFIGFILE*] [--debugfile *DEBUGFILE*]
 
 # DESCRIPTION
 
-Shinken receiver daemon.
+Shinken broker daemon.
 
-Its role is to get data from schedulers (like status) and manage it (like
-storing it in database). The management itself is done by modules.
-Different modules exists : export into ndo database (MySQL and Oracle
-backend), export to merlin database (MySQL), service-perfdata export and a
-couchdb export, or a mix of them (why not?).
+The shinken-broker's role is to export and manage data from schedulers (such as status).
+The management itself is done by modules.
+
+The following management modules are included:
+ * export into an NDO (Nagios Data Out) database (MySQL or Oracle backend)
+ * export to MERLIN (Module for Effortless Redundancy and Loadbalancing In Nagios) database
+   (MySQL backend)
+ * service-perfdata export
+ * export to CouchDB
+
+Multiple modules can be enabled simultaneously
 
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
 
 -d, \--daemon
-:   Run in daemon mode.
+:   Run in daemon mode
+
+-r, \--replace
+:   Replace previously running broker
 
 -h, \--help
-:   Print detailed help screen.
+:   Print detailed help screen
 
-\--debug *FILE*
-:   Debug File.
-
-
+\--debugfile *DEBUGFILE*
+:   Enable debug logging to *DEBUGFILE*

--- a/doc/manpages/markdown/shinken-discovery.8.md
+++ b/doc/manpages/markdown/shinken-discovery.8.md
@@ -1,48 +1,45 @@
 % shinken-discovery(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
-
+% December 29, 2011
 
 # NAME
 
-shinken-discovery - Shinken discovery command.
+shinken-discovery - Shinken discovery command
 
 # SYNOPSIS
 
-shinken-discovery [*options*] ...
+shinken-discovery [-w] [-c *CONFIGFILE*] [-o *OUTPUT_PATH*] [-r *RUNNER*[,*RUNNER,...]] [-m *MACRO* [*MACRO* ...]]
 
 # DESCRIPTION
 
-Shinken discovery daemon.
+Shinken discovery command
 
-Until now, there are two discovery modules :
- * Standard network one, that uses the nmap tool
- * VMware one, that uses the *check_esx3.pl* script and a vcenter installation.
+There are two discovery modules included:
+ * Standard network discovery which uses the nmap tool
+ * VMware discovery which uses the *check_esx3.pl* script and a vcenter installation.
 
-It's better to do the whole discovery in one pass, because one module can
+It is best to do the whole discovery in one pass because one module can
 use data from the other.
 
 # OPTIONS
+\-- version
+:   Show the version and exit
 
--c *CONFIGFILE*, \--cfg-config *CONFIGGILE*
-:   Configuration file.
+-c *CONFIGFILE*, \--cfg-input *CONFIGGILE*
+:   Discovery configuration file
 
--o *DIRECTORY*, \--dir-output *DIRECTORY*
-:   output directory.
+-o *OUTPUT_PATH*, \--dir-output *OUTPUT_PATH*
+:   Directory output for results
 
--w, \--overwrite
-:   Allow overwriting existing files.
+-w, \--overright
+:   Allow overwriting existing files (disabled by default)
 
--r *PATH*
-:   Indicate path to the nmap binary.
+-r *RUNNERS*
+:   Comma-separated list of discovery runner modules to use
 
--m *NETWORK*
-:   Indicate lan to scan.
+-m *MACROS*
+:   List of macros to pass to discovery runner modules. Must be the last
+    argument. Ex: NMAPTARGETS=192.168.0.0/24
 
 -h, \--help
 :   Print detailed help screen.
-
-\--debug *FILE*
-:   Debug File.
-
-

--- a/doc/manpages/markdown/shinken-poller.8.md
+++ b/doc/manpages/markdown/shinken-poller.8.md
@@ -1,21 +1,24 @@
 % shinken-poller(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
+% December 29, 2011
 
 # NAME
 
-shinken-poller - Shinken poller command.
+shinken-poller - Shinken poller daemon
 
 # SYNOPSIS
 
-shinken-poller [*options*] ...
+shinken-poller [-dr] [-c *CONFIGFILE*] [--debugfile *DEBUGFILE*]
 
 # DESCRIPTION
 
-Daemon in charge of launching plugins as requested by schedulers. When the
-check is finished it returns the result to the schedulers.
+The shinken-poller daemon is in charge of launching plugins as requested by
+schedulers. When the check is finished it returns the result to the schedulers.
 
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
@@ -29,7 +32,5 @@ check is finished it returns the result to the schedulers.
 -h, \--help
 :   Print detailed help screen.
 
-\--debug *FILE*
-:   Debug File.
-
-
+\--debugfile *DEBUGFILE*
+:   Enable debug logging to *DEBUGFILE*

--- a/doc/manpages/markdown/shinken-reactionner.8.md
+++ b/doc/manpages/markdown/shinken-reactionner.8.md
@@ -1,35 +1,38 @@
 % shinken-reactionner(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
-
+% December 29, 2011
 
 # NAME
 
-shinken-reactionner - Shinken reactionner command.
+shinken-reactionner - Shinken reactionner daemon
 
 # SYNOPSIS
 
-shinken-reactionner [*options*] ...
+shinken-reactionner [-dr] [-c *CONFIGFILE*] [--debugfile *DEBUGFILE*]
 
 # DESCRIPTION
 
-Shinken reactionner Daemon.
+Shinken reactionner daemon
+
+The shinken-reactionner is similar to shinken-poller but handles actions such
+as notifications and event-handlers from the schedulers rather than checks.
 
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
 
 -d, \--daemon
-:   Run in daemon mode.
+:   Run in daemon mode
 
 -r, \--replace
-:   Replace previous running arbiter.
+:   Replace previous running reactionner
 
 -h, \--help
-:   Print detailed help screen.
+:   Print detailed help screen
 
-\--debug *FILE*
-:   Debug File.
-
-
+\--debugfile *DEBUGFILE*
+:   Enable debug logging to *DEBUGFILE*

--- a/doc/manpages/markdown/shinken-receiver.8.md
+++ b/doc/manpages/markdown/shinken-receiver.8.md
@@ -1,10 +1,10 @@
 % shinken-receiver(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
+% December 29, 2011
 
 # NAME
 
-shinken-receiver - Shinken receiver command.
+shinken-receiver - Shinken receiver daemon
 
 # SYNOPSIS
 
@@ -14,7 +14,13 @@ shinken-receiver  [*options*] ...
 
 Shinken receiver daemon
 
+The shinken-receiver daemon manages passive information and serves as a buffer
+that will be read from by the shinken-arbiter to dispatch data.
+
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
@@ -22,10 +28,11 @@ Shinken receiver daemon
 -d, \--daemon
 :   Run in daemon mode.
 
+-r, \--replace
+:   Replace previous running arbiter.
+
 -h, \--help
 :   Print detailed help screen.
 
-\--debug *FILE*
-:   Debug File.
-
-
+\--debugfile *FILE*
+:   Enable debug logging to *FILE*

--- a/doc/manpages/markdown/shinken-scheduler.8.md
+++ b/doc/manpages/markdown/shinken-scheduler.8.md
@@ -1,20 +1,27 @@
 % shinken-scheduler(8) Shinken User Manuals
 % Arthur Gautier
-% September 14, 2011
+% December 29, 2011
 
 # NAME
 
-shinken-scheduler - Shinken scheduler command.
+shinken-scheduler - Shinken scheduler daemon
 
 # SYNOPSIS
 
-shinken-scheduler [*options*] ...
+shinken-scheduler [-dr] [-c *CONFIGFILE*] [--debugfile *DEBUGFILE*]
 
 # DESCRIPTION
 
-Shinken scheduler daemon.
+Shinken scheduler daemon
+
+The shinken-scheduler manages the dispatching of checks and actions sent to
+shinken-reactionner and shinken-poller based on configuration sent to it by
+shinken-arbiter.
 
 # OPTIONS
+
+\--version
+:   Show version number and exit
 
 -c *CONFIGFILE*, \--config *CONFIGFILE*
 :   Config file
@@ -28,7 +35,5 @@ Shinken scheduler daemon.
 -h, \--help
 :   Print detailed help screen.
 
-\--debug *FILE*
-:   Debug File.
-
-
+\--debugfile *DEBUGFILE*
+:   Enable debug logging to *DEBUGFILE*


### PR DESCRIPTION
Man pages in doc/man/ were in Perlpod documentation format rather than troff format. Man pages were regenerated using pandoc.

Additionally, many of the man pages were out of date and missing options. These were corrected and descriptions for the daemons were updated.

You'll want to verify that I described the purpose of each daemon accurately.
