### PR TITLE
* Fix nrpe error handler

### DIFF
--- a/shinken/modules/nrpe_poller.py
+++ b/shinken/modules/nrpe_poller.py
@@ -43,11 +43,13 @@ try :
     SSLWantReadError = OpenSSL.SSL.WantReadError
     SSLSysCallError = OpenSSL.SSL.SysCallError
     SSLZeroReturnError = OpenSSL.SSL.ZeroReturnError
+    SSLError = OpenSSL.SSL.Error
 except ImportError:
     OpenSSL = None
     SSLWantReadError = None
     SSLSysCallError = None
     SSLZeroReturnError = None
+    SSLError = None
 
 from Queue import Empty
 from shinken.basemodule import BaseModule
@@ -262,6 +264,9 @@ class NRPEAsyncClient(asyncore.dispatcher):
 
             except SSLSysCallError:
                 buf = ''
+
+            except SSLError:
+                bug = ''
 
             # Maybe we got nothing from the server (it refuse our ip,
             # or refuse arguments...)


### PR DESCRIPTION
Catch an other error :

error: uncaptured python exception, closing channel <nrpe_poller.NRPEAsyncClient connected at 0x2fb2710> (<class 'OpenSSL.SSL.Error'>:[('SSL routines', 'SSL3_READ_BYTES', 'ssl handshake failure')] [/usr/lib/python2.6/asyncore.py|read|76] [/usr/lib/python2.6/asyncore.py|handle_read_event|414] [/opt/shinken/shinken/shinken/modules/nrpe_poller.py|handle_read|242] [/usr/lib/python2.6/asyncore.py|recv|365])

Bye !
