### PR TITLE
Enh/Fix: typo and move compiled regex into basemodule.py to reusing it into all herited classes.

### DIFF
--- a/shinken/basemodule.py
+++ b/shinken/basemodule.py
@@ -32,6 +32,7 @@ that shinken modules will subclass
 import os
 import signal
 import time
+from re import compile
 from multiprocessing import Queue, Process
 
 
@@ -108,6 +109,7 @@ class BaseModule(object):
         # the queue the module will put its result data
         self.from_q = None
         self.process = None
+        self.illegal_char = compile(r'[^\w]');
         self.init_try = 0
 
 

--- a/shinken/modules/graphite_broker.py
+++ b/shinken/modules/graphite_broker.py
@@ -55,7 +55,6 @@ class Graphite_broker(BaseModule):
         BaseModule.__init__(self, modconf)
         self.host = getattr(modconf, 'host', 'localhost')
         self.port = int(getattr(modconf, 'port', '2003'))
-        self.illegal_char = re.compile(r'[^\w]');
 
 
     # Called by Broker so we can do init stuff

--- a/shinken/modules/graphite_ui.py
+++ b/shinken/modules/graphite_ui.py
@@ -82,7 +82,7 @@ class Graphite_Webui(BaseModule):
 
 
 
-    # Give the link for the PNP UI, with a Name
+    # Give the link for the GRAPHITE UI, with a Name
     def get_external_ui_link(self):
         return {'label' : 'Graphite', 'uri' : self.uri}
 
@@ -101,7 +101,7 @@ class Graphite_Webui(BaseModule):
             elts = e.split('=', 1)
             if len(elts) != 2:
                 continue
-            name = re.sub(r'[^\w]', '_', elts[0])
+            name = self.illegal_char.sub('_', elts[0])
             raw = elts[1]
             # get the first value of ;
             if ';' in raw:
@@ -129,7 +129,7 @@ class Graphite_Webui(BaseModule):
 
 
     # Ask for an host or a service the graph UI that the UI should
-    # give to get the graph image link and PNP page link too.
+    # give to get the graph image link and Graphite page link too.
     def get_graph_uris(self, elt, graphstart, graphend):
         if not elt:
             return []
@@ -151,11 +151,11 @@ class Graphite_Webui(BaseModule):
             values['graphstart'] = graphstart
             values['graphend'] = graphend 
             if t == 'host':
-                values['host'] = re.sub("[^a-zA-Z0-9]", "_",elt.host_name)
+                values['host'] = self.illegal_char.sub("_",elt.host_name)
                 values['service'] = '__HOST__'
             if t == 'service':
-                values['host'] = re.sub("[^a-zA-Z0-9]", "_",elt.host.host_name)
-                values['service'] = re.sub("[^a-zA-Z0-9]", "_",elt.service_description)
+                values['host'] = self.illegal_char.sub("_",elt.host.host_name)
+                values['service'] = self.illegal_char.sub("_",elt.service_description)
             values['uri'] = self.uri
             # Split, we may have several images.
             for img in html.substitute(values).split('\n'):
@@ -180,7 +180,7 @@ class Graphite_Webui(BaseModule):
                 return []
 
             # Remove all non alpha numeric character
-            host_name = re.sub(r'[^\w]', '_', elt.host_name)
+            host_name = self.illegal_char.sub('_', elt.host_name)
 
             # Send a bulk of all metrics at once
             for (metric, _) in couples:
@@ -203,8 +203,8 @@ class Graphite_Webui(BaseModule):
                 return []
 
             # Remove all non alpha numeric character
-            desc = re.sub(r'[^\w]', '_', elt.service_description)
-            host_name = re.sub(r'[^\w]', '_', elt.host.host_name)
+            desc = self.illegal_char.sub('_', elt.service_description)
+            host_name = self.illegal_char.sub('_', elt.host.host_name)
             
             # Send a bulk of all metrics at once
             for (metric, value) in couples:


### PR DESCRIPTION
Hi,

Tiny improvement about graphite broker again. Move the illegal_char into basemodule.py allowing to reuse it through inheritance.

And some typo fixes.
