### PR TITLE
SNI support on HTTPS checks

### DIFF
--- a/etc/packs/network/services/http/commands.cfg
+++ b/etc/packs/network/services/http/commands.cfg
@@ -9,12 +9,12 @@ define command {
 # And with SSL
 define command {
        command_name     check_https
-       command_line     $PLUGINSDIR$/check_http -H $HOSTADDRESS$ -S
+       command_line     $PLUGINSDIR$/check_http -H $HOSTADDRESS$ -S --sni
 }
 
 
 # Look at a SSL certificate
 define command {
        command_name	check_https_certificate
-       command_line	$PLUGINSDIR$/check_http -H $HOSTADDRESS$ -C 30
+       command_line	$PLUGINSDIR$/check_http -H $HOSTADDRESS$ -C 30 --sni
 }


### PR DESCRIPTION
This is a very trivial patch that adds SNI support to the HTTPS checks.

This is very useful to actually check the certificates on SNI enabled hosts.
