### PR TITLE
Fix nrpe error handler

### DIFF
--- a/shinken/modules/nrpe_poller.py
+++ b/shinken/modules/nrpe_poller.py
@@ -41,10 +41,12 @@ import shlex
 try :
     import OpenSSL
     SSLWantReadError = OpenSSL.SSL.WantReadError
+    SSLSysCallError = OpenSSL.SSL.SysCallError
     SSLZeroReturnError = OpenSSL.SSL.ZeroReturnError
 except ImportError:
     OpenSSL = None
     SSLWantReadError = None
+    SSLSysCallError = None
     SSLZeroReturnError = None
 
 from Queue import Empty
@@ -256,6 +258,9 @@ class NRPEAsyncClient(asyncore.dispatcher):
             # We can have nothing, it's just that the server
             # do not want to talk to us :(
             except SSLZeroReturnError :
+                buf = ''
+
+            except SSLSysCallError:
                 buf = ''
 
             # Maybe we got nothing from the server (it refuse our ip,


### PR DESCRIPTION
Hello !

We got this error :

error: uncaptured python exception, closing channel <nrpe_poller.NRPEAsyncClient connected at 0x1d70128> (<class 'Op
enSSL.SSL.SysCallError'>:(104, 'Connection reset by peer') [/usr/lib/python2.6/asyncore.py|read|76] [/usr/lib/python
2.6/asyncore.py|handle_read_event|416]
 [/opt/shinken/shinken/shinken/modules/nrpe_poller.py|handle_read|240] [/usr/lib/python2.6/asyncore.py|recv|365])

It seems there is an exception is not caught.

I made this patch to try to get it.

Thanks !
