### PR TITLE
Change invalid check_mongodb.py -c parameter to -C

### DIFF
--- a/etc/packs/databases/mongodb/commands.cfg
+++ b/etc/packs/databases/mongodb/commands.cfg
@@ -53,7 +53,7 @@ define command {
 # Check the index miss ratio
 define command {
        command_name     check_mongodb_index_miss_ratio
-       command_line	$PLUGINSDIR$/check_mongodb.py -H $HOSTADDRESS$ -P 27017 -A index_miss_ration -W .005 -C .01
+       command_line	$PLUGINSDIR$/check_mongodb.py -H $HOSTADDRESS$ -P 27017 -A index_miss_ratio -W .005 -C .01
 }
 
 


### PR DESCRIPTION
With a vanilla 1.2 install, all of the MongoDB monitoring commands were reporting a failed status for me. I noticed this:

```
# /usr/local/shinken/libexec/check_mongodb.py -H localhost -P 27017 -A lock -W 5 -c 10
Usage: check_mongodb.py [options]

check_mongodb.py: error: no such option: -c
```

Looking at the source for check_mongodb.py, the correct parameter appears to be -C. I changed all of the commands in etc/packs/databases/mongodb/commands.cfg to reflect this.
