### PR TITLE
Add log levels in shinken logging handler

### DIFF
--- a/shinken/action.py
+++ b/shinken/action.py
@@ -247,7 +247,7 @@ if os.name != 'nt':
                     close_fds=True, shell=force_shell, env=self.local_env,
                     preexec_fn=os.setsid)
             except OSError , exp:
-                logger.log("Debug : Error in launching command: %s %s %s" % (self.command, exp, force_shell))
+                logger.log(logger.INFO, "Debug : Error in launching command: %s %s %s" % (self.command, exp, force_shell))
                 # Maybe it's just a shell we try to exec. So we must retry
                 if not force_shell and exp.errno == 8 and exp.strerror == 'Exec format error':
                     return self.execute__(True)
@@ -291,7 +291,7 @@ else:
                 self.process = subprocess.Popen(cmd,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=self.local_env, shell=True)
             except WindowsError, exp:
-                logger.log("We kill the process : %s %s" % (exp, self.command))
+                logger.log(logger.INFO, "We kill the process : %s %s" % (exp, self.command))
                 self.status = 'timeout'
                 self.execution_time = time.time() - self.check_time
   

--- a/shinken/arbiterlink.py
+++ b/shinken/arbiterlink.py
@@ -67,7 +67,7 @@ class ArbiterLink(SatelliteLink):
 
     # Look for ourself as an arbiter. Should be our fqdn name, or if not, our hostname one
     def is_me(self):
-        logger.log("And arbiter is launched with the hostname:%s from an arbiter point of view of addr :%s" % (self.host_name, socket.getfqdn()), print_it=False)
+        logger.log(logger.INFO, "And arbiter is launched with the hostname:%s from an arbiter point of view of addr :%s" % (self.host_name, socket.getfqdn()), print_it=False)
         return self.host_name == socket.getfqdn() or self.host_name == socket.gethostname()
 
 

--- a/shinken/basemodule.py
+++ b/shinken/basemodule.py
@@ -149,7 +149,7 @@ class BaseModule(object):
         if not self.is_external:
             return
         self.stop_process()
-        logger.log("Starting external process for instance %s" % (self.name))
+        logger.log(logger.INFO, "Starting external process for instance %s" % (self.name))
         p = Process(target=self.main, args=())
 
         # Under windows we should not call start() on an object that got
@@ -164,7 +164,7 @@ class BaseModule(object):
         # We save the process data AFTER the fork()
         self.process = p
         self.properties['process'] = p  # TODO: temporary
