### PR TITLE
Update shinken/modules/logstore_sqlite.py

### DIFF
--- a/shinken/modules/logstore_sqlite.py
+++ b/shinken/modules/logstore_sqlite.py
@@ -7,6 +7,7 @@ It is one possibility for an exchangeable storage for log broks
 """
 
 import os
+import sys
 import time
 import datetime
 import re
@@ -57,7 +58,9 @@ class LiveStatusLogStoreSqlite(BaseModule):
     def __init__(self, modconf):
         BaseModule.__init__(self, modconf)
         self.plugins = []
-        self.database_file = getattr(modconf, 'database_file', os.path.join(os.path.abspath('.'), 'var', 'livestatus.db'))
+        # Change. The var folder is not defined based upon '.', but upon ../var from the process name (shinken-broker)
+        # When the database_file variable, the defaukt variable was calculated from '.'... Depending on where you were when you ran the commmand the behavior changed.
+        self.database_file = getattr(modconf, 'database_file', os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), '..','var', 'livestatus.db'))
         self.archive_path = getattr(modconf, 'archive_path', os.path.join(os.path.dirname(self.database_file), 'archives'))
         try:
             os.stat(self.archive_path)


### PR DESCRIPTION
When the database_file variable is not mentionned, the default value was calculated from '.'
Depending on where you were when you ran the commmand the behavior changed.

Now, it is calculated using the process (shinken-broker) path. (../var)
