### PR TITLE
pack: network/services/dns handle default value for dns verification.

### DIFF
--- a/etc/packs/network/services/dns/commands.cfg
+++ b/etc/packs/network/services/dns/commands.cfg
@@ -1,5 +1,5 @@
 # Check a DNS server
 define command {
        command_name     check_dns
-       command_line     $PLUGINSDIR$/check_dns -H $HOSTADDRESS$
+       command_line     $PLUGINSDIR$/check_dns -H $_HOSTDNSHOSTNAME$ -a $_HOSTDNSEXPECTEDRESULT$ -s $HOSTADDRESS$
 }

--- a/etc/packs/network/services/dns/templates.cfg
+++ b/etc/packs/network/services/dns/templates.cfg
@@ -2,4 +2,7 @@ define host{
    name           dns
    use            generic-host
    register       0
+
+   _DNSHOSTNAME        $HOSTNAME$
+   _DNSEXPECTEDRESULT  $HOSTADDRESS$
 }


### PR DESCRIPTION
In this patch there is a bugfix, interogated serveur is specified by -s and net -H.
-H is the question part of the dns request, by default the $HOSTNAME$
-a is the expected result, by default $HOSTADDRESS$ .
-s is the server interoggated.

You could overload on host or template with :
- _DNSHOSTNAME for the question part
- _DNSEXPECTEDRESULT for the result that we expected.

Regards