-        logger.log("%s is now started ; pid=%d" % (self.name, p.pid))
+        logger.log(logger.INFO, "%s is now started ; pid=%d" % (self.name, p.pid))
 
     def __kill(self):
         """Sometime terminate() is not enough, we must "help"
@@ -184,12 +184,12 @@ class BaseModule(object):
     def stop_process(self):
         """Request the module process to stop and release it"""
         if self.process:
-            logger.log("I'm stopping module '%s' process pid:%s " %
+            logger.log(logger.INFO, "I'm stopping module '%s' process pid:%s " %
                        (self.get_name(), self.process.pid))
             self.process.terminate()
             self.process.join(timeout=1)
             if self.process.is_alive():
-                logger.log("The process is still alive, I help it to die")
+                logger.log(logger.INFO, "The process is still alive, I help it to die")
                 self.__kill()
             self.process = None
 
@@ -237,11 +237,11 @@ class BaseModule(object):
     def main(self):
         """module "main" method. Only used by external modules."""
         self.set_signal_handler()
-        logger.log("[%s[%d]]: Now running.." % (self.name, os.getpid()))
+        logger.log(logger.INFO, "[%s[%d]]: Now running.." % (self.name, os.getpid()))
         while not self.interrupted:
             self.do_loop_turn()
         self.do_stop()
-        logger.log("[%s]: exiting now.." % (self.name))
+        logger.log(logger.INFO, "[%s]: exiting now.." % (self.name))
 
     # TODO: apparently some modules would uses "work" as the main method ??
     work = main

--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -165,7 +165,7 @@ class Arbiter(Daemon):
         elif isinstance(b, ExternalCommand):
             self.external_commands.append(b)
         else:
-            logger.log('Warning : cannot manage object type %s (%s)' % (type(b), b))
+            logger.log(logger.INFO, 'Warning : cannot manage object type %s (%s)' % (type(b), b))
 
             
     # We must push our broks to the broker
@@ -259,9 +259,9 @@ class Arbiter(Daemon):
                 self.me = arb
                 self.is_master = not self.me.spare
                 if self.is_master:
-                    logger.log("I am the master Arbiter : %s" % arb.get_name())
+                    logger.log(logger.INFO, "I am the master Arbiter : %s" % arb.get_name())
                 else:
-                    logger.log("I am the spare Arbiter : %s" % arb.get_name())
+                    logger.log(logger.INFO, "I am the spare Arbiter : %s" % arb.get_name())
 
                 # Set myself as alive ;)
                 self.me.alive = True
@@ -275,7 +275,7 @@ class Arbiter(Daemon):
                      With the value %s \
                      Thanks." % socket.gethostname())
 
-        logger.log("My own modules : " + ','.join([m.get_name() for m in self.me.modules]))
+        logger.log(logger.INFO, "My own modules : " + ','.join([m.get_name() for m in self.me.modules]))
 
         # we request the instances without them being *started* 
         # (for those that are concerned ("external" modules):
@@ -395,7 +395,7 @@ class Arbiter(Daemon):
         #    sys.exit("Configuration is incorrect, sorry, I bail out")
 
         # REF: doc/shinken-conf-dispatching.png (2)
-        logger.log("Cutting the hosts and services into parts")
+        logger.log(logger.INFO, "Cutting the hosts and services into parts")
         self.confs = self.conf.cut_into_parts()
 
         # The conf can be incorrect here if the cut into parts see errors like
@@ -404,7 +404,7 @@ class Arbiter(Daemon):
             self.conf.show_errors()
             sys.exit("Configuration is incorrect, sorry, I bail out")
 
-        logger.log('Things look okay - No serious problems were detected during the pre-flight check')
+        logger.log(logger.INFO, 'Things look okay - No serious problems were detected during the pre-flight check')
 
         # Clean objects of temporary/unecessary attributes for live work:
         self.conf.clean()
@@ -441,7 +441,7 @@ class Arbiter(Daemon):
         self.host = self.me.address
         self.port = self.me.port
         
-        logger.log("Configuration Loaded")
+        logger.log(logger.INFO, "Configuration Loaded")
         print ""
 
 
@@ -450,7 +450,7 @@ class Arbiter(Daemon):
         try:
             # Log will be broks
             for line in self.get_header():
-                self.log.log(line)
+                self.log.log(logger.INFO, line)
 
             self.load_config_file()
 
@@ -471,9 +471,9 @@ class Arbiter(Daemon):
             # ends up here and must be handled.
             sys.exit(exp.code)
         except Exception, exp:
-            logger.log("CRITICAL ERROR: I got an unrecoverable error. I have to exit")
-            logger.log("You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
-            logger.log("Back trace of it: %s" % (traceback.format_exc()))
+            logger.log(logger.INFO, "CRITICAL ERROR: I got an unrecoverable error. I have to exit")
+            logger.log(logger.INFO, "You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
+            logger.log(logger.INFO, "Back trace of it: %s" % (traceback.format_exc()))
             raise
 
 
@@ -521,12 +521,12 @@ class Arbiter(Daemon):
                 # Maybe the queue had problems
                 # log it and quit it
                 except (IOError, EOFError), exp:
-                    logger.log("Warning : an external module queue got a problem '%s'" % str(exp))
+                    logger.log(logger.INFO, "Warning : an external module queue got a problem '%s'" % str(exp))
                     break
 
     # We wait (block) for arbiter to send us something
     def wait_for_master_death(self):
-        logger.log("Waiting for master death")
+        logger.log(logger.INFO, "Waiting for master death")
         timeout = 1.0
         self.last_master_speack = time.time()
 
@@ -535,7 +535,7 @@ class Arbiter(Daemon):
         for arb in self.conf.arbiterlinks:
             if not arb.spare:
                 master_timeout = arb.check_interval * arb.max_check_attempts
-        logger.log("I'll wait master for %d seconds" % master_timeout)
+        logger.log(logger.INFO, "I'll wait master for %d seconds" % master_timeout)
 
         
         while not self.interrupted:
@@ -558,7 +558,7 @@ class Arbiter(Daemon):
             # Now check if master is dead or not
             now = time.time()
             if now - self.last_master_speack > master_timeout:
-                logger.log("Master is dead!!!")
+                logger.log(logger.INFO, "Master is dead!!!")
                 self.must_run = True
                 break
 
@@ -597,7 +597,7 @@ class Arbiter(Daemon):
 
         if self.conf.human_timestamp_log:
             logger.set_human_format()
-        logger.log("Begin to dispatch configurations to satellites")
+        logger.log(logger.INFO, "Begin to dispatch configurations to satellites")
         self.dispatcher = Dispatcher(self.conf, self.me)
         self.dispatcher.check_alive()
         self.dispatcher.check_dispatch()

--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -111,18 +111,18 @@ class Broker(BaseSatellite):
                 if 'full_instance_id' in data:
                     c_id = data['full_instance_id']
                     source = elt.source
-                    logger.log('The module %s is asking me to get all initial data from the scheduler %d' % (source, c_id))
+                    logger.log(logger.INFO, 'The module %s is asking me to get all initial data from the scheduler %d' % (source, c_id))
                     # so we just reset the connection and the running_id, it will just get all new things
                     try:
                         self.schedulers[c_id]['con'] = None
                         self.schedulers[c_id]['running_id'] = 0
                     except KeyError: # maybe this instance was not known, forget it
-                        logger.log("WARNING: the module %s ask me a full_instance_id for an unknown ID (%d)!" % (source, c_id))
+                        logger.log(logger.INFO, "WARNING: the module %s ask me a full_instance_id for an unknown ID (%d)!" % (source, c_id))
             # Maybe a module tells me that it's dead, I must log it's last words...
             if elt.get_type() == 'ICrash':
                 data = elt.get_data()
-                logger.log('ERROR : the module %s just crash! Please look at the traceback:' % data['name'])
-                logger.log(data['trace'])
+                logger.log(logger.INFO, 'ERROR : the module %s just crash! Please look at the traceback:' % data['name'])
+                logger.log(logger.INFO, data['trace'])
                 # The module death will be looked for elsewhere and restarted.
 
 
@@ -157,7 +157,7 @@ class Broker(BaseSatellite):
             # Get the good links tab for looping..
         links = self.get_links_from_type(type)
         if links is None:
-            logger.log('DBG: Type unknown for connection! %s' % type)
+            logger.log(logger.INFO, 'DBG: Type unknown for connection! %s' % type)
             return
 
         if type == 'scheduler':
@@ -187,7 +187,7 @@ class Broker(BaseSatellite):
             # But the multiprocessing module is not compatible with it!
             # so we must disable it immediately after
             socket.setdefaulttimeout(None)
-            logger.log("Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
 
@@ -214,20 +214,20 @@ class Broker(BaseSatellite):
             #     print "I do not ask for brok generation"
             links[id]['running_id'] = new_run_id
         except Pyro_exp_pack, exp:
-            logger.log("Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
 #        except Pyro.errors.NamingError, exp:
-#            logger.log("[%s] the %s '%s' is not initialized : %s" % (self.name, type, links[id]['name'], str(exp)))
+#            logger.log(logger.INFO, "[%s] the %s '%s' is not initialized : %s" % (self.name, type, links[id]['name'], str(exp)))
 #            links[id]['con'] = None
 #            return
         except KeyError , exp:
-            logger.log("the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             traceback.print_stack()
             return
 
-        logger.log("Connection OK to the %s %s" % (type, links[id]['name']))
+        logger.log(logger.INFO, "Connection OK to the %s %s" % (type, links[id]['name']))
 
 
     # Get a brok. Our role is to put it in the modules
@@ -240,9 +240,9 @@ class Broker(BaseSatellite):
                 mod.manage_brok(b)
             except Exception , exp:
                 print exp.__dict__
-                logger.log("Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (mod.get_name(),str(exp)))
-                logger.log("Exception type : %s" % type(exp))
-                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                logger.log(logger.INFO, "Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (mod.get_name(),str(exp)))
+                logger.log(logger.INFO, "Exception type : %s" % type(exp))
+                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                 self.modules_manager.set_to_restart(mod)
 
 
@@ -283,7 +283,7 @@ class Broker(BaseSatellite):
             # Get the good links tab for looping..
         links = self.get_links_from_type(type)
         if links is None:
-            logger.log('DBG: Type unknown for connection! %s' % type)
+            logger.log(logger.INFO, 'DBG: Type unknown for connection! %s' % type)
             return
 
         # We check for new check in each schedulers and put
@@ -306,24 +306,24 @@ class Broker(BaseSatellite):
                 print exp
                 self.pynag_con_init(sched_id, type=type)
             except Pyro.errors.ProtocolError , exp:
-                logger.log("Connection problem to the %s %s : %s" % (type, links[sched_id]['name'], str(exp)))
+                logger.log(logger.INFO, "Connection problem to the %s %s : %s" % (type, links[sched_id]['name'], str(exp)))
                 links[sched_id]['con'] = None
             # scheduler must not #be initialized
             except AttributeError , exp:
-                logger.log("The %s %s should not be initialized : %s" % (type, links[sched_id]['name'], str(exp)))
+                logger.log(logger.INFO, "The %s %s should not be initialized : %s" % (type, links[sched_id]['name'], str(exp)))
             # scheduler must not have checks
             except Pyro.errors.NamingError , exp:
-                logger.log("The %s %s should not be initialized : %s" % (type, links[sched_id]['name'], str(exp)))
+                logger.log(logger.INFO, "The %s %s should not be initialized : %s" % (type, links[sched_id]['name'], str(exp)))
             except (Pyro.errors.ConnectionClosedError, Pyro.errors.TimeoutError), exp:
-                logger.log("Connection problem to the %s %s : %s" % (type, links[sched_id]['name'], str(exp)))
+                logger.log(logger.INFO, "Connection problem to the %s %s : %s" % (type, links[sched_id]['name'], str(exp)))
                 links[sched_id]['con'] = None
             #  What the F**k? We do not know what happened,
             # so.. bye bye :)
             except Exception,x:
                 print x.__class__
                 print x.__dict__
-                logger.log(str(x))
-                logger.log(''.join(Pyro.util.getPyroTraceback(x)))
+                logger.log(logger.INFO, str(x))
+                logger.log(logger.INFO, ''.join(Pyro.util.getPyroTraceback(x)))
                 sys.exit(1)
 
         
@@ -392,7 +392,7 @@ class Broker(BaseSatellite):
             self.schedulers[sched_id]['last_connection'] = 0
 
 
-        logger.log("We have our schedulers : %s " % self.schedulers)
+        logger.log(logger.INFO, "We have our schedulers : %s " % self.schedulers)
 
         # Now get arbiter
         for arb_id in conf['arbiters']:
@@ -413,7 +413,7 @@ class Broker(BaseSatellite):
 
             # We do not connect to the arbiter. Connection hangs
 
-        logger.log("We have our arbiters : %s " % self.arbiters)
+        logger.log(logger.INFO, "We have our arbiters : %s " % self.arbiters)
 
         # Now for pollers
         for pol_id in conf['pollers']:
@@ -437,7 +437,7 @@ class Broker(BaseSatellite):
 #                    #And we connect to it
 #                    self.app.pynag_con_init(pol_id, 'poller')
 
-        logger.log("We have our pollers : %s" % self.pollers)
+        logger.log(logger.INFO, "We have our pollers : %s" % self.pollers)
 
         # Now reactionners
         for rea_id in conf['reactionners'] :
@@ -462,17 +462,17 @@ class Broker(BaseSatellite):
 #                    #And we connect to it
 #                    self.app.pynag_con_init(rea_id, 'reactionner')
 
-        logger.log("We have our reactionners : %s" % self.reactionners)
+        logger.log(logger.INFO, "We have our reactionners : %s" % self.reactionners)
 
         if not self.have_modules:
             self.modules = mods = conf['global']['modules']
             self.have_modules = True
-            logger.log("We received modules %s " % mods)
+            logger.log(logger.INFO, "We received modules %s " % mods)
 
         # Set our giving timezone from arbiter
         use_timezone = conf['global']['use_timezone']
         if use_timezone != 'NOTSET':
-            logger.log("Setting our timezone to %s" % use_timezone)
+            logger.log(logger.INFO, "Setting our timezone to %s" % use_timezone)
             os.environ['TZ'] = use_timezone
             time.tzset()
         
@@ -622,9 +622,9 @@ class Broker(BaseSatellite):
             self.load_config_file()
         
             for line in self.get_header():
-                self.log.log(line)
+                self.log.log(logger.INFO, line)
 
-            logger.log("[Broker] Using working directory : %s" % os.path.abspath(self.workdir))
+            logger.log(logger.INFO, "[Broker] Using working directory : %s" % os.path.abspath(self.workdir))
         
             self.do_daemon_init_and_start()
 
@@ -651,8 +651,8 @@ class Broker(BaseSatellite):
             self.do_mainloop()
 
         except Exception, exp:
-            logger.log("CRITICAL ERROR: I got an unrecoverable error. I have to exit")
-            logger.log("You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
-            logger.log("Back trace of it: %s" % (traceback.format_exc()))
+            logger.log(logger.INFO, "CRITICAL ERROR: I got an unrecoverable error. I have to exit")
+            logger.log(logger.INFO, "You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
+            logger.log(logger.INFO, "Back trace of it: %s" % (traceback.format_exc()))
             raise
 

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -116,9 +116,9 @@ class Receiver(BaseSatellite):
                 mod.manage_brok(b)
             except Exception , exp:
                 print exp.__dict__
-                logger.log("Warning : The mod %s raise an exception: %s, I kill it" % (mod.get_name(),str(exp)))
-                logger.log("Exception type : %s" % type(exp))
-                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                logger.log(logger.INFO, "Warning : The mod %s raise an exception: %s, I kill it" % (mod.get_name(),str(exp)))
+                logger.log(logger.INFO, "Exception type : %s" % type(exp))
+                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                 to_del.append(mod)
         # Now remove mod that raise an exception
         self.modules_manager.clear_instances(to_del)
@@ -163,12 +163,12 @@ class Receiver(BaseSatellite):
         if not self.have_modules:
             self.modules = mods = conf['global']['modules']
             self.have_modules = True
-            logger.log("We received modules %s " % mods)
+            logger.log(logger.INFO, "We received modules %s " % mods)
 
         # Set our giving timezone from arbiter
         use_timezone = conf['global']['use_timezone']
         if use_timezone != 'NOTSET':
-            logger.log("Setting our timezone to %s" % use_timezone)
+            logger.log(logger.INFO, "Setting our timezone to %s" % use_timezone)
             os.environ['TZ'] = use_timezone
             time.tzset()
         
@@ -253,9 +253,9 @@ class Receiver(BaseSatellite):
             self.load_config_file()
         
             for line in self.get_header():
-                self.log.log(line)
+                self.log.log(logger.INFO, line)
 
-            logger.log("[Receiver] Using working directory : %s" % os.path.abspath(self.workdir))
+            logger.log(logger.INFO, "[Receiver] Using working directory : %s" % os.path.abspath(self.workdir))
         
             self.do_daemon_init_and_start()
             
@@ -282,8 +282,8 @@ class Receiver(BaseSatellite):
             self.do_mainloop()
 
         except Exception, exp:
-            logger.log("CRITICAL ERROR: I got an unrecoverable error. I have to exit")
-            logger.log("You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
-            logger.log("Back trace of it: %s" % (traceback.format_exc()))
+            logger.log(logger.INFO, "CRITICAL ERROR: I got an unrecoverable error. I have to exit")
+            logger.log(logger.INFO, "You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
+            logger.log(logger.INFO, "Back trace of it: %s" % (traceback.format_exc()))
             raise
 

--- a/shinken/daemons/schedulerdaemon.py
+++ b/shinken/daemons/schedulerdaemon.py
@@ -163,7 +163,7 @@ class Shinken(BaseSatellite):
 
     def compensate_system_time_change(self, difference):
         """ Compensate a system time change of difference for all hosts/services/checks/notifs """
-        logger.log('Warning: A system time change of %d has been detected.  Compensating...' % difference)
+        logger.log(logger.INFO, 'Warning: A system time change of %d has been detected.  Compensating...' % difference)
         # We only need to change some value
         self.program_start = max(0, self.program_start + difference)
 
@@ -368,12 +368,12 @@ class Shinken(BaseSatellite):
             self.load_config_file()
             self.do_daemon_init_and_start()
             self.uri2 = self.pyro_daemon.register(self.interface, "ForArbiter")
-            logger.log("[scheduler] General interface is at: %s" % self.uri2)
+            logger.log(logger.INFO, "[scheduler] General interface is at: %s" % self.uri2)
             self.do_mainloop()
         except Exception, exp:
-            logger.log("CRITICAL ERROR: I got an unrecoverable error. I have to exit")
-            logger.log("You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
-            logger.log("Back trace of it: %s" % (traceback.format_exc()))
+            logger.log(logger.INFO, "CRITICAL ERROR: I got an unrecoverable error. I have to exit")
+            logger.log(logger.INFO, "You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
+            logger.log(logger.INFO, "Back trace of it: %s" % (traceback.format_exc()))
             raise
             
             

--- a/shinken/daemons/skonfdaemon.py
+++ b/shinken/daemons/skonfdaemon.py
@@ -185,7 +185,7 @@ class Skonf(Daemon):
         elif isinstance(b, ExternalCommand):
             self.external_commands.append(b)
         else:
-            logger.log('Warning : cannot manage object type %s (%s)' % (type(b), b))
+            logger.log(logger.INFO, 'Warning : cannot manage object type %s (%s)' % (type(b), b))
 
             
 
@@ -212,9 +212,9 @@ class Skonf(Daemon):
                 self.me = arb
                 self.is_master = not self.me.spare
                 if self.is_master:
-                    logger.log("I am the master Arbiter : %s" % arb.get_name())
+                    logger.log(logger.INFO, "I am the master Arbiter : %s" % arb.get_name())
                 else:
-                    logger.log("I am the spare Arbiter : %s" % arb.get_name())
+                    logger.log(logger.INFO, "I am the spare Arbiter : %s" % arb.get_name())
 
                 # Set myself as alive ;)
                 self.me.alive = True
@@ -228,7 +228,7 @@ class Skonf(Daemon):
                      With the value %s \
                      Thanks." % socket.gethostname())
 
-        logger.log("My own modules : " + ','.join([m.get_name() for m in self.me.modules]))
+        logger.log(logger.INFO, "My own modules : " + ','.join([m.get_name() for m in self.me.modules]))
 
         # we request the instances without them being *started* 
         # (for these that are concerned ("external" modules):
@@ -350,7 +350,7 @@ class Skonf(Daemon):
         #    sys.exit("Configuration is incorrect, sorry, I bail out")
 
         # REF: doc/shinken-conf-dispatching.png (2)
-        logger.log("Cutting the hosts and services into parts")
+        logger.log(logger.INFO, "Cutting the hosts and services into parts")
         self.confs = self.conf.cut_into_parts()
 
         # The conf can be incorrect here if the cut into parts see errors like
@@ -359,7 +359,7 @@ class Skonf(Daemon):
             self.conf.show_errors()
             sys.exit("Configuration is incorrect, sorry, I bail out")
 
-        logger.log('Things look okay - No serious problems were detected during the pre-flight check')
+        logger.log(logger.INFO, 'Things look okay - No serious problems were detected during the pre-flight check')
 
         # Now clean objects of temporary/unecessary attributes for live work:
         self.conf.clean()
@@ -396,7 +396,7 @@ class Skonf(Daemon):
         self.host = self.me.address
         self.port = 8766#self.me.port
         
-        logger.log("Configuration Loaded")
+        logger.log(logger.INFO, "Configuration Loaded")
         print ""
 
 
@@ -437,7 +437,7 @@ class Skonf(Daemon):
         try:
             # Log will be broks
             for line in self.get_header():
-                self.log.log(line)
+                self.log.log(logger.INFO, line)
 
             self.load_config_file()
             self.load_web_configuration()
@@ -465,7 +465,7 @@ class Skonf(Daemon):
             except OSError, exp:
                # We look for the "Function not implemented" under Linux
                if exp.errno == 38 and os.name == 'posix':
-                  logger.log("ERROR : get an exception (%s). If you are under Linux, please check that your /dev/shm directory exists." % (str(exp)))
+                  logger.log(logger.INFO, "ERROR : get an exception (%s). If you are under Linux, please check that your /dev/shm directory exists." % (str(exp)))
                   raise
 
 
@@ -489,9 +489,9 @@ class Skonf(Daemon):
             # ends up here and must be handled.
             sys.exit(exp.code)
         except Exception, exp:
-            logger.log("CRITICAL ERROR: I got an unrecoverable error. I have to exit")
-            logger.log("You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
-            logger.log("Back trace of it: %s" % (traceback.format_exc()))
+            logger.log(logger.INFO, "CRITICAL ERROR: I got an unrecoverable error. I have to exit")
+            logger.log(logger.INFO, "You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help")
+            logger.log(logger.INFO, "Back trace of it: %s" % (traceback.format_exc()))
             raise
 
 
@@ -539,13 +539,13 @@ class Skonf(Daemon):
                 # Maybe the queue got problem
                 # log it and quit it
                 except (IOError, EOFError), exp:
-                    logger.log("Warning : an external module queue got a problem '%s'" % str(exp))
+                    logger.log(logger.INFO, "Warning : an external module queue got a problem '%s'" % str(exp))
                     break
 
 
     # We wait (block) for arbiter to send us something
     def wait_for_master_death(self):
-        logger.log("Waiting for master death")
+        logger.log(logger.INFO, "Waiting for master death")
         timeout = 1.0
         self.last_master_speack = time.time()
 
@@ -554,7 +554,7 @@ class Skonf(Daemon):
         for arb in self.conf.arbiterlinks:
             if not arb.spare:
                 master_timeout = arb.check_interval * arb.max_check_attempts
-        logger.log("I'll wait master for %d seconds" % master_timeout)
+        logger.log(logger.INFO, "I'll wait master for %d seconds" % master_timeout)
         
         while not self.interrupted:
             elapsed, _, tcdiff = self.handleRequests(timeout)
@@ -576,7 +576,7 @@ class Skonf(Daemon):
             # Now check if master is dead or not
             now = time.time()
             if now - self.last_master_speack > master_timeout:
-                logger.log("Master is dead!!!")
+                logger.log(logger.INFO, "Master is dead!!!")
                 self.must_run = True
                 break
 
@@ -708,7 +708,7 @@ class Skonf(Daemon):
                         
                         
             except Exception, exp:
-                logger.log("Warning in loading plugins : %s" % exp)
+                logger.log(logger.INFO, "Warning in loading plugins : %s" % exp)
 
 
 
@@ -877,7 +877,7 @@ class Skonf(Daemon):
         # save this worker
         self.workers[w.id] = w
         
-        logger.log("[%s] Allocating new %s Worker : %s" % (self.name, w.module_name, w.id))
+        logger.log(logger.INFO, "[%s] Allocating new %s Worker : %s" % (self.name, w.module_name, w.id))
         
         # Ok, all is good. Start it!
         w.start()
@@ -886,7 +886,7 @@ class Skonf(Daemon):
     # TODO : fix hard coded server/database
     def init_db(self):
        if not Connection:
-          logger.log('ERROR : you need the pymongo lib for running skonfui. Please install it')
+          logger.log(logger.INFO, 'ERROR : you need the pymongo lib for running skonfui. Please install it')
           sys.exit(2)
 
        con = Connection('localhost')

--- a/shinken/discovery/discoverymanager.py
+++ b/shinken/discovery/discoverymanager.py
@@ -112,7 +112,7 @@ class DiscoveryManager:
                     self.db = getattr(self.dbconnection, database)
                     print "Connection to Mongodb:%s:%s is OK" % (uri, database)
                 except Exception, exp:
-                    logger.log('Error in database init : %s' % exp)
+                    logger.log(logger.INFO, 'Error in database init : %s' % exp)
 
     # Look if the name is a IPV4 address or not
     def is_ipv4_addr(self, name):

--- a/shinken/dispatcher.py
+++ b/shinken/dispatcher.py
@@ -148,12 +148,12 @@ class Dispatcher:
                 sched = r.confs[cfg_id].assigned_to
                 if sched is None:
                     if self.first_dispatch_done:
-                        logger.log("Scheduler configuration %d is unmanaged!!" % cfg_id)
+                        logger.log(logger.INFO, "Scheduler configuration %d is unmanaged!!" % cfg_id)
                     self.dispatch_ok = False
                 else:
                     if not sched.alive:
                         self.dispatch_ok = False # so we ask a new dispatching
-                        logger.log("Warning : Scheduler %s had the configuration %d but is dead, I am not happy." % (sched.get_name(), cfg_id))
+                        logger.log(logger.INFO, "Warning : Scheduler %s had the configuration %d but is dead, I am not happy." % (sched.get_name(), cfg_id))
                         sched.conf.assigned_to = None
                         sched.conf.is_assigned = False
                         sched.conf.push_flavor = 0
@@ -163,7 +163,7 @@ class Dispatcher:
                     # so ask it what it is really managing, and if not, put the conf unassigned
                     if not sched.do_i_manage(cfg_id, push_flavor):
                         self.dispatch_ok = False # so we ask a new dispatching
-                        logger.log("Warning : Scheduler %s did not managed its configuration %d,I am not happy." % (sched.get_name(), cfg_id))
+                        logger.log(logger.INFO, "Warning : Scheduler %s did not managed its configuration %d,I am not happy." % (sched.get_name(), cfg_id))
                         if sched.conf:
                             sched.conf.assigned_to = None
                             sched.conf.is_assigned = False
@@ -184,7 +184,7 @@ class Dispatcher:
                         # We must have the good number of satellite or we are not happy
                         # So we are sure to raise a dispatch every loop a satellite is missing
                         if len(r.to_satellites_managed_by[kind][cfg_id]) < r.get_nb_of_must_have_satellites(kind):
-                            logger.log("Warning : Missing satellite %s for configuration %d :" % (kind, cfg_id))
+                            logger.log(logger.INFO, "Warning : Missing satellite %s for configuration %d :" % (kind, cfg_id))
 
                             # TODO : less violent! Must only resent to who need?
                             # must be caught by satellite who sees that it already has the conf (hash)
@@ -210,7 +210,7 @@ class Dispatcher:
                             #wim = satellite.managed_confs# what_i_managed()
                             #print "%s [%s]Look at what manage the %s %s (alive? %s, reachable? %s): %s (look for %s)" % (int(time.time()), r.get_name(), kind, satellite.get_name(), satellite.alive, satellite.reachable, wim, cfg_id)
                             if not satellite.alive or (satellite.reachable and not satellite.do_i_manage(cfg_id, push_flavor)):
-                                logger.log('[%s] Warning : The %s %s seems to be down, I must re-dispatch its role to someone else.' % (r.get_name(), kind, satellite.get_name()))
+                                logger.log(logger.INFO, '[%s] Warning : The %s %s seems to be down, I must re-dispatch its role to someone else.' % (r.get_name(), kind, satellite.get_name()))
                                 self.dispatch_ok = False # so we will redispatch all
                                 r.to_satellites_need_dispatch[kind][cfg_id]  = True
                                 r.to_satellites_managed_by[kind][cfg_id] = []
@@ -246,7 +246,7 @@ class Dispatcher:
                 if elt.conf is None and elt.reachable:
                     # print "Ask", elt.get_name() , 'if it got conf'
                     if elt.have_conf():
-                        logger.log('Warning : The element %s have a conf and should not have one! I ask it to idle now' % elt.get_name())
+                        logger.log(logger.INFO, 'Warning : The element %s have a conf and should not have one! I ask it to idle now' % elt.get_name())
                         elt.active = False
                         elt.wait_new_conf()
                         # I do not care about order not send or not. If not,
@@ -277,11 +277,11 @@ class Dispatcher:
                     # We can put it idle, no active and wait_new_conf
                     if len(id_to_delete) == len(cfg_ids):
                         satellite.active = False
-                        logger.log("I ask %s to wait a new conf" % satellite.get_name())
+                        logger.log(logger.INFO, "I ask %s to wait a new conf" % satellite.get_name())
                         satellite.wait_new_conf()
                     else:#It is not fully idle, just less cfg
                         for id in id_to_delete:
-                            logger.log("I ask to remove configuration N%d from %s" %(cfg_id, satellite.get_name()))
+                            logger.log(logger.INFO, "I ask to remove configuration N%d from %s" %(cfg_id, satellite.get_name()))
                             satellite.remove_from_conf(cfg_id)
 
 
@@ -325,8 +325,8 @@ class Dispatcher:
                 conf_to_dispatch = [ cfg for cfg in r.confs.values() if not cfg.is_assigned ]
                 nb_conf = len(conf_to_dispatch)
                 if nb_conf > 0:
-                    logger.log("Dispatching Realm %s" % r.get_name())
-                    logger.log('[%s] Dispatching %d/%d configurations' % (r.get_name(), nb_conf, len(r.confs)))
+                    logger.log(logger.INFO, "Dispatching Realm %s" % r.get_name())
+                    logger.log(logger.INFO, '[%s] Dispatching %d/%d configurations' % (r.get_name(), nb_conf, len(r.confs)))
 
                 # Now we get in scheds all scheduler of this realm and upper so
                 # we will send them conf (in this order)
@@ -334,7 +334,7 @@ class Dispatcher:
 
                 if nb_conf > 0:
                     print_string = '[%s] Schedulers order : %s' % (r.get_name(), ','.join([s.get_name() for s in scheds]))
-                    logger.log(print_string)
+                    logger.log(logger.INFO, print_string)
 
 
                 # Try to send only for alive members
@@ -343,11 +343,11 @@ class Dispatcher:
                 # Now we do the real job
                 # every_one_need_conf = False
                 for conf in conf_to_dispatch:
-                    logger.log('[%s] Dispatching configuration %s' % (r.get_name(), conf.id))
+                    logger.log(logger.INFO, '[%s] Dispatching configuration %s' % (r.get_name(), conf.id))
 
                     # If there is no alive schedulers, not good...
                     if len(scheds) == 0:
-                        logger.log('[%s] but there a no alive schedulers in this realm!' % r.get_name())
+                        logger.log(logger.INFO, '[%s] but there a no alive schedulers in this realm!' % r.get_name())
 
                     # we need to loop until the conf is assigned
                     # or when there are no more schedulers available
@@ -364,9 +364,9 @@ class Dispatcher:
                                 r.to_satellites_managed_by[kind][cfg_id] = []
                             break
                         
-                        logger.log('[%s] Trying to send conf %d to scheduler %s' % (r.get_name(), conf.id, sched.get_name()))
+                        logger.log(logger.INFO, '[%s] Trying to send conf %d to scheduler %s' % (r.get_name(), conf.id, sched.get_name()))
                         if not sched.need_conf:
-                            logger.log('[%s] The scheduler %s do not need conf, sorry' % (r.get_name(), sched.get_name()))
+                            logger.log(logger.INFO, '[%s] The scheduler %s do not need conf, sorry' % (r.get_name(), sched.get_name()))
                             continue
                         
                         #every_one_need_conf = True
@@ -385,10 +385,10 @@ class Dispatcher:
                         
                         is_sent = sched.put_conf(conf_package)
                         if not is_sent:
-                            logger.log('[%s] WARNING : configuration dispatching error for scheduler %s' %(r.get_name(), sched.get_name()))
+                            logger.log(logger.INFO, '[%s] WARNING : configuration dispatching error for scheduler %s' %(r.get_name(), sched.get_name()))
                             continue
                         
-                        logger.log('[%s] Dispatch OK of conf in scheduler %s' % (r.get_name(), sched.get_name()))
+                        logger.log(logger.INFO, '[%s] Dispatch OK of conf in scheduler %s' % (r.get_name(), sched.get_name()))
 
                         sched.conf = conf
                         sched.push_flavor = conf.push_flavor
@@ -414,9 +414,9 @@ class Dispatcher:
             conf_to_dispatch = [ cfg for cfg in self.conf.confs.values() if not cfg.is_assigned ]
             nb_missed = len(conf_to_dispatch)
             if nb_missed > 0:
-                logger.log("WARNING : All schedulers configurations are not dispatched, %d are missing" % nb_missed)
+                logger.log(logger.INFO, "WARNING : All schedulers configurations are not dispatched, %d are missing" % nb_missed)
             else:
-                logger.log("OK, all schedulers configurations are dispatched :)")
+                logger.log(logger.INFO, "OK, all schedulers configurations are dispatched :)")
                 self.dispatch_ok = True
 
             # Sched without conf in a dispatch ok are set to no need_conf
@@ -476,7 +476,7 @@ class Dispatcher:
                             satellite_string = "[%s] Dispatching %s satellite with order : " % (r.get_name(), kind)
                             for satellite in satellites:
                                 satellite_string += '%s (spare:%s), ' % (satellite.get_name(), str(satellite.spare))
-                            logger.log(satellite_string)
+                            logger.log(logger.INFO, satellite_string)
 
 
                             # Now we dispatch cfg to every one ask for it
@@ -495,15 +495,15 @@ class Dispatcher:
                                     is_sent = False
                                     # Maybe this satellite already got this configuration, so skip it
                                     if satellite.do_i_manage(cfg_id, flavor):
-                                        logger.log('[%s] Skipping configuration %d send to the %s %s : it already got it' % (r.get_name(), cfg_id, kind, satellite.get_name()))
+                                        logger.log(logger.INFO, '[%s] Skipping configuration %d send to the %s %s : it already got it' % (r.get_name(), cfg_id, kind, satellite.get_name()))
                                         is_sent = True
                                     else: # ok, it really need it :) 
-                                        logger.log('[%s] Trying to send configuration to %s %s' %(r.get_name(), kind, satellite.get_name()))
+                                        logger.log(logger.INFO, '[%s] Trying to send configuration to %s %s' %(r.get_name(), kind, satellite.get_name()))
                                         is_sent = satellite.put_conf(satellite.cfg)
 
                                     if is_sent:
                                         satellite.active = True
-                                        logger.log('[%s] Dispatch OK of configuration %s to %s %s' %(r.get_name(), cfg_id, kind, satellite.get_name()))
+                                        logger.log(logger.INFO, '[%s] Dispatch OK of configuration %s to %s %s' %(r.get_name(), cfg_id, kind, satellite.get_name()))
                                         # We change the satellite configuration, update our data
                                         satellite.known_conf_managed_push(cfg_id, flavor)
 
@@ -517,7 +517,7 @@ class Dispatcher:
                             # else:
                             #    #I've got enough satellite, the next one are spare for me
                             if nb_cfg_sent == r.get_nb_of_must_have_satellites(kind):
-                                logger.log("[%s] OK, no more %s sent need" % (r.get_name(), kind))
+                                logger.log(logger.INFO, "[%s] OK, no more %s sent need" % (r.get_name(), kind))
                                 r.to_satellites_need_dispatch[kind][cfg_id]  = False
 
 
@@ -526,12 +526,12 @@ class Dispatcher:
             for r in self.realms:
                 for rec in r.receivers:
                     if rec.need_conf:
-                        logger.log('[%s] Trying to send configuration to receiver %s' %(r.get_name(), rec.get_name()))
+                        logger.log(logger.INFO, '[%s] Trying to send configuration to receiver %s' %(r.get_name(), rec.get_name()))
                         is_sent = rec.put_conf(rec.cfg)
                         if is_sent:
                             rec.active = True
                             rec.need_conf = False
-                            logger.log('[%s] Dispatch OK of configuration to receiver %s' %(r.get_name(), rec.get_name()))
+                            logger.log(logger.INFO, '[%s] Dispatch OK of configuration to receiver %s' %(r.get_name(), rec.get_name()))
                         else:
-                            logger.log('[%s] WARNING : dispatching failed for receiver %s' %(r.get_name(), rec.get_name()))
+                            logger.log(logger.INFO, '[%s] WARNING : dispatching failed for receiver %s' %(r.get_name(), rec.get_name()))
                             

--- a/shinken/external_command.py
+++ b/shinken/external_command.py
@@ -316,7 +316,7 @@ class ExternalCommandManager:
 
         #Only log if we are in the Arbiter
         if self.mode == 'dispatcher' and self.conf.log_external_commands:
-            logger.log('EXTERNAL COMMAND: '+command.rstrip())
+            logger.log(logger.INFO, 'EXTERNAL COMMAND: '+command.rstrip())
         r = self.get_command_and_args(command)
         if r is not None:
             is_global = r['global']
@@ -351,7 +351,7 @@ class ExternalCommandManager:
                 else:
                     print "Problem: a configuration is found, but is not assigned!"
         if not host_found:
-                logger.log("Warning:  Passive check result was received for host '%s', but the host could not be found!" % host_name)
+                logger.log(logger.INFO, "Warning:  Passive check result was received for host '%s', but the host could not be found!" % host_name)
                 #print "Sorry but the host", host_name, "was not found"
 
 
@@ -499,7 +499,7 @@ class ExternalCommandManager:
                     if s is not None:
                         args.append(s)
                     else: #error, must be logged
-                        logger.log("Warning: a command was received for service '%s' on host '%s', but the service could not be found!" % (srv_name, tmp_host))
+                        logger.log(logger.INFO, "Warning: a command was received for service '%s' on host '%s', but the service could not be found!" % (srv_name, tmp_host))
 
         except IndexError:
             safe_print("Sorry, the arguments are not corrects")
@@ -1229,7 +1229,7 @@ class ExternalCommandManager:
     def PROCESS_HOST_CHECK_RESULT(self, host, status_code, plugin_output):
         #raise a PASSIVE check only if needed
         if self.conf.log_passive_checks:
-            logger.log('PASSIVE HOST CHECK: %s;%d;%s' % (host.get_name(), status_code, plugin_output))
+            logger.log(logger.INFO, 'PASSIVE HOST CHECK: %s;%d;%s' % (host.get_name(), status_code, plugin_output))
         now = time.time()
         cls = host.__class__
         # If globally disable OR locally, do not launch
@@ -1252,7 +1252,7 @@ class ExternalCommandManager:
     def PROCESS_SERVICE_CHECK_RESULT(self, service, return_code, plugin_output):
         # raise a PASSIVE check only if needed
         if self.conf.log_passive_checks:
-            logger.log('PASSIVE SERVICE CHECK: %s;%s;%d;%s' % (service.host.get_name(), service.get_name(), return_code, plugin_output))
+            logger.log(logger.INFO, 'PASSIVE SERVICE CHECK: %s;%s;%d;%s' % (service.host.get_name(), service.get_name(), return_code, plugin_output))
         now = time.time()
         cls = service.__class__
         # If globally disable OR locally, do not launch

--- a/shinken/modules/glpidb_broker/glpidb_broker.py
+++ b/shinken/modules/glpidb_broker/glpidb_broker.py
@@ -179,7 +179,7 @@ class Glpidb_broker(BaseModule):
 
     #Host result
     #def manage_host_check_result_brok(self, b):
-        #logger.log("GLPI : data in DB %s " % b)
+        #logger.log(logger.INFO, "GLPI : data in DB %s " % b)
         #b.data['date'] = time.strftime('%Y-%m-%d %H:%M:%S')
         #query = self.db_backend.create_insert_query('glpi_plugin_monitoring_serviceevents', b.data)
         #return [query]
@@ -187,7 +187,7 @@ class Glpidb_broker(BaseModule):
 
     #Host result
     #def manage_host_check_resultup_brok(self, b):
-        #logger.log("GLPI : data in DB %s " % b)
+        #logger.log(logger.INFO, "GLPI : data in DB %s " % b)
         #new_data = copy.deepcopy(b.data)
         #new_data['last_check'] = time.strftime('%Y-%m-%d %H:%M:%S')
         #new_data['id'] = b.data['plugin_monitoring_services_id']
@@ -202,7 +202,7 @@ class Glpidb_broker(BaseModule):
 
     #Service result
     def manage_service_check_result_brok(self, b):
-        #logger.log("GLPI : data in DB %s " % b)
+        #logger.log(logger.INFO, "GLPI : data in DB %s " % b)
         try:
             b.data['plugin_monitoring_servicescatalogs_id']
             return ''
@@ -215,7 +215,7 @@ class Glpidb_broker(BaseModule):
 
     #Service result
     def manage_service_check_resultup_brok(self, b):
-        logger.log("GLPI : data in DB %s " % b.data)
+        logger.log(logger.INFO, "GLPI : data in DB %s " % b.data)
         new_data = copy.deepcopy(b.data)
         new_data['last_check'] = time.strftime('%Y-%m-%d %H:%M:%S')
         del new_data['perf_data']

--- a/shinken/modules/hack_poller_tag_by_macros.py
+++ b/shinken/modules/hack_poller_tag_by_macros.py
@@ -55,7 +55,7 @@ class Hack_pt_by_macros(BaseModule):
         
 
     def hook_late_configuration(self, arb):
-        logger.log("[HackPollerTagByMacros in hook late config")
+        logger.log(logger.INFO, "[HackPollerTagByMacros in hook late config")
         for h in arb.conf.hosts:
             if h.poller_tag == 'None' and self.host_macro_name.upper() in h.customs:
                 v = h.customs[self.host_macro_name.upper()]

--- a/shinken/modules/ip_tag_arbiter/ip_tag_arbiter.py
+++ b/shinken/modules/ip_tag_arbiter/ip_tag_arbiter.py
@@ -41,7 +41,7 @@ class Ip_Tag_Arbiter(BaseModule):
         
 
     def hook_early_configuration(self, arb):
-        logger.log("[IpTag] in hook late config")
+        logger.log(logger.INFO, "[IpTag] in hook late config")
         for h in arb.conf.hosts:
             if not hasattr(h, 'address') and not hasattr(h, 'host_name'):
                 continue

--- a/shinken/modules/livestatus_broker/livestatus_broker.py
+++ b/shinken/modules/livestatus_broker/livestatus_broker.py
@@ -207,7 +207,7 @@ class LiveStatus_broker(BaseModule, Daemon):
 
         # Check if some og the required directories exist
         #if not os.path.exists(bottle.TEMPLATE_PATH[0]):
-        #    logger.log('ERROR : the view path do not exist at %s' % bottle.TEMPLATE_PATH)
+        #    logger.log(logger.INFO, 'ERROR : the view path do not exist at %s' % bottle.TEMPLATE_PATH)
         #    sys.exit(2)
 
         self.load_plugins()
@@ -244,9 +244,9 @@ class LiveStatus_broker(BaseModule, Daemon):
                             mod.manage_brok(b)
                         except Exception, exp:
                             print exp.__dict__
-                            logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
-                            logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                            logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                            logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
+                            logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                            logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                             self.modules_manager.set_to_restart(mod)
                 except Exception, exp:
                     msg = Message(id=0, type='ICrash', data={
@@ -321,9 +321,9 @@ class LiveStatus_broker(BaseModule, Daemon):
                 mod.manage_brok(brok)
             except Exception, exp:
                 print exp.__dict__
-                logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
-                logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
+                logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                 self.modules_manager.set_to_restart(mod)
 
     def do_stop(self):
@@ -389,9 +389,9 @@ class LiveStatus_broker(BaseModule, Daemon):
                                 mod.manage_brok(b)
                             except Exception, exp:
                                 print exp.__dict__
-                                logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
-                                logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                                logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(), str(exp)))
+                                logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                                 self.modules_manager.set_to_restart(mod)
                 except Queue.Empty:
                     self.livestatus.counters.calc_rate()

--- a/shinken/modules/nagios_retention_file_scheduler.py
+++ b/shinken/modules/nagios_retention_file_scheduler.py
@@ -59,7 +59,7 @@ class Nagios_retention_scheduler(BaseModule):
 
     # Ok, main function that is called in the retention creation pass
     def hook_save_retention(self, daemon):
-        logger.log("[NagiosRetention] asking me to update the retention objects, but I won't do it.")
+        logger.log(logger.INFO, "[NagiosRetention] asking me to update the retention objects, but I won't do it.")
 
 
     def _cut_line(self, line):

--- a/shinken/modules/ndodb_mysql_broker/__init__.py
+++ b/shinken/modules/ndodb_mysql_broker/__init__.py
@@ -30,7 +30,7 @@ from shinken.log import logger
 #called by the plugin manager to get a instance
 def get_instance(mod_conf):
 
-    logger.log("Get a ndoDB instance for plugin %s" % mod_conf.get_name())
+    logger.log(logger.INFO, "Get a ndoDB instance for plugin %s" % mod_conf.get_name())
 
     #Default behavior : character_set is utf8 and synchro is turned off
     if not hasattr( mod_conf, 'character_set'):

--- a/shinken/modules/ndodb_mysql_broker/ndodb_mysql_broker.py
+++ b/shinken/modules/ndodb_mysql_broker/ndodb_mysql_broker.py
@@ -82,7 +82,7 @@ class Ndodb_Mysql_broker(BaseModule):
     # TODO: add conf param to get pass with init
     # Conf from arbiter!
     def init(self):
-        logger.log("I connect to NDO database")
+        logger.log(logger.INFO, "I connect to NDO database")
         self.db = DBMysql(self.host, self.user, self.password, self.database,
                           self.character_set, table_prefix='nagios_',
                           port=self.port)
@@ -107,7 +107,7 @@ class Ndodb_Mysql_broker(BaseModule):
             self.centreon_version = False
         else:
             self.centreon_version = True
-            logger.log("[MySQL/NDO] Using the centreon version")
+            logger.log(logger.INFO, "[MySQL/NDO] Using the centreon version")
 
         # Cache for database id
         # In order not to query the database every time
@@ -171,7 +171,7 @@ class Ndodb_Mysql_broker(BaseModule):
         try:
             self.db.connect_database()
         except _mysql_exceptions.OperationalError, exp:
-            logger.log(
+            logger.log(logger.INFO, 
                 "[MySQL/NDO] Module raised an exception: %s ." \
                 "Please check the arguments!" % \
                 exp)
@@ -371,7 +371,7 @@ class Ndodb_Mysql_broker(BaseModule):
             res.append(q)
 
         # We also clean cache, because we are not sure about this data now
-        logger.log("[MySQL/NDO] Flushing caches (clean from instance %d)" % instance_id)
+        logger.log(logger.INFO, "[MySQL/NDO] Flushing caches (clean from instance %d)" % instance_id)
         self.services_cache_sync = {}
         self.hosts_cache_sync = {}
 

--- a/shinken/modules/pickle_retention_file_generic.py
+++ b/shinken/modules/pickle_retention_file_generic.py
@@ -60,7 +60,7 @@ class Pickle_retention_generic(BaseModule):
     # Ok, main function that is called in the retention creation pass
     def hook_save_retention(self, daemon):
         log_mgr = logger
-        logger.log("[PickleRetentionGeneric] asking me to update the retention objects")
+        logger.log(logger.INFO, "[PickleRetentionGeneric] asking me to update the retention objects")
 
         #Now the flat file method
         try:

--- a/shinken/modules/simplelog_broker.py
+++ b/shinken/modules/simplelog_broker.py
@@ -92,7 +92,7 @@ class Simple_log_broker(BaseModule):
         yesterday = get_day(now-3600)
         #print "Dates: t_last_mod : %d, t_last_mod_day: %d, today : %d" % (t_last_mod, t_last_mod_day, today)
         if t_last_mod_day != today:
-            logger.log("We are archiving the old log file")
+            logger.log(logger.INFO, "We are archiving the old log file")
 
             #For the first pass, it's not already open
             if not first_pass:
@@ -111,7 +111,7 @@ class Simple_log_broker(BaseModule):
             s_day = d.strftime("-%m-%d-%Y-00")
             archive_name = f_base_name+s_day+ext
             file_archive_path = os.path.join(self.archive_path, archive_name)
-            logger.log("Moving the old log file from %s to %s" % (self.path, file_archive_path))
+            logger.log(logger.INFO, "Moving the old log file from %s to %s" % (self.path, file_archive_path))
 
             shutil.move(self.path, file_archive_path)
 
@@ -143,7 +143,7 @@ There a lot of different possible broks to manage. """
     def init(self):
         moved = self.check_and_do_archive(first_pass=True)
         if not moved:
