### PR TITLE
Fix : Graphite broker improvements

### DIFF
--- a/shinken/modules/graphite_broker.py
+++ b/shinken/modules/graphite_broker.py
@@ -49,6 +49,7 @@ class Graphite_broker(BaseModule):
         BaseModule.__init__(self, modconf)
         self.host = getattr(modconf, 'host', 'localhost')
         self.port = int(getattr(modconf, 'port', '2003'))
+        self.illegal_char = re.compile(r'[^\w]');
 
 
     #Called by Broker so we can do init stuff
@@ -74,7 +75,7 @@ class Graphite_broker(BaseModule):
             elts = e.split('=', 1)
             if len(elts) != 2:
                 continue
-            name = re.sub('[^a-zA-Z0-9]', '_', elts[0])
+            name = self.illegal_char.sub('_', elts[0])
             raw = elts[1]
             # get the first value of ;
             if ';' in raw:
@@ -89,7 +90,7 @@ class Graphite_broker(BaseModule):
 
             # Try to get the int/float in it :)
             for key,value in name_value.items():
-                m = re.search("(\d*\.*\d*)", value)
+                m = re.search("(\d*\.?\d*)(.*)", value)
                 if m:
                     name_value[key] = m.groups(0)[0]
                 else:
@@ -105,8 +106,8 @@ class Graphite_broker(BaseModule):
         data = b.data
         
         perf_data = data['perf_data']
-        hname = re.sub('[^a-zA-Z0-9]', '_', data['host_name'])
-        desc = re.sub('[^a-zA-Z0-9]', '_', data['service_description'])
+        hname = self.illegal_char.sub('_', data['host_name'])
+        desc = self.illegal_char.sub('_', data['service_description'])
         check_time = int(data['last_chk'])
 
 #        print "Graphite:", hname, desc, check_time, perf_data
@@ -132,7 +133,7 @@ class Graphite_broker(BaseModule):
         data = b.data
         
         perf_data = data['perf_data']
-        hname = re.sub('[^a-zA-Z0-9]', '_', data['host_name'])
+        hname = self.illegal_char.sub('_', data['host_name'])
         check_time = int(data['last_chk'])
 
  #       print "Graphite:", hname, check_time, perf_data

--- a/shinken/modules/graphite_ui.py
+++ b/shinken/modules/graphite_ui.py
@@ -91,7 +91,7 @@ class Graphite_Webui(BaseModule):
             elts = e.split('=', 1)
             if len(elts) != 2:
                 continue
-            name = re.sub('[^a-zA-Z0-9]', '_', elts[0])
+            name = re.sub(r'[^\w]', '_', elts[0])
             raw = elts[1]
             # get the first value of ;
             if ';' in raw:
@@ -105,11 +105,12 @@ class Graphite_Webui(BaseModule):
                 continue
 
             # Try to get the int/float in it :)
-            m = re.search("(\d*\.*\d*)", name_value[name])
-            if m:
-                name_value[name] = m.groups(0)[0]
-            else:
-                continue
+            for key,value in name_value.items():
+                m = re.search("(\d*\.*\d*)(.*)", value)
+                if m:
+                    name_value[key] = m.groups(0)
+                else:
+                    continue
 #            print "graphite : got in the end :", name, value
             for key,value in name_value.items():
                 res.append((key, value))
@@ -126,6 +127,7 @@ class Graphite_Webui(BaseModule):
         t = elt.__class__.my_type
         r = []
 
+
         if t == 'host':
             couples = self.get_metric_and_value(elt.perf_data)
 
@@ -133,12 +135,16 @@ class Graphite_Webui(BaseModule):
             if len(couples) == 0:
                 return []
 
+            # Remove all non alpha numeric character
+            host_name = re.sub(r'[^\w]', '_', elt.host_name)
+
             # Send a bulk of all metrics at once
             for (metric, _) in couples:
                 uri = self.uri + 'render/?width=586&height=308&lineMode=connected'
                 if re.search(r'_warn|_crit', metric):
                     continue
-                uri += "&target=%s.__HOST__.%s" % (elt.host_name, metric+"*")
+                uri += "&target=%s.__HOST__.%s" % (host_name, metric)
+                uri += "&target=%s.__HOST__.%s" % (host_name, metric+"?????")
                 v = {}
                 v['link'] = self.uri
                 v['img_src'] = uri
@@ -152,12 +158,19 @@ class Graphite_Webui(BaseModule):
             if len(couples) == 0:
                 return []
 
+            # Remove all non alpha numeric character
+            desc = re.sub(r'[^\w]', '_', elt.service_description)
+            host_name = re.sub(r'[^\w]', '_', elt.host.host_name)
+            
             # Send a bulk of all metrics at once
-            for (metric, _) in couples:
+            for (metric, value) in couples:
                 uri = self.uri + 'render/?width=586&height=308&lineMode=connected'
                 if re.search(r'_warn|_crit', metric):
                     continue
-                uri += "&target=%s.%s.%s" % (elt.host.host_name, elt.service_description, metric+"*")
+                elif value[1] == '%':
+                    uri += "&yMin=0&yMax=100" 
+                uri += "&target=%s.%s.%s" % (host_name, desc, metric)
+                uri += "&target=%s.%s.%s" % (host_name, desc, metric+"?????")
                 v = {}
                 v['link'] = self.uri
                 v['img_src'] = uri


### PR DESCRIPTION
I do some improvements with graphite broker. Now, it will extract int/float part of all metric in perfdata instead of only the first. So, now if threshold exists but have unexpected character in it, the metric is valid. It is the case with check_oracle_health which have threshold in full nagios format  'Min:Max'. 
Now regex used to avoid illegal character is compiled, a little improvement but still.
I improve way to display metric with their thresholds, so now it will not display metric with the same beginning.
And a final bonus, to scale Y axis when metric is a percentage :D. This assume metric has a unit of measure in it.
