### PR TITLE
use subfolders in the templates graphite

### DIFF
--- a/shinken/modules/graphite_ui.py
+++ b/shinken/modules/graphite_ui.py
@@ -153,7 +153,15 @@ class Graphite_Webui(BaseModule):
         e = e.strftime('%H:%M_%Y%m%d')
 
         # Do we have a template?
-        thefile = self.templates_path + '/' + elt.check_command.get_name().split('!')[0] + '.graph'
+        # Do we have a template for the given source?
+        thesourcefile = os.path.join(self.templates_path ,  source , elt.check_command.get_name().split('!')[0] + '.graph')
+
+        if os.path.isfile(thesourcefile):
+                thefile = thesourcefile
+        else:
+                # If not try to use the one for the parent folder
+                thefile = os.path.join(self.templates_path ,  elt.check_command.get_name().split('!')[0] + '.graph')
+
         if os.path.isfile(thefile):
             template_html = ''
             with open(thefile, 'r') as template_file:


### PR DESCRIPTION
under the graphite template folder, you can create subfolders 
named like the source (detail for the detailed page, 
and dashboard for the widgets)