-            logger.log("I open the log file %s" % self.path)
+            logger.log(logger.INFO, "I open the log file %s" % self.path)
             self.file = open(self.path,'a')
 
 

--- a/shinken/modules/webui_broker/webui_broker.py
+++ b/shinken/modules/webui_broker/webui_broker.py
@@ -177,7 +177,7 @@ class Webui_broker(BaseModule, Daemon):
 
         # Check if the view dir really exist
         if not os.path.exists(bottle.TEMPLATE_PATH[0]):
-            logger.log('ERROR : the view path do not exist at %s' % bottle.TEMPLATE_PATH)
+            logger.log(logger.INFO, 'ERROR : the view path do not exist at %s' % bottle.TEMPLATE_PATH)
             sys.exit(2)
 
         self.load_plugins()
@@ -229,9 +229,9 @@ class Webui_broker(BaseModule, Daemon):
                           mod.manage_brok(b)
                       except Exception , exp:
                           print exp.__dict__
-                          logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
-                          logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                          logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                          logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
+                          logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                          logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                           self.modules_manager.set_to_restart(mod)
               except Exception, exp:            
                   msg = Message(id=0, type='ICrash', data={'name' : self.get_name(), 'exception' : exp, 'trace' : traceback.format_exc()})
@@ -315,7 +315,7 @@ class Webui_broker(BaseModule, Daemon):
                         
                         
             except Exception, exp:
