### PR TITLE
ndodb_mysql_broker module was not working on python2.5

### DIFF
--- a/shinken/modules/ndodb_mysql_broker/ndodb_mysql_broker.py
+++ b/shinken/modules/ndodb_mysql_broker/ndodb_mysql_broker.py
@@ -161,7 +161,7 @@ class Ndodb_Mysql_broker(BaseModule):
     def connect_database(self):    
         try :
             self.db.connect_database()
-        except _mysql_exceptions.OperationalError as exp:
+        except _mysql_exceptions.OperationalError, exp:
             logger.log( "[MySQL/NDO] Module raise an exception : %s . Please check the arguments!" % exp)
             raise
 


### PR DESCRIPTION
The construct except Exception as inst: has been introduced in
python2.6.
This was leading to package installation on debian fail,
due to dh_python2 byte-compiling modules on both python2.5 and
python2.6 (if both 2.5 and 2.6 are installed on the target).

I rebuilded packages using this fix, and I was then able to
correctly install the package.
