### PR TITLE
dashboard/currently: use a 24H clock format

### DIFF
--- a/shinken/webui/plugins/dashboard/views/currently.tpl
+++ b/shinken/webui/plugins/dashboard/views/currently.tpl
@@ -11,7 +11,7 @@ widget_context = 'dashboard';
 <script type="text/javascript">
 $(function($) {
   var options1 = {
-        format: '%I %M %S %p' // 12-hour
+        format: '%H:%M:%S ' // 24-hour
       }
       $('#clock').jclock(options1);
 


### PR DESCRIPTION
Using am/pm is confusing in a globalized, round-the-clock environment. This
commit makes it 24H based.

A nice addition would be to be able to choose between the 2 clock formats.
