### PR TITLE
Fix typo for bookmarks.

### DIFF
--- a/shinken/webui/plugins/problems/views/problems.tpl
+++ b/shinken/webui/plugins/problems/views/problems.tpl
@@ -83,7 +83,7 @@
         %if user.is_admin:
         var advfct=1;
         %else:
-        var advcft=0;
+        var advfct=0;
         %end
 
 	%for b in bookmarks:


### PR DESCRIPTION
A bug prevented bookmarks to be used by non admin users. It is fixed by this patch.
