### PR TITLE
Add the variable 'source' in the the get_graph_uris function. 

### DIFF
--- a/shinken/modules/pnp_ui.py
+++ b/shinken/modules/pnp_ui.py
@@ -89,7 +89,11 @@ class PNP_Webui(BaseModule):
 
     # Ask for an host or a service the graph UI that the UI should
     # give to get the graph image link and PNP page link too.
-    def get_graph_uris(self, elt, graphstart, graphend):
+    # for now, the source variable does nothing. Values passed to this variable can be : 
+    # 'detail' for the element detail page
+    # 'dashboard' for the dashboard widget
+    # you can cutomize the url depending on this value. (or not)
+    def get_graph_uris(self, elt, graphstart, graphend, source = 'detail'):
         if not elt:
             return []
 


### PR DESCRIPTION
This variable basiocally does nothing.
The possible values can be 
'detail' for the element detail page
'dashboard' for the widget graph.

You can customize the url sent using this variable.
