### PR TITLE
Fix: way to distinguish systemd from old init system more reliable

### DIFF
--- a/install.d/shinken.conf
+++ b/install.d/shinken.conf
@@ -36,7 +36,7 @@ export BACKUPDIR=${BACKUPDIR:-"/opt/backup"}
 export SKUSER=${SKUSER:-"shinken"}
 export SKGROUP=${SKGROUP:-"shinken"}
 export KEEPDAYSLOG=7
-export INIT=$(cat /proc/1/comm)
+export INIT=$(grep Name /proc/1/status | awk '{print $2}')
 # default retention module (pickle|mongodb) 
 # work only if ENABLEOPTPKGS
 export RETENTIONMODULE=${RETENTIONMODULE:-"pickle"}


### PR DESCRIPTION
Hi,

More accurate and reliable way to find init system across distrib version as "comm" file isn't on "old" distrib like CentOS/RedHat 6.
