### PR TITLE
Change check_mysql's commands and templates to be able to define MySQL credentials per host.

### DIFF
--- a/etc/packs/databases/mysql/commands.cfg
+++ b/etc/packs/databases/mysql/commands.cfg
@@ -9,111 +9,111 @@
 # Distant mysql check
 define command {
        command_name	check_mysql_connection
-       command_line	$PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode connection-time --warning $_HOSTCONNECTIONTIME_WARN$ --critical $_HOSTCONNECTIONTIME_CRIT$
+       command_line	$PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode connection-time --warning $_HOSTCONNECTIONTIME_WARN$ --critical $_HOSTCONNECTIONTIME_CRIT$
 }
 
 define command {
        command_name     check_mysql_querycache_hitrate
-       command_line	$PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode querycache-hitrate --warning $_HOSTQUERYCACHEHITRATE_WARN$ --critical $_HOSTQUERYCACHEHITRATE_CRIT$
+       command_line	$PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode querycache-hitrate --warning $_HOSTQUERYCACHEHITRATE_WARN$ --critical $_HOSTQUERYCACHEHITRATE_CRIT$
 }
 
 define command {
        command_name     check_mysql_uptime
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode uptime
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode uptime
 }
 
 define command {
        command_name     check_mysql_threads_connected
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode threads-connected --warning $_HOSTTHREADSCONNECTED_WARN$ --critical $_HOSTTHREADSCONNECTED_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threads-connected --warning $_HOSTTHREADSCONNECTED_WARN$ --critical $_HOSTTHREADSCONNECTED_CRIT$
 }
 
 define command {
        command_name     check_mysql_qcache_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode qcache-hitrate --warning $_HOSTQCACHEHITRATE_WARN$ --critical $_HOSTQCACHEHITRATE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode qcache-hitrate --warning $_HOSTQCACHEHITRATE_WARN$ --critical $_HOSTQCACHEHITRATE_CRIT$
 }
 
 define command {
        command_name     check_mysql_qcache_lowmem_prunes
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode qcache-lowmem-prunes --warning $_HOSTQCACHELOWMEMPRUNES_WARN$ --critical $_HOSTQCACHELOWMEMPRUNES_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode qcache-lowmem-prunes --warning $_HOSTQCACHELOWMEMPRUNES_WARN$ --critical $_HOSTQCACHELOWMEMPRUNES_CRIT$
 }
 
 define command {
        command_name     check_mysql_keycache_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode keycache-hitrate --warning $_HOSTKEYCACHEHITRATE_WARN$ --critical $_HOSTKEYCACHEHITRATE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode keycache-hitrate --warning $_HOSTKEYCACHEHITRATE_WARN$ --critical $_HOSTKEYCACHEHITRATE_CRIT$
 }
 
 define command {
        command_name     check_mysql_bufferpool_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode bufferpool-hitrate --warning $_HOSTBUFFERPOOLHITRATE_WARN$ --critical $_HOSTBUFFERPOOLHITRATE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode bufferpool-hitrate --warning $_HOSTBUFFERPOOLHITRATE_WARN$ --critical $_HOSTBUFFERPOOLHITRATE_CRIT$
 }
 
 define command {
        command_name     check_mysql_bufferpool_wait_free
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode bufferpool-wait-free --warning $_HOSTBUFFERPOOLWAITFREE_WARN$ --critical $_HOSTBUFFERPOOLWAITFREE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode bufferpool-wait-free --warning $_HOSTBUFFERPOOLWAITFREE_WARN$ --critical $_HOSTBUFFERPOOLWAITFREE_CRIT$
 }
 
 define command {
        command_name     check_mysql_log_waits
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode log-waits --warning $_HOSTLOGWAITS_WARN$ --critical $_HOSTLOGWAITS_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode log-waits --warning $_HOSTLOGWAITS_WARN$ --critical $_HOSTLOGWAITS_CRIT$
 }
 
 define command {
        command_name     check_mysql_tablecache_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode tablecache-hitrate --warning $_HOSTTABLECACHEHITRATE_WARN$ --critical $_HOSTTABLECACHEHITRATE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode tablecache-hitrate --warning $_HOSTTABLECACHEHITRATE_WARN$ --critical $_HOSTTABLECACHEHITRATE_CRIT$
 }
 
 define command {
        command_name     check_mysql_table_lock_contention
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode table-lock-contention --warning $_HOSTTABLELOCKCONTENTION_WARN$ --critical $_HOSTTABLELOCKCONTENTION_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode table-lock-contention --warning $_HOSTTABLELOCKCONTENTION_WARN$ --critical $_HOSTTABLELOCKCONTENTION_CRIT$
 }
 
 define command {
        command_name     check_mysql_index_usage
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode index-usage --warning $_HOSTINDEXUSAGE_WARN$ --critical $_HOSTINDEXUSAGE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode index-usage --warning $_HOSTINDEXUSAGE_WARN$ --critical $_HOSTINDEXUSAGE_CRIT$
 }
 
 define command {
        command_name     check_mysql_tmp_disk_tables
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode tmp-disk-tables --warning $_HOSTTMPDISKTABLES_WARN$ --critical $_HOSTTMPDISKTABLES_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode tmp-disk-tables --warning $_HOSTTMPDISKTABLES_WARN$ --critical $_HOSTTMPDISKTABLES_CRIT$
 }
 
 define command {
        command_name     check_mysql_slow_queries
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode slow-queries --warning $_HOSTSLOWQUERIES_WARN$ --critical $_HOSTSLOWQUERIES_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slow-queries --warning $_HOSTSLOWQUERIES_WARN$ --critical $_HOSTSLOWQUERIES_CRIT$
 }
 
 define command {
        command_name     check_mysql_long_running_procs
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode long-running-procs --warning $_HOSTLONGRUNNINGPROCS_WARN$ --critical $_HOSTLONGRUNNINGPROCS_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode long-running-procs --warning $_HOSTLONGRUNNINGPROCS_WARN$ --critical $_HOSTLONGRUNNINGPROCS_CRIT$
 }
 
 define command {
        command_name     check_mysql_slave_lag
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode slave-lag --warning $_HOSTSLAVELAG_WARN$ --critical $_HOSTSLAVELAG_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-lag --warning $_HOSTSLAVELAG_WARN$ --critical $_HOSTSLAVELAG_CRIT$
 }
 
 define command {
        command_name     check_mysql_slave_io_running
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode slave-io-running
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-io-running
 }
 
 define command {
        command_name     check_mysql_slave_sql_running
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode slave-sql-running
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-sql-running
 }
 
 define command {
        command_name     check_mysql_open_files
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode open-files --warning $_HOSTOPENFILES_WARN$ --critical $_HOSTOPENFILES_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode open-files --warning $_HOSTOPENFILES_WARN$ --critical $_HOSTOPENFILES_CRIT$
 }
 
 define command {
        command_name     check_mysql_cluster_ndb_running
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode cluster-ndb-running
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode cluster-ndb-running
 }
 
 define command {
        command_name     check_mysql_threadcache_hitrate
-       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQL_USER$ --password $_HOSTMYSQL_PASSWORD$ --mode threadcache-hitrate --warning $_HOSTTHREADCACHE_WARN$ --critical $_HOSTTHREADCACHE_CRIT$
+       command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threadcache-hitrate --warning $_HOSTTHREADCACHE_WARN$ --critical $_HOSTTHREADCACHE_CRIT$
 }
 

--- a/etc/packs/databases/mysql/templates.cfg
+++ b/etc/packs/databases/mysql/templates.cfg
@@ -4,8 +4,8 @@ define host{
    use            generic-host
    register       0
 
-   _MYSQL_USER                $MYSQLUSER$
-   _MYSQL_PASSWORD            $MYSQLPASSWORD$
+   _MYSQLUSER                $MYSQLUSER$
+   _MYSQLPASSWORD            $MYSQLPASSWORD$
 
    _CONNECTIONTIME_WARN       1
    _CONNECTIONTIME_CRIT       5


### PR DESCRIPTION
This should not change anything to people already using the resource.cfg macros.
