### PR TITLE
Update shinken/modules/graphite_ui.py

### DIFF
--- a/shinken/modules/graphite_ui.py
+++ b/shinken/modules/graphite_ui.py
@@ -24,7 +24,9 @@ for mainly get graphs and links.
 
 import re
 import socket
+import os
 
+from string import Template
 from shinken.basemodule import BaseModule
 
 #print "Loaded AD module"
@@ -47,7 +49,8 @@ class Graphite_Webui(BaseModule):
     def __init__(self, modconf):
         BaseModule.__init__(self, modconf)
         self.uri = getattr(modconf, 'uri', None)
-        
+        self.templates_path = getattr(modconf, 'templates_path', '/tmp')
+
         if not self.uri:
             raise Exception('The WebUI Graphite module is missing uri parameter.')
 
@@ -118,6 +121,37 @@ class Graphite_Webui(BaseModule):
 
         t = elt.__class__.my_type
         r = []
+
+        # Do we have a template ?
+        if os.path.isfile(self.templates_path+'/'+elt.check_command.get_name()):
+            template_html = ''
+            with open(self.templates_path+'/'+elt.check_command.get_name(),'r') as template_file:
+                template_html += template_file.read()
+            # Read the template file, as template string python object
+            template_file.closed
+            html=Template(template_html)
+            # Build the dict to instanciate the template string
+            values = {}
+            values['graphstart'] = graphstart
+            values['graphend'] = graphend 
+            if t == 'host':
+                values['host'] = elt.host_name
+                values['service'] = '_HOST_'
+            if t == 'service':
+                values['host'] = elt.host.host_name
+                values['service'] = elt.service_description
+            values['uri'] = self.uri
+            # Split, we may have several images.
+            for img in html.substitute(values).split('\n'):
+                if not img == "":
+                    v = {}
+                    v['link'] = self.uri
+                    v['img_src'] = img
+                    r.append(v)
+            # No need to continue, we have the images already.      					
+            return r
+             
+        # If no template is present, then the usual way
 
         if t == 'host':
             couples = self.get_metric_and_value(elt.perf_data)


### PR DESCRIPTION
This change allow us to create Graphite templates.

Templates are files containing links to the graphite url api, with shinken values.
The match between the shinken object (service/host) and the template is made with the check_command (like PNP)

For example, the service Ping, is checked with the check_command check_ping. It gives 2 variables  : pl & rta
The template file is names check_ping (in the right folder), and contains : 

$uri/render/?width=586&height=308&target=$host.$service.rta
$uri/render/?width=586&height=308&target=$host.$service.pl

$uri, $host, $service, $graphend , $graphstart (omitted here), are replaced by the module with the corresponding values.

There is also a new module attribute : template_path. I will request it as well.
I will create templates as soon as I can put my hand on a graphite somewhere. (no infra at all at home)