-                logger.log("Warning in loading plugins : %s" % exp)
+                logger.log(logger.INFO, "Warning in loading plugins : %s" % exp)
 
 
 
@@ -437,9 +437,9 @@ class Webui_broker(BaseModule, Daemon):
                         break
             except Exception , exp:
                 print exp.__dict__
-                logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
-                logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
+                logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                 self.modules_manager.set_to_restart(mod)        
 
         # Ok if we got a real contact, and if a module auth it
@@ -475,9 +475,9 @@ class Webui_broker(BaseModule, Daemon):
                     uris.extend(r)
             except Exception , exp:
                 print exp.__dict__
-                logger.log("[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
-                logger.log("[%s] Exception type : %s" % (self.name, type(exp)))
-                logger.log("Back trace of this kill: %s" % (traceback.format_exc()))
+                logger.log(logger.INFO, "[%s] Warning : The mod %s raise an exception: %s, I'm tagging it to restart later" % (self.name, mod.get_name(),str(exp)))
+                logger.log(logger.INFO, "[%s] Exception type : %s" % (self.name, type(exp)))
+                logger.log(logger.INFO, "Back trace of this kill: %s" % (traceback.format_exc()))
                 self.modules_manager.set_to_restart(mod)        
 
         safe_print("Will return", uris)

--- a/shinken/modules/ws_arbiter.py
+++ b/shinken/modules/ws_arbiter.py
@@ -106,7 +106,7 @@ class Ws_arbiter(BaseModule):
     # We initialise the HTTP part. It's a simple wsgi backend
     # with a select hack so we can still exit if someone ask it
     def init_http(self):
-        logger.log("Starting WS arbiter http socket")
+        logger.log(logger.INFO, "Starting WS arbiter http socket")
         self.srv = run(host=self.host, port=self.port, server='wsgirefselect')
         # And we link our page
         route('/push_check_result', callback=get_page, method='POST')

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -401,7 +401,7 @@ class Config(Item):
                 fd.close()
                 config_base_dir = os.path.dirname(file)
             except IOError, exp:
-                logger.log("Error: Cannot open config file '%s' for reading: %s" % (file, exp))
+                logger.log(logger.INFO, "Error: Cannot open config file '%s' for reading: %s" % (file, exp))
                 #The configuration is invalid because we have a bad file!
                 self.conf_is_correct = False
                 continue
@@ -424,14 +424,14 @@ class Config(Item):
                     try:
                         fd = open(cfg_file_name, 'rU')
                         if self.read_config_silent == 0:
-                            logger.log("Processing object config file '%s'" % cfg_file_name)
+                            logger.log(logger.INFO, "Processing object config file '%s'" % cfg_file_name)
                         res.write(os.linesep + '# IMPORTEDFROM=%s' % (cfg_file_name) + os.linesep)
                         res.write(fd.read().decode('utf8', 'replace'))
                         #Be sure to add a line return so we won't mix files
                         res.write('\n')
                         fd.close()
                     except IOError, exp:
-                        logger.log("Error: Cannot open config file '%s' for reading: %s" % (cfg_file_name, exp))
+                        logger.log(logger.INFO, "Error: Cannot open config file '%s' for reading: %s" % (cfg_file_name, exp))
                     #The configuration is invalid because we have a bad file!
                         self.conf_is_correct = False
                 elif re.search("^cfg_dir", line):
@@ -442,21 +442,21 @@ class Config(Item):
                         cfg_dir_name = os.path.join(config_base_dir, elts[1])
                     #Ok, look if it's really a directory
                     if not os.path.isdir(cfg_dir_name):
-                        logger.log("Error: Cannot open config dir '%s' for reading" % cfg_dir_name)
+                        logger.log(logger.INFO, "Error: Cannot open config dir '%s' for reading" % cfg_dir_name)
                         self.conf_is_correct = False
                     #Now walk for it
                     for root, dirs, files in os.walk(cfg_dir_name):
                         for file in files:
                             if re.search("\.cfg$", file):
                                 if self.read_config_silent == 0:
-                                    logger.log("Processing object config file '%s'" % os.path.join(root, file))
+                                    logger.log(logger.INFO, "Processing object config file '%s'" % os.path.join(root, file))
                                 try:
                                     res.write(os.linesep + '# IMPORTEDFROM=%s' % (os.path.join(root, file)) + os.linesep)
                                     fd = open(os.path.join(root, file), 'rU')
                                     res.write(fd.read().decode('utf8', 'replace'))
                                     fd.close()
                                 except IOError, exp:
-                                    logger.log("Error: Cannot open config file '%s' for reading: %s" % (os.path.join(root, file), exp))
+                                    logger.log(logger.INFO, "Error: Cannot open config file '%s' for reading: %s" % (os.path.join(root, file), exp))
                                     # The configuration is invalid
                                     # because we have a bad file!
                                     self.conf_is_correct = False
@@ -624,7 +624,7 @@ class Config(Item):
         self.modules.create_reversed_list()
 
         if len(self.arbiterlinks) == 0:
-            logger.log("Warning : there is no arbiter, I add one in localhost:7770", print_it=False)
+            logger.log(logger.INFO, "Warning : there is no arbiter, I add one in localhost:7770", print_it=False)
             a = ArbiterLink({'arbiter_name' : 'Default-Arbiter',
                              'host_name' : socket.gethostname(),
                              'address' : 'localhost', 'port' : '7770',
@@ -770,7 +770,7 @@ class Config(Item):
             for prop, entry in properties.items():
                 if isinstance(entry, UnusedProp):
                     text = 'Notice : the parameter %s is useless and can be removed from the configuration (Reason: %s)' %  (prop, entry.text)
-                    logger.log(text)
+                    logger.log(logger.INFO, text)
 
 
     # It's used to raise warning if the user got parameter
@@ -789,11 +789,11 @@ class Config(Item):
             print "\n"
             mailing_list_uri = "https://lists.sourceforge.net/lists/listinfo/shinken-devel"
             text = 'Warning : the following parameter(s) are not curently managed.'
-            logger.log(text)
+            logger.log(logger.INFO, text)
             for s in unmanaged:
-                logger.log(s)
+                logger.log(logger.INFO, s)
             text = 'Please look if you really need it. If so, please register at the devel mailing list (%s) and ask for it or propose us a patch :)' % mailing_list_uri
-            logger.log(text)
+            logger.log(logger.INFO, text)
             print "\n"
 
 
@@ -949,35 +949,35 @@ class Config(Item):
             #so all hosts without realm wil be link with it
             default = Realm({'realm_name' : 'Default', 'default' : '1'})
             self.realms = Realms([default])
-            logger.log("Notice : the is no defined realms, so I add a new one %s" % default.get_name(), print_it=False)
+            logger.log(logger.INFO, "Notice : the is no defined realms, so I add a new one %s" % default.get_name(), print_it=False)
             lists = [self.pollers, self.brokers, self.reactionners, self.receivers, self.schedulerlinks]
             for l in lists:
                 for elt in l:
                     if not hasattr(elt, 'realm'):
                         elt.realm = 'Default'
-                        logger.log("Notice : Tagging %s with realm %s" % (elt.get_name(), default.get_name()), print_it=False)
+                        logger.log(logger.INFO, "Notice : Tagging %s with realm %s" % (elt.get_name(), default.get_name()), print_it=False)
 
 
     #If a satellite is missing, we add them in the localhost
     #with defaults values
     def fill_default_satellites(self):
         if len(self.schedulerlinks) == 0:
-            logger.log("Warning : there is no scheduler, I add one in localhost:7768", print_it=False)
+            logger.log(logger.INFO, "Warning : there is no scheduler, I add one in localhost:7768", print_it=False)
             s = SchedulerLink({'scheduler_name' : 'Default-Scheduler',
                                'address' : 'localhost', 'port' : '7768'})
             self.schedulerlinks = SchedulerLinks([s])
         if len(self.pollers) == 0:
-            logger.log("Warning : there is no poller, I add one in localhost:7771", print_it=False)
+            logger.log(logger.INFO, "Warning : there is no poller, I add one in localhost:7771", print_it=False)
             p = PollerLink({'poller_name' : 'Default-Poller',
                             'address' : 'localhost', 'port' : '7771'})
             self.pollers = PollerLinks([p])
         if len(self.reactionners) == 0:
-            logger.log("Warning : there is no reactionner, I add one in localhost:7769", print_it=False)
+            logger.log(logger.INFO, "Warning : there is no reactionner, I add one in localhost:7769", print_it=False)
             r = ReactionnerLink({'reactionner_name' : 'Default-Reactionner',
                                  'address' : 'localhost', 'port' : '7769'})
             self.reactionners = ReactionnerLinks([r])
         if len(self.brokers) == 0:
-            logger.log("Warning : there is no broker, I add one in localhost:7772", print_it=False)
+            logger.log(logger.INFO, "Warning : there is no broker, I add one in localhost:7772", print_it=False)
             b = BrokerLink({'broker_name' : 'Default-Broker',
                             'address' : 'localhost', 'port' : '7772',
                             'manage_arbiters' : '1'})
@@ -1135,17 +1135,17 @@ class Config(Item):
 
         #We add them to the brokers if we need it
         if mod_to_add != []:
-            logger.log("Warning : I autogenerated some Broker modules, please look at your configuration")
+            logger.log(logger.INFO, "Warning : I autogenerated some Broker modules, please look at your configuration")
             for m in mod_to_add:
-                logger.log("Warning : the module %s is autogenerated" % m.module_name)
+                logger.log(logger.INFO, "Warning : the module %s is autogenerated" % m.module_name)
                 for b in self.brokers:
                     b.modules.append(m)
 
         #Then for schedulers
         if mod_to_add_to_schedulers != []:
-            logger.log("Warning : I autogenerated some Scheduler modules, please look at your configuration")
+            logger.log(logger.INFO, "Warning : I autogenerated some Scheduler modules, please look at your configuration")
             for m in mod_to_add_to_schedulers:
-                logger.log("Warning : the module %s is autogenerated" %  m.module_name)
+                logger.log(logger.INFO, "Warning : the module %s is autogenerated" %  m.module_name)
                 for b in self.schedulerlinks:
                     b.modules.append(m)
 
@@ -1174,9 +1174,9 @@ class Config(Item):
 
         #We add them to the brokers if we need it
         if mod_to_add != []:
-            logger.log("Warning : I autogenerated some Arbiter modules, please look at your configuration")
+            logger.log(logger.INFO, "Warning : I autogenerated some Arbiter modules, please look at your configuration")
             for (mod, data) in mod_to_add:
-                logger.log("Warning : the module %s is autogenerated" % data['module_name'])
+                logger.log(logger.INFO, "Warning : the module %s is autogenerated" % data['module_name'])
                 for a in self.arbiterlinks:
                     a.modules = ','.join([getattr(a, 'modules', ''), data['module_name']])
                 self.modules.items[mod.id] = mod
@@ -1248,13 +1248,13 @@ class Config(Item):
     def check_error_on_hard_unmanaged_parameters(self):
         r = True
         if self.use_regexp_matching:
-            logger.log("Error : the use_regexp_matching parameter is not managed.")
+            logger.log(logger.INFO, "Error : the use_regexp_matching parameter is not managed.")
             r &= False
         #if self.ochp_command != '':
-        #    logger.log("Error : the ochp_command parameter is not managed.")
+        #    logger.log(logger.INFO, "Error : the ochp_command parameter is not managed.")
         #    r &= False
         #if self.ocsp_command != '':
-        #    logger.log("Error : the ocsp_command parameter is not managed.")
+        #    logger.log(logger.INFO, "Error : the ocsp_command parameter is not managed.")
         #    r &= False
         return r
 
@@ -1265,32 +1265,32 @@ class Config(Item):
     # does not have the satellites.
     def is_correct(self):
         """ Check if all elements got a good configuration """
-        logger.log('Running pre-flight check on configuration data...')
+        logger.log(logger.INFO, 'Running pre-flight check on configuration data...')
         r = self.conf_is_correct
 
         # Globally unamanged parameters
         if self.read_config_silent == 0:
-            logger.log('Checking global parameters...')
+            logger.log(logger.INFO, 'Checking global parameters...')
         if not self.check_error_on_hard_unmanaged_parameters():
             r = False
-            logger.log("check global parameters failed")
+            logger.log(logger.INFO, "check global parameters failed")
             
         for x in ('hosts', 'hostgroups', 'contacts', 'contactgroups', 'notificationways',
                   'escalations', 'services', 'servicegroups', 'timeperiods', 'commands',
                   'hostsextinfo','servicesextinfo'):
             if self.read_config_silent == 0:
-                logger.log('Checking %s...' % (x))
+                logger.log(logger.INFO, 'Checking %s...' % (x))
             cur = getattr(self, x)
             if not cur.is_correct():
                 r = False
-                logger.log("\t%s conf incorrect !!" % (x))
+                logger.log(logger.INFO, "\t%s conf incorrect !!" % (x))
             if self.read_config_silent == 0:
-                logger.log('\tChecked %d %s' % (len(cur), x))
+                logger.log(logger.INFO, '\tChecked %d %s' % (len(cur), x))
 
         # Hosts got a special check for loops
         if not self.hosts.no_loop_in_parents():
             r = False
-            logger.log("hosts: detected loop in parents ; conf incorrect")
+            logger.log(logger.INFO, "hosts: detected loop in parents ; conf incorrect")
         
         for x in ( 'servicedependencies', 'hostdependencies', 'arbiterlinks', 'schedulerlinks',
                    'reactionners', 'pollers', 'brokers', 'receivers', 'resultmodulations',
@@ -1298,12 +1298,12 @@ class Config(Item):
             try: cur = getattr(self, x)
             except: continue
             if self.read_config_silent == 0:
-                logger.log('Checking %s...' % (x))
+                logger.log(logger.INFO, 'Checking %s...' % (x))
             if not cur.is_correct():
                 r = False
-                logger.log("\t%s conf incorrect !!" % (x))
+                logger.log(logger.INFO, "\t%s conf incorrect !!" % (x))
             if self.read_config_silent == 0:
-                logger.log('\tChecked %d %s' % (len(cur), x))
+                logger.log(logger.INFO, '\tChecked %d %s' % (len(cur), x))
 
         # Look that all scheduler got a broker that will take brok.
         # If there are no, raise an Error
@@ -1311,7 +1311,7 @@ class Config(Item):
             rea = s.realm
             if rea:
                 if len(rea.potential_brokers) == 0:
-                    logger.log("Error : the scheduler %s got no broker in its realm or upper" % s.get_name())
+                    logger.log(logger.INFO, "Error : the scheduler %s got no broker in its realm or upper" % s.get_name())
                     self.add_error("Error : the scheduler %s got no broker in its realm or upper" % s.get_name())
                     r = False
                      
@@ -1326,7 +1326,7 @@ class Config(Item):
                 pollers_tag.add(t)
         if not hosts_tag.issubset(pollers_tag):
             for tag in hosts_tag.difference(pollers_tag):
-                logger.log("Error : hosts exist with poller_tag %s but no poller got this tag" %  tag )
+                logger.log(logger.INFO, "Error : hosts exist with poller_tag %s but no poller got this tag" %  tag )
                 self.add_error("Error : hosts exist with poller_tag %s but no poller got this tag" %  tag )
                 r = False
 
@@ -1338,7 +1338,7 @@ class Config(Item):
                     for elt in e.business_rule.list_all_elements():
                         elt_r = elt.get_realm().realm_name
                         if not elt_r == e_r:
-                            logger.log("Error : Business_rule '%s' got hosts from another realm : %s" %  (e.get_full_name(), elt_r) )
+                            logger.log(logger.INFO, "Error : Business_rule '%s' got hosts from another realm : %s" %  (e.get_full_name(), elt_r) )
                             self.add_error("Error : Business_rule '%s' got hosts from another realm : %s" %  (e.get_full_name(), elt_r) )
                             r = False
                 
@@ -1410,7 +1410,7 @@ class Config(Item):
     # Now it's time to show all configuration errors
     def show_errors(self):
         for err in self.configuration_errors:
-            logger.log(err)
+            logger.log(logger.INFO, err)
 
 
     #Create packs of hosts and services so in a pack,
@@ -1543,7 +1543,7 @@ class Config(Item):
             for pack in r.packs:
                 nb_elements += len(pack)
                 nb_elements_all_realms += len(pack)
-            logger.log("Number of hosts in the realm %s : %d (distributed in %d linked packs)" %(r.get_name(), nb_elements, len(r.packs)))
+            logger.log(logger.INFO, "Number of hosts in the realm %s : %d (distributed in %d linked packs)" %(r.get_name(), nb_elements, len(r.packs)))
 
             if nb_schedulers == 0 and nb_elements != 0:
                 err = "Error : The realm %s have hosts but no scheduler!" %r.get_name()
@@ -1574,10 +1574,10 @@ class Config(Item):
             # Now in packs we have the number of packs [h1, h2, etc]
             # equal to the number of schedulers.
             r.packs = packs
-        logger.log("Number of hosts in all the realm  %d" % nb_elements_all_realms)
-        logger.log("Number of hosts %d" % len(self.hosts))
+        logger.log(logger.INFO, "Number of hosts in all the realm  %d" % nb_elements_all_realms)
+        logger.log(logger.INFO, "Number of hosts %d" % len(self.hosts))
         if len(self.hosts) != nb_elements_all_realms:
-            logger.log("There are %d hosts defined, and %d hosts dispatched in the realms. Some hosts have been ignored" %( len(self.hosts), nb_elements_all_realms))
+            logger.log(logger.INFO, "There are %d hosts defined, and %d hosts dispatched in the realms. Some hosts have been ignored" %( len(self.hosts), nb_elements_all_realms))
             self.add_error("There are %d hosts defined, and %d hosts dispatched in the realms. Some hosts have been ignored" %( len(self.hosts), nb_elements_all_realms))
 
 
@@ -1636,7 +1636,7 @@ class Config(Item):
             # if a scheduler have accepted the conf
             cur_conf.is_assigned = False 
 
-        logger.log("Creating packs for realms")
+        logger.log(logger.INFO, "Creating packs for realms")
 
         # Just create packs. There can be numerous ones
         # In pack we've got hosts and service

--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -188,7 +188,7 @@ class Contact(Item):
         if hasattr(self, 'contact_name'):
             for c in cls.illegal_object_name_chars:
                 if c in self.contact_name:
-                    logger.log("%s : My contact_name got the caracter %s that is not allowed." % (self.get_name(), c))
+                    logger.log(logger.INFO, "%s : My contact_name got the caracter %s that is not allowed." % (self.get_name(), c))
                     state = False
         else:
             if hasattr(self, 'alias'): #take the alias if we miss the contact_name
@@ -201,19 +201,19 @@ class Contact(Item):
     # Raise a log entry when a downtime begins
     # CONTACT DOWNTIME ALERT: test_contact;STARTED; Contact has entered a period of scheduled downtime
     def raise_enter_downtime_log_entry(self):
-        logger.log("CONTACT DOWNTIME ALERT: %s;STARTED; Contact has entered a period of scheduled downtime" % self.get_name())
+        logger.log(logger.INFO, "CONTACT DOWNTIME ALERT: %s;STARTED; Contact has entered a period of scheduled downtime" % self.get_name())
 
 
     # Raise a log entry when a downtime has finished
     # CONTACT DOWNTIME ALERT: test_contact;STOPPED; Contact has exited from a period of scheduled downtime
     def raise_exit_downtime_log_entry(self):
-        logger.log("CONTACT DOWNTIME ALERT: %s;STOPPED; Contact has exited from a period of scheduled downtime" % self.get_name())
+        logger.log(logger.INFO, "CONTACT DOWNTIME ALERT: %s;STOPPED; Contact has exited from a period of scheduled downtime" % self.get_name())
 
 
     # Raise a log entry when a downtime prematurely ends
     # CONTACT DOWNTIME ALERT: test_contact;CANCELLED; Contact has entered a period of scheduled downtime
     def raise_cancel_downtime_log_entry(self):
-        logger.log("CONTACT DOWNTIME ALERT: %s;CANCELLED; Scheduled downtime for contact has been cancelled." % self.get_name())
+        logger.log(logger.INFO, "CONTACT DOWNTIME ALERT: %s;CANCELLED; Scheduled downtime for contact has been cancelled." % self.get_name())
 
 
 class Contacts(Items):

--- a/shinken/objects/escalation.py
+++ b/shinken/objects/escalation.py
@@ -150,34 +150,34 @@ class Escalation(Item):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.log('%s : I do not have %s' % (self.get_name(), prop))
+                    logger.log(logger.INFO, '%s : I do not have %s' % (self.get_name(), prop))
                     state = False # Bad boy...
 
         # Raised all previously saw errors like unknown contacts and co
         if self.configuration_errors != []:
             state = False
             for err in self.configuration_errors:
-                logger.log(err)
+                logger.log(logger.INFO, err)
 
         # Ok now we manage special cases...
         if not hasattr(self, 'contacts') and not hasattr(self, 'contact_groups'):
-            logger.log('%s : I do not have contacts nor contact_groups' % self.get_name())
+            logger.log(logger.INFO, '%s : I do not have contacts nor contact_groups' % self.get_name())
             state = False
 
         # If time_based or not, we do not check all properties
         if self.time_based:
             if not hasattr(self, 'first_notification_time'):
-                logger.log('%s : I do not have first_notification_time' % self.get_name())
+                logger.log(logger.INFO, '%s : I do not have first_notification_time' % self.get_name())
                 state = False
             if not hasattr(self, 'last_notification_time'):
-                logger.log('%s : I do not have last_notification_time' % self.get_name())
+                logger.log(logger.INFO, '%s : I do not have last_notification_time' % self.get_name())
                 state = False
         else: # we check classical properties
             if not hasattr(self, 'first_notification'):
-                logger.log('%s : I do not have first_notification' % self.get_name())
+                logger.log(logger.INFO, '%s : I do not have first_notification' % self.get_name())
                 state = False
             if not hasattr(self, 'last_notification'):
-                logger.log('%s : I do not have last_notification' % self.get_name())
+                logger.log(logger.INFO, '%s : I do not have last_notification' % self.get_name())
                 state = False
 
         return state

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -376,7 +376,7 @@ class Host(SchedulingItem):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.log("%s : I do not have %s" % (self.get_name(), prop))
+                    logger.log(logger.INFO, "%s : I do not have %s" % (self.get_name(), prop))
                     state = False #Bad boy...
 
         # Then look if we have some errors in the conf
@@ -388,39 +388,39 @@ class Host(SchedulingItem):
         if self.configuration_errors != []:
             state = False
             for err in self.configuration_errors:
-                logger.log(err)
+                logger.log(logger.INFO, err)
 
         if not hasattr(self, 'notification_period'):
             self.notification_period = None
 
         # Ok now we manage special cases...
         if self.notifications_enabled and self.contacts == []:
-            logger.log("Warning : the host %s has no contacts nor contact_groups in (%s)" % (self.get_name(), source))
+            logger.log(logger.INFO, "Warning : the host %s has no contacts nor contact_groups in (%s)" % (self.get_name(), source))
         
         if getattr(self, 'check_command', None) is None:
-            logger.log("%s : I've got no check_command" % self.get_name())
+            logger.log(logger.INFO, "%s : I've got no check_command" % self.get_name())
             state = False
         # Ok got a command, but maybe it's invalid
         else:
             if not self.check_command.is_valid():
-                logger.log("%s : my check_command %s is invalid" % (self.get_name(), self.check_command.command))
+                logger.log(logger.INFO, "%s : my check_command %s is invalid" % (self.get_name(), self.check_command.command))
                 state = False
             if self.got_business_rule:
                 if not self.business_rule.is_valid():
-                    logger.log("%s : my business rule is invalid" % (self.get_name(),))
+                    logger.log(logger.INFO, "%s : my business rule is invalid" % (self.get_name(),))
                     for bperror in self.business_rule.configuration_errors:
-                        logger.log("%s : %s" % (self.get_name(), bperror))
+                        logger.log(logger.INFO, "%s : %s" % (self.get_name(), bperror))
                     state = False
         
         if not hasattr(self, 'notification_interval') and self.notifications_enabled == True:
-            logger.log("%s : I've got no notification_interval but I've got notifications enabled" % self.get_name())
+            logger.log(logger.INFO, "%s : I've got no notification_interval but I've got notifications enabled" % self.get_name())
             state = False
 
         # If active check is enabled with a check_interval!=0, we must have a check_period
         if ( getattr(self, 'active_checks_enabled', False) 
              and getattr(self, 'check_period', None) is None 
              and getattr(self, 'check_interval', 1) != 0 ):
-            logger.log("%s : My check_period is not correct" % self.get_name())
+            logger.log(logger.INFO, "%s : My check_period is not correct" % self.get_name())
             state = False
         
         if not hasattr(self, 'check_period'):
@@ -429,7 +429,7 @@ class Host(SchedulingItem):
         if hasattr(self, 'host_name'):
             for c in cls.illegal_object_name_chars:
                 if c in self.host_name:
-                    logger.log("%s : My host_name got the caracter %s that is not allowed." % (self.get_name(), c))
+                    logger.log(logger.INFO, "%s : My host_name got the caracter %s that is not allowed." % (self.get_name(), c))
                     state = False
 
         return state
@@ -663,21 +663,21 @@ class Host(SchedulingItem):
     # Add a log entry with a HOST ALERT like:
     # HOST ALERT: server;DOWN;HARD;1;I don't know what to say...
     def raise_alert_log_entry(self):
-        logger.log('HOST ALERT: %s;%s;%s;%d;%s' % (self.get_name(), self.state, self.state_type, self.attempt, self.output))
+        logger.log(logger.INFO, 'HOST ALERT: %s;%s;%s;%d;%s' % (self.get_name(), self.state, self.state_type, self.attempt, self.output))
 
 
     # If the configuration allow it, raise an initial log like
     # CURRENT HOST STATE: server;DOWN;HARD;1;I don't know what to say...
     def raise_initial_state(self):
         if self.__class__.log_initial_states:
-            logger.log('CURRENT HOST STATE: %s;%s;%s;%d;%s' % (self.get_name(), self.state, self.state_type, self.attempt, self.output))
+            logger.log(logger.INFO, 'CURRENT HOST STATE: %s;%s;%s;%d;%s' % (self.get_name(), self.state, self.state_type, self.attempt, self.output))
 
 
     # Add a log entry with a Freshness alert like:
     # Warning: The results of host 'Server' are stale by 0d 0h 0m 58s (threshold=0d 1h 0m 0s).
     # I'm forcing an immediate check of the host.
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
-        logger.log("Warning: The results of host '%s' are stale by %s (threshold=%s).  I'm forcing an immediate check of the host." \
+        logger.log(logger.INFO, "Warning: The results of host '%s' are stale by %s (threshold=%s).  I'm forcing an immediate check of the host." \
                       % (self.get_name(), format_t_into_dhms_format(t_stale_by), format_t_into_dhms_format(t_threshold)))
 
 
@@ -691,54 +691,54 @@ class Host(SchedulingItem):
         else:
             state = self.state
         if self.__class__.log_notifications:
-            logger.log("HOST NOTIFICATION: %s;%s;%s;%s;%s" % (contact.get_name(), self.get_name(), state, \
+            logger.log(logger.INFO, "HOST NOTIFICATION: %s;%s;%s;%s;%s" % (contact.get_name(), self.get_name(), state, \
                                                                  command.get_name(), self.output))
 
     # Raise a log entry with a Eventhandler alert like
     # HOST NOTIFICATION: superadmin;server;UP;notify-by-rss;no output
     def raise_event_handler_log_entry(self, command):
         if self.__class__.log_event_handlers:
-            logger.log("HOST EVENT HANDLER: %s;%s;%s;%s;%s" % (self.get_name(), self.state, self.state_type, self.attempt, \
+            logger.log(logger.INFO, "HOST EVENT HANDLER: %s;%s;%s;%s;%s" % (self.get_name(), self.state, self.state_type, self.attempt, \
                                                                  command.get_name()))
 
 
     #Raise a log entry with FLAPPING START alert like
     #HOST FLAPPING ALERT: server;STARTED; Host appears to have started flapping (50.6% change >= 50.0% threshold)
     def raise_flapping_start_log_entry(self, change_ratio, threshold):
-        logger.log("HOST FLAPPING ALERT: %s;STARTED; Host appears to have started flapping (%.1f%% change >= %.1f%% threshold)" % \
+        logger.log(logger.INFO, "HOST FLAPPING ALERT: %s;STARTED; Host appears to have started flapping (%.1f%% change >= %.1f%% threshold)" % \
                       (self.get_name(), change_ratio, threshold))
 
 
     #Raise a log entry with FLAPPING STOP alert like
     #HOST FLAPPING ALERT: server;STOPPED; host appears to have stopped flapping (23.0% change < 25.0% threshold)
     def raise_flapping_stop_log_entry(self, change_ratio, threshold):
-        logger.log("HOST FLAPPING ALERT: %s;STOPPED; Host appears to have stopped flapping (%.1f%% change < %.1f%% threshold)" % \
+        logger.log(logger.INFO, "HOST FLAPPING ALERT: %s;STOPPED; Host appears to have stopped flapping (%.1f%% change < %.1f%% threshold)" % \
                       (self.get_name(), change_ratio, threshold))
 
 
     #If there is no valid time for next check, raise a log entry
     def raise_no_next_check_log_entry(self):
-        logger.log("Warning : I cannot schedule the check for the host '%s' because there is not future valid time" % \
+        logger.log(logger.INFO, "Warning : I cannot schedule the check for the host '%s' because there is not future valid time" % \
                       (self.get_name()))
 
     #Raise a log entry when a downtime begins
     #HOST DOWNTIME ALERT: test_host_0;STARTED; Host has entered a period of scheduled downtime
     def raise_enter_downtime_log_entry(self):
-        logger.log("HOST DOWNTIME ALERT: %s;STARTED; Host has entered a period of scheduled downtime" % \
+        logger.log(logger.INFO, "HOST DOWNTIME ALERT: %s;STARTED; Host has entered a period of scheduled downtime" % \
                       (self.get_name()))
 
 
     #Raise a log entry when a downtime has finished
     #HOST DOWNTIME ALERT: test_host_0;STOPPED; Host has exited from a period of scheduled downtime
     def raise_exit_downtime_log_entry(self):
-        logger.log("HOST DOWNTIME ALERT: %s;STOPPED; Host has exited from a period of scheduled downtime" % \
+        logger.log(logger.INFO, "HOST DOWNTIME ALERT: %s;STOPPED; Host has exited from a period of scheduled downtime" % \
                       (self.get_name()))
 
 
     #Raise a log entry when a downtime prematurely ends
     #HOST DOWNTIME ALERT: test_host_0;CANCELLED; Service has entered a period of scheduled downtime
     def raise_cancel_downtime_log_entry(self):
-        logger.log("HOST DOWNTIME ALERT: %s;CANCELLED; Scheduled downtime for host has been cancelled." % \
+        logger.log(logger.INFO, "HOST DOWNTIME ALERT: %s;CANCELLED; Scheduled downtime for host has been cancelled." % \
                       (self.get_name()))
 
 
@@ -759,7 +759,7 @@ class Host(SchedulingItem):
             if c.output != self.output:
                 need_stalk = False
         if need_stalk:
-            logger.log("Stalking %s : %s" % (self.get_name(), self.output))
+            logger.log(logger.INFO, "Stalking %s : %s" % (self.get_name(), self.output))
 
 
     #fill act_depend_of with my parents (so network dep)
@@ -1097,7 +1097,7 @@ class Hosts(Items):
 
         # and raise errors about it
         for h in host_in_loops:
-            logger.log("Error: The host '%s' is part of a circular parent/child chain!" % h.get_name())
+            logger.log(logger.INFO, "Error: The host '%s' is part of a circular parent/child chain!" % h.get_name())
             r = False
 
         return r

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -330,7 +330,7 @@ Like temporary attributes such as "imported_from", etc.. """
         if self.configuration_errors != []:
             state = False
             for err in self.configuration_errors:
-                logger.log(err)
+                logger.log(logger.INFO, err)
 
         for prop, entry in properties.items():
             if not hasattr(self, prop) and entry.required:

--- a/shinken/objects/realm.py
+++ b/shinken/objects/realm.py
@@ -291,7 +291,7 @@ class Realm(Itemgroup):
              self.nb_brokers, len(self.potential_brokers),
              self.nb_receivers, len(self.potential_receivers)
              )
-        logger.log(s)
+        logger.log(logger.INFO, s)
 
 
 

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -363,7 +363,7 @@ class Service(SchedulingItem):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.log("Error : the service %s on host '%s' do not have %s" % (desc, hname, prop))
+                    logger.log(logger.INFO, "Error : the service %s on host '%s' do not have %s" % (desc, hname, prop))
                     state = False # Bad boy...
 
         # Then look if we have some errors in the conf
@@ -375,7 +375,7 @@ class Service(SchedulingItem):
         if self.configuration_errors != []:
             state = False
             for err in self.configuration_errors:
-                logger.log(err)
+                logger.log(logger.INFO, err)
 
         #If no notif period, set it to None, mean 24x7
         if not hasattr(self, 'notification_period'):
@@ -383,39 +383,39 @@ class Service(SchedulingItem):
 
         # Ok now we manage special cases...
         if self.notifications_enabled and self.contacts == []:
-            logger.log("Warning The service '%s' in the host '%s' do not have contacts nor contact_groups in '%s'" % (desc, hname, source))
+            logger.log(logger.INFO, "Warning The service '%s' in the host '%s' do not have contacts nor contact_groups in '%s'" % (desc, hname, source))
 
         # Set display_name if need
         if getattr(self, 'display_name', '') == '':
             self.display_name = getattr(self, 'service_description', '')
 
         if not hasattr(self, 'check_command'):
-            logger.log("%s : I've got no check_command" % self.get_name())
+            logger.log(logger.INFO, "%s : I've got no check_command" % self.get_name())
             state = False
         # Ok got a command, but maybe it's invalid
         else:
             if not self.check_command.is_valid():
-                logger.log("%s : my check_command %s is invalid" % (self.get_name(), self.check_command.command))
+                logger.log(logger.INFO, "%s : my check_command %s is invalid" % (self.get_name(), self.check_command.command))
                 state = False
             if self.got_business_rule:
                 if not self.business_rule.is_valid():
-                    logger.log("%s : my business rule is invalid" % (self.get_name(),))
+                    logger.log(logger.INFO, "%s : my business rule is invalid" % (self.get_name(),))
                     for bperror in self.business_rule.configuration_errors:
-                        logger.log("%s : %s" % (self.get_name(), bperror))
+                        logger.log(logger.INFO, "%s : %s" % (self.get_name(), bperror))
                     state = False
         if not hasattr(self, 'notification_interval') \
                 and  self.notifications_enabled == True:
-            logger.log("%s : I've got no notification_interval but I've got notifications enabled" % self.get_name())
+            logger.log(logger.INFO, "%s : I've got no notification_interval but I've got notifications enabled" % self.get_name())
             state = False
         if self.host is None:
-            logger.log("The service '%s' got a unknown host_name '%s'." % (desc, self.host_name))
+            logger.log(logger.INFO, "The service '%s' got a unknown host_name '%s'." % (desc, self.host_name))
             state = False
         if not hasattr(self, 'check_period'):
             self.check_period = None
         if hasattr(self, 'service_description'):
             for c in cls.illegal_object_name_chars:
                 if c in self.service_description:
-                    logger.log("%s : My service_description got the caracter %s that is not allowed." % (self.get_name(), c))
+                    logger.log(logger.INFO, "%s : My service_description got the caracter %s that is not allowed." % (self.get_name(), c))
                     state = False
         return state
 
@@ -664,7 +664,7 @@ class Service(SchedulingItem):
     # Add a log entry with a SERVICE ALERT like:
     # SERVICE ALERT: server;Load;UNKNOWN;HARD;1;I don't know what to say...
     def raise_alert_log_entry(self):
-        logger.log('SERVICE ALERT: %s;%s;%s;%s;%d;%s' % (self.host.get_name(),
+        logger.log(logger.INFO, 'SERVICE ALERT: %s;%s;%s;%s;%d;%s' % (self.host.get_name(),
                                                          self.get_name(),
                                                          self.state,
                                                          self.state_type,
@@ -676,7 +676,7 @@ class Service(SchedulingItem):
     # CURRENT SERVICE STATE: server;Load;UNKNOWN;HARD;1;I don't know what to say...
     def raise_initial_state(self):
         if self.__class__.log_initial_states:
-            logger.log('CURRENT SERVICE STATE: %s;%s;%s;%s;%d;%s' % (self.host.get_name(),
+            logger.log(logger.INFO, 'CURRENT SERVICE STATE: %s;%s;%s;%s;%d;%s' % (self.host.get_name(),
                                                          self.get_name(),
                                                          self.state,
                                                          self.state_type,
@@ -688,7 +688,7 @@ class Service(SchedulingItem):
     # Warning: The results of host 'Server' are stale by 0d 0h 0m 58s (threshold=0d 1h 0m 0s).
     # I'm forcing an immediate check of the host.
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
-        logger.log("Warning: The results of service '%s' on host '%s' are stale by %s (threshold=%s).  I'm forcing an immediate check of the service." \
+        logger.log(logger.INFO, "Warning: The results of service '%s' on host '%s' are stale by %s (threshold=%s).  I'm forcing an immediate check of the service." \
                       % (self.get_name(), self.host.get_name(), format_t_into_dhms_format(t_stale_by), format_t_into_dhms_format(t_threshold)))
 
 
@@ -704,7 +704,7 @@ class Service(SchedulingItem):
         else:
             state = self.state
         if self.__class__.log_notifications:
-            logger.log("SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s" % (contact.get_name(),
+            logger.log(logger.INFO, "SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s" % (contact.get_name(),
                                                                     self.host.get_name(),
                                                                     self.get_name(), state,
                                                                     command.get_name(), self.output))
@@ -714,7 +714,7 @@ class Service(SchedulingItem):
     # SERVICE EVENT HANDLER: test_host_0;test_ok_0;OK;SOFT;4;eventhandler
     def raise_event_handler_log_entry(self, command):
         if self.__class__.log_event_handlers:
-            logger.log("SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s" % (self.host.get_name(),
+            logger.log(logger.INFO, "SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s" % (self.host.get_name(),
                                                                      self.get_name(),
                                                                      self.state,
                                                                      self.state_type,
@@ -725,41 +725,41 @@ class Service(SchedulingItem):
     # Raise a log entry with FLAPPING START alert like
     # SERVICE FLAPPING ALERT: server;LOAD;STARTED; Service appears to have started flapping (50.6% change >= 50.0% threshold)
     def raise_flapping_start_log_entry(self, change_ratio, threshold):
-        logger.log("SERVICE FLAPPING ALERT: %s;%s;STARTED; Service appears to have started flapping (%.1f%% change >= %.1f%% threshold)" % \
+        logger.log(logger.INFO, "SERVICE FLAPPING ALERT: %s;%s;STARTED; Service appears to have started flapping (%.1f%% change >= %.1f%% threshold)" % \
                       (self.host.get_name(), self.get_name(), change_ratio, threshold))
 
 
     # Raise a log entry with FLAPPING STOP alert like
     # SERVICE FLAPPING ALERT: server;LOAD;STOPPED; Service appears to have stopped flapping (23.0% change < 25.0% threshold)
     def raise_flapping_stop_log_entry(self, change_ratio, threshold):
-        logger.log("SERVICE FLAPPING ALERT: %s;%s;STOPPED; Service appears to have stopped flapping (%.1f%% change < %.1f%% threshold)" % \
+        logger.log(logger.INFO, "SERVICE FLAPPING ALERT: %s;%s;STOPPED; Service appears to have stopped flapping (%.1f%% change < %.1f%% threshold)" % \
                       (self.host.get_name(), self.get_name(), change_ratio, threshold))
 
 
     # If there is no valid time for next check, raise a log entry
     def raise_no_next_check_log_entry(self):
-        logger.log("Warning : I cannot schedule the check for the service '%s' on host '%s' because there is not future valid time" % \
+        logger.log(logger.INFO, "Warning : I cannot schedule the check for the service '%s' on host '%s' because there is not future valid time" % \
                       (self.get_name(), self.host.get_name()))
 
 
     # Raise a log entry when a downtime begins
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;STARTED; Service has entered a period of scheduled downtime
     def raise_enter_downtime_log_entry(self):
-        logger.log("SERVICE DOWNTIME ALERT: %s;%s;STARTED; Service has entered a period of scheduled downtime" % \
+        logger.log(logger.INFO, "SERVICE DOWNTIME ALERT: %s;%s;STARTED; Service has entered a period of scheduled downtime" % \
                       (self.host.get_name(), self.get_name()))
 
 
     # Raise a log entry when a downtime has finished
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;STOPPED; Service has exited from a period of scheduled downtime
     def raise_exit_downtime_log_entry(self):
-        logger.log("SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service has exited from a period of scheduled downtime" % \
+        logger.log(logger.INFO, "SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service has exited from a period of scheduled downtime" % \
                       (self.host.get_name(), self.get_name()))
 
 
     # Raise a log entry when a downtime prematurely ends
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;CANCELLED; Service has entered a period of scheduled downtime
     def raise_cancel_downtime_log_entry(self):
-        logger.log("SERVICE DOWNTIME ALERT: %s;%s;CANCELLED; Scheduled downtime for service has been cancelled." % \
+        logger.log(logger.INFO, "SERVICE DOWNTIME ALERT: %s;%s;CANCELLED; Scheduled downtime for service has been cancelled." % \
                       (self.host.get_name(), self.get_name()))
 
 
@@ -781,7 +781,7 @@ class Service(SchedulingItem):
             if c.output == self.output:
                 need_stalk = False
         if need_stalk:
-            logger.log("Stalking %s : %s" % (self.get_name(), c.output))
+            logger.log(logger.INFO, "Stalking %s : %s" % (self.get_name(), c.output))
 
 
     # Give data for checks's macros

--- a/shinken/objects/timeperiod.py
+++ b/shinken/objects/timeperiod.py
@@ -198,7 +198,7 @@ class Timeperiod(Item):
                 _to = 1
 
             # Now raise the log
-            logger.log('TIMEPERIOD TRANSITION: %s;%d;%d' % (self.get_name(), _from, _to))
+            logger.log(logger.INFO, 'TIMEPERIOD TRANSITION: %s;%d;%d' % (self.get_name(), _from, _to))
         
 
     # clean the get_next_valid_time_from_t cache

--- a/shinken/satellitelink.py
+++ b/shinken/satellitelink.py
@@ -95,7 +95,7 @@ class SatelliteLink(Item):
             # so we must disable it imadiatly after
             socket.setdefaulttimeout(None)
             self.con = None
-            logger.log('Error : in creation connection for %s : %s' % (self.get_name(), str(exp)))
+            logger.log(logger.INFO, 'Error : in creation connection for %s : %s' % (self.get_name(), str(exp)))
     
 
 
@@ -151,7 +151,7 @@ class SatelliteLink(Item):
         # We are dead now. Must raise
         # a brok to say it
         if was_alive:
-            logger.log("Warning : Setting the satellite %s to a dead state." % self.get_name())
+            logger.log(logger.INFO, "Warning : Setting the satellite %s to a dead state." % self.get_name())
             b = self.get_update_status_brok()
             self.broks.append(b)
 
@@ -165,7 +165,7 @@ class SatelliteLink(Item):
         # Don't need to warn again and again if the satellite is already dead
         if self.alive:
             s = "Info : Add failed attempt to %s (%d/%d) %s" % (self.get_name(), self.attempt, self.max_check_attempts, reason)
-            logger.log(s)
+            logger.log(logger.INFO, s)
         # check when we just go HARD (dead)
         if self.attempt == self.max_check_attempts:
             self.set_dead()

--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -290,10 +290,10 @@ class Scheduler:
                 try :
                     f(self)
                 except Exception, exp:
-                    logger.log('Warning : The instance %s raise an exception %s. I disable it and set it to restart it later' % (inst.get_name(), str(exp)))
+                    logger.log(logger.INFO, 'Warning : The instance %s raise an exception %s. I disable it and set it to restart it later' % (inst.get_name(), str(exp)))
                     output = cStringIO.StringIO()
                     traceback.print_exc(file=output)
-                    logger.log("Back trace of this remove : %s" % (output.getvalue()))
+                    logger.log(logger.INFO, "Back trace of this remove : %s" % (output.getvalue()))
                     output.close()
                     self.sched_daemon.modules_manager.set_to_restart(inst)
 
@@ -361,7 +361,7 @@ class Scheduler:
             nb_actions_drops = 0
 
         if nb_checks_drops != 0 or nb_broks_drops != 0 or nb_actions_drops != 0:
-            logger.log("Warning : We drop %d checks, %d broks and %d actions" % (nb_checks_drops, nb_broks_drops, nb_actions_drops))
+            logger.log(logger.INFO, "Warning : We drop %d checks, %d broks and %d actions" % (nb_checks_drops, nb_broks_drops, nb_actions_drops))
 
 
     # For tunning purpose we use caches but we do not want them to explode
@@ -569,9 +569,9 @@ class Scheduler:
 
                 # If we' ve got a problem with the notification, raise a Warning log
                 if timeout:
-                    logger.log("Warning : Contact %s %s notification command '%s ' timed out after %d seconds" % (self.actions[c.id].contact.contact_name, self.actions[c.id].ref.__class__.my_type, self.actions[c.id].command, int(execution_time)))
+                    logger.log(logger.INFO, "Warning : Contact %s %s notification command '%s ' timed out after %d seconds" % (self.actions[c.id].contact.contact_name, self.actions[c.id].ref.__class__.my_type, self.actions[c.id].command, int(execution_time)))
                 elif c.exit_status != 0:
-                    logger.log("Warning : the notification command '%s' raised an error (exit code=%d) : '%s'" % (c.command, c.exit_status, c.output))
+                    logger.log(logger.INFO, "Warning : the notification command '%s' raised an error (exit code=%d) : '%s'" % (c.command, c.exit_status, c.output))
             except KeyError , exp: # bad number for notif, not that bad
                 #print exp
                 pass
@@ -593,13 +593,13 @@ class Scheduler:
             # It just die
             try:
                 if c.status == 'timeout':
-                    logger.log("Warning : %s event handler command '%s ' timed out after %d seconds" % (self.actions[c.id].ref.__class__.my_type.capitalize(), self.actions[c.id].command, int(c.execution_time)))
+                    logger.log(logger.INFO, "Warning : %s event handler command '%s ' timed out after %d seconds" % (self.actions[c.id].ref.__class__.my_type.capitalize(), self.actions[c.id].command, int(c.execution_time)))
                 self.actions[c.id].status = 'zombie'
             # Maybe we got a return of a old even handler, so we can forget it
             except KeyError:
                 pass
         else:
-            logger.log("Error : the received result type in unknown ! %s" % str(c.is_a))
+            logger.log(logger.INFO, "Error : the received result type in unknown ! %s" % str(c.is_a))
 
 
 
@@ -626,7 +626,7 @@ class Scheduler:
         # Get good links tab for looping..
         links = self.get_links_from_type(type)
         if links is None:
-            logger.log('DBG: Type unknown for connection! %s' % type)
+            logger.log(logger.INFO, 'DBG: Type unknown for connection! %s' % type)
             return
 
         # We want only to initiate connections to the passive
@@ -657,7 +657,7 @@ class Scheduler:
             # But the multiprocessing module is not copatible with it!
             # so we must disable it imadiatly after
             socket.setdefaulttimeout(None)
-            logger.log("Warning : Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
 
@@ -666,24 +666,24 @@ class Scheduler:
             pyro.set_timeout(con, 5)
             con.ping()
         except Pyro.errors.ProtocolError, exp:
-            logger.log("Warning : Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
         except Pyro.errors.NamingError, exp:
-            logger.log("Warning : the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
         except KeyError , exp:
-            logger.log("Warning : the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             traceback.print_stack()
             return
         except Pyro.errors.CommunicationError, exp:
-            logger.log("Warning : the %s '%s' got CommunicationError : %s" % (type, links[id]['name'], str(exp)))
+            logger.log(logger.INFO, "Warning : the %s '%s' got CommunicationError : %s" % (type, links[id]['name'], str(exp)))
             links[id]['con'] = None
             return
 
-        logger.log("Info : Connection OK to the %s %s" % (type, links[id]['name']))
+        logger.log(logger.INFO, "Info : Connection OK to the %s %s" % (type, links[id]['name']))
 
 
     # We should push actions to our passives satellites
@@ -703,20 +703,20 @@ class Scheduler:
                     con.push_actions(lst, self.instance_id)
                     self.nb_checks_send += len(lst)
                 except Pyro.errors.ProtocolError, exp:
-                    logger.log("Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except Pyro.errors.NamingError, exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except KeyError , exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     traceback.print_stack()
                     return
                 except Pyro.errors.CommunicationError, exp:
-                    logger.log("Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 #we come back to normal timeout
@@ -740,20 +740,20 @@ class Scheduler:
                     con.push_actions(lst, self.instance_id)
                     self.nb_checks_send += len(lst)
                 except Pyro.errors.ProtocolError, exp:
-                    logger.log("Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except Pyro.errors.NamingError, exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except KeyError , exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     traceback.print_stack()
                     return
                 except Pyro.errors.CommunicationError, exp:
-                    logger.log("Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 #we come back to normal timeout
@@ -780,20 +780,20 @@ class Scheduler:
                     print "Received %d passive results" % nb_received
                     self.waiting_results.extend(results)
                 except Pyro.errors.ProtocolError, exp:
-                    logger.log("Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except Pyro.errors.NamingError, exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except KeyError , exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     traceback.print_stack()
                     return
                 except Pyro.errors.CommunicationError, exp:
-                    logger.log("Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 #we come back to normal timeout
@@ -816,20 +816,20 @@ class Scheduler:
                     print "Received %d passive results" % nb_received
                     self.waiting_results.extend(results)
                 except Pyro.errors.ProtocolError, exp:
-                    logger.log("Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : Connection problem to the %s %s : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except Pyro.errors.NamingError, exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 except KeyError , exp:
-                    logger.log("Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' is not initialized : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     traceback.print_stack()
                     return
                 except Pyro.errors.CommunicationError, exp:
-                    logger.log("Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
+                    logger.log(logger.INFO, "Warning : the %s '%s' got CommunicationError : %s" % (type, p['name'], str(exp)))
                     p['con'] = None
                     return
                 #we come back to normal timeout
@@ -1128,7 +1128,7 @@ class Scheduler:
         # We now have all full broks
         self.has_full_broks = True
 
-        logger.log("[%s] Created initial Broks: %d" % (self.instance_name, len(self.broks)))
+        logger.log(logger.INFO, "[%s] Created initial Broks: %d" % (self.instance_name, len(self.broks)))
 
 
     # Crate a brok with program status info
@@ -1376,7 +1376,7 @@ class Scheduler:
                 worker_names[a.worker] += 1
 
         for w in worker_names:
-            logger.log("Warning : %d actions never came back for the satellite '%s'. I'm reenable them for polling" % (worker_names[w], w))
+            logger.log(logger.INFO, "Warning : %d actions never came back for the satellite '%s'. I'm reenable them for polling" % (worker_names[w], w))
 
 
     # Main function
@@ -1387,9 +1387,9 @@ class Scheduler:
         # Ok, now all is initialized, we can make the inital broks
         self.fill_initial_broks(with_logs=True)
 
-        logger.log("Info : [%s] First scheduling launched" % self.instance_name)
+        logger.log(logger.INFO, "Info : [%s] First scheduling launched" % self.instance_name)
         self.schedule()
-        logger.log("Info : [%s] First scheduling done" % self.instance_name)
+        logger.log(logger.INFO, "Info : [%s] First scheduling done" % self.instance_name)
 
         # Now connect to the passive satellites if needed
         for p_id in self.pollers:


### PR DESCRIPTION
This is a attempt to implement logging levels (as done by standard python logging library) on shinken logging handler.

Until now, log levels was set in logged string, so each module could use a different syntax (WARNING, W, WarNing...).
With this patch, you have to specify the logging level when calling log() function (or directly info(), warning(), ... functions).

If this patch is accepted, I will look over all python file to set correct logging level for each call to the logging function.
