### PR TITLE
add remote_user_variable from wsgi environment, to use set 'remote_us… …  …er_enable 2'

### DIFF
--- a/shinken/webui/plugins/login/login.py
+++ b/shinken/webui/plugins/login/login.py
@@ -86,8 +86,12 @@ def get_root():
     user = app.request.get_cookie("user", secret=app.auth_secret)
     if user:
         redirect("/problems")
-    elif app.remote_user_variable in app.request.headers and app.remote_user_enable == '1':
-        user_name = app.request.headers[app.remote_user_variable]
+    elif app.remote_user_enable > 0:
+        user_name=None
+        if app.remote_user_variable in app.request.headers and app.remote_user_enable == '1':
+            user_name = app.request.headers[app.remote_user_variable]
+        elif app.remote_user_variable in app.request.environ and app.remote_user_enable == '2':
+            user_name = app.request.environ[app.remote_user_variable]
         c = app.datamgr.get_contact(user_name)
         print "Got", c
         if not c:


### PR DESCRIPTION
Hello Jean,
this patch allows to check also the wsgi environ dict for a remote user authentication. This is the place where apache puts this information in the fastcgi and scgi case.

It is activated only by setting remote_user_enable  to 2 in shinken specific.
Please tell me if it does not meet coding styles etc. It's working fine here.

Thanks
  Hermann
