### PR TITLE
Add a  ZeroMQ Broker module called zmq_broker

### DIFF
--- a/shinken/modules/zmq_broker.py
+++ b/shinken/modules/zmq_broker.py
@@ -70,7 +70,7 @@ class SetEncoder(json.JSONEncoder):
 # Msgpack custom encoder, encodes set to lists
 def encode_monitoring_data(obj):
     if isinstance(obj, set):
-        return list(set)
+        return list(obj)
     return obj
 
 # Class for the ZeroMQ broker


### PR DESCRIPTION
Add a ZeroMQ (http://www.zeromq.org/) broker to publish monitoring updates on a ZeroMQ PUB socket. This means that any number of subscribers can listen on the specified endpoint (tcp, inter process or in memory) for monitoring updates.

Serializes the monitoring update before sending them as a ZeroMQ message.
Two serialization methods are available in this initial version:
- JSON
- Msgpack (http://msgpack.org/)

The module takes two options so far:
- pub_endpoint: The endpoint to which ZeroMQ will publish messages. See http://api.zeromq.org/2-1:zmq-tcp, http://api.zeromq.org/2-1:zmq-ipc, http://api.zeromq.org/2-1:zmq-inproc.
- serialize_to: The serialization method to use for the outgoing data. Can be 'json' or 'msgpack'. The default is 'json'.

Initial TODO list:
- Make sure everything is serialized correctly.
- Use ZeroMQ topics to be able to filter by interest.
- AND/OR Provide filters to select what data to send on the topic in the module configuration.
