### PR TITLE
Fix : Make scheduler more deterministic

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -535,7 +535,7 @@ class SchedulingItem(Item):
                 if ((self.check_interval * cls.interval_length) % 60) == 0:
                     second = datetime.fromtimestamp(self.next_chk).second
                     if second > 48:
-                        self.next_chk = self.next_chk - (((second % 4) + 1) * 10)
+                        self.next_chk = self.next_chk - ((second % 48) + 48 * random.uniform(0.1,1.0))
             # else: keep the self.next_chk value in the future
         else:
             self.next_chk = int(force_time)


### PR DESCRIPTION
1 - Avoid scheduling at the end of a minute for recurring checks that are multiples of 60.
2 - Use random.uniform instead of random.random to evenly distribute checks.
3 - Use a larger time-window to schedule checks, more efficient formula.

Overall the patch should make Shinken friendly to metric databases that like to receive
data in a recurring period. Issue #626

Eventually some magic should be added to handle cases where all checks for a given check_interval cannot be completed and check scheduling start to be pushed in the past… The code needs to make the next check jump back to the future and generate a log message saying that scheduling is falling behind, too many checks for the given check_interval.
