### PR TITLE
Change the default max_plugins_output_length 

### DIFF
--- a/etc/nagios.cfg
+++ b/etc/nagios.cfg
@@ -89,7 +89,7 @@ flap_history=30
 
 
 #Max plugin output for the plugins launched by the pollers, in bytes
-max_plugins_output_length=8192
+max_plugins_output_length=65536
 
 
 #Enable or not the state change on impact detection (like


### PR DESCRIPTION
to 64k to handle the large output of check_nwc_health
