### PR TITLE
Fix: invalid variable name causes nrpe_poller crash when recieving SSLEr...

### DIFF
--- a/shinken/modules/nrpe_poller.py
+++ b/shinken/modules/nrpe_poller.py
@@ -254,7 +254,7 @@ class NRPEAsyncClient(asyncore.dispatcher):
                 buf = ''
 
             except SSLError:
-                bug = ''
+                buf = ''
 
             # Maybe we got nothing from the server (it refuse our ip,
             # or refuse arguments...)


### PR DESCRIPTION
This seems to fix #501 for me. Been running for over an hour without any nrpe_poller dying.
