### PR TITLE
sometimes sched dict do not contains con key

### DIFF
--- a/shinken/satellite.py
+++ b/shinken/satellite.py
@@ -610,7 +610,10 @@ class Satellite(BaseSatellite):
                 continue
 
             try:
-                con = sched['con']
+                try:
+                    con = sched['con']
+                except KeyError:
+                    con = None
                 if con is not None:  # None = not initialized
                     pyro.set_timeout(con, 120)
                     # OK, go for it :)


### PR DESCRIPTION
I just updated to 1.2.4 and I wasn't receiving mail notifications when hosts/services were going UP or DOWN anymore.

I started looking in logs and found the following:

```
File "/usr/local/shinken/src/shinken/shinken/satellite.py", line 613, in get_new_actions
    con = sched['con']
KeyError: 'con'
```

in most services.

I don't know if this used to work < 1.2.4.

But I applied this patch, restarted services and my inbox was filled with notifications.
