### PR TITLE
Use the new folder "graphite" for graphite templates.

### DIFF
--- a/etc/shinken-specific.cfg
+++ b/etc/shinken-specific.cfg
@@ -375,7 +375,7 @@ define module{
     module_type     graphite_webui
     uri             http://YOURSERVERNAME/  ; put the real PNP uri here. YOURSERVERNAME will be changed
                                             ; by the localname of the server
-    templates_path /usr/local/shinken/share/templates/
+    templates_path /usr/local/shinken/share/templates/graphite/
 
 }
 


### PR DESCRIPTION
Existing templates should be prefixed with .graph, and move to that folder.

I think the install process should change this value (and some others), when the install dir is not /usr/local/shinken/
