### PR TITLE
Issue #648 : indexed access to set object

### DIFF
--- a/shinken/modules/livestatus_broker/livestatus_query_metainfo.py
+++ b/shinken/modules/livestatus_broker/livestatus_query_metainfo.py
@@ -472,7 +472,7 @@ class LiveStatusQueryMetainfo(object):
                         # hint : hosts_names
                         if len(hosts) == 1:
                             self.query_hints['target'] = HINT_SERVICES_BY_HOST
-                            self.query_hints['host_name'] = hosts[0]
+                            self.query_hints['host_name'] = hosts.pop()
                         else:
                             self.query_hints['target'] = HINT_SERVICES
                             self.query_hints['host_names_service_descriptions'] = services


### PR DESCRIPTION
Correct bug with indexed access connected to issue #648. Livestatus failed with Nagvis like queries when only one host is implied. Example : 

GET services
Filter: host_name = host1
Filter: service_description = service1
And: 2
Filter: host_name = host1
Filter: service_description = service2
And: 2
Or: 2
