### PR TITLE
Add properties to ESX Host and ESX VM in discovery_runner

### DIFF
--- a/libexec/discovery/vmware_discovery_runner.py
+++ b/libexec/discovery/vmware_discovery_runner.py
@@ -145,11 +145,13 @@ def print_all_links(res, rules):
     r = []
     for host in res:
         host_name = _apply_rules(host, rules)
+        print "%s::esxhostname=%s" % (host_name, host_name)
         print "%s::isesxhost=1" % host_name
         for vm in res[host]:
             # First we apply rules on the names
             vm_name = _apply_rules(vm, rules)
             #v = (('host', host_name),('host', vm_name))
+            print "%s::vmname=%s" % (vm_name, vm_name)
             print "%s::isesxvm=1" % vm_name
             print "%s::esxhost=%s" % (vm_name, host_name)
             #r.append(v)


### PR DESCRIPTION
This can be used to select some VMs/Host by name

I needed this feature. As I coded it for my self, I submit it if someone else  may find it useful.

For exemple :

```
define discoveryrule {
       discoveryrule_name       CustomVMRule
       creation_type            host
       vmname                  ^LAB-
       +use                     lab-vm
}
```

I tried to add "istpl" and "isvmup"

check_esx3.pl doesn't give Template info

And I don't know if "isvmup" useful for discovery (maybe is some circumstances)
