### PR TITLE
Update shinken/modules/graphite_ui.py

### DIFF
--- a/shinken/modules/graphite_ui.py
+++ b/shinken/modules/graphite_ui.py
@@ -179,16 +179,18 @@ class Graphite_Webui(BaseModule):
             # If no values, we can exit now
             if len(couples) == 0:
                 return []
-
-            uri = self.uri + 'render/?width=586&height=308'
-            # Send a bulk of all metrics at once
+    
+            base_uri = self.uri + 'render/?width=586&height=308'
+            # Send a graph with one metric per graph
+            # Graphs with several metrics can be created using templates.
+            # This is a way to correctly manage the checks with an unpredictable number of metrics. Like Disks, interfaces, ...
             for (metric, _) in couples:
                 uri += "&target=%s.%s.%s" % (elt.host.host_name, elt.service_description, metric)
-
-            v = {}
-            v['link'] = self.uri
-            v['img_src'] = uri
-            r.append(v)
+                v = {}
+                v['link'] = self.uri
+                v['img_src'] = uri
+                r.append(v)
+                
             return r
 
         # Oups, bad type?


### PR DESCRIPTION
Send graphs with one metric per graph
Graphs with several metrics can be created using templates.
This is a way to correctly manage the checks with an unpredictable number of metrics. Like Disks, interfaces, ...
