### PR TITLE
* Fix parents list update with hot_host_dependencies module

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -518,6 +518,10 @@ class Host(SchedulingItem):
         # and father list in mine
         self.parent_dependencies.remove(other)
 
+        # Delete parent from parents list
+        if other in self.parents:
+            self.parents.remove(other)
+
     # Add a dependency for action event handler, notification, etc)
     # and add ourself in it's dep list
     def add_host_act_dependency(self, h, status, timeperiod, inherits_parent):
@@ -528,6 +532,9 @@ class Host(SchedulingItem):
 
         # And the parent/child dep lists too
         h.register_son_in_parent_child_dependencies(self)
+
+        # Add parent in parents list
+        self.parents.append(h)
 
     # Register the dependency between 2 service for action (notification etc)
     # but based on a BUSINESS rule, so on fact:


### PR DESCRIPTION
Hello !

I m testing hot_dependecies module for hosts...
It's working but ... Changes are not visible in liveStatus module because parents list attributes of the hosts is not updated ...
I made this patch but I don't know if it's really correct ....
Maybe, LiveStatus must read an other attribute to reply to the "parents" requests ??

Thanks !
