### PR TITLE
add webui option processing for bindAddress and umask

### DIFF
--- a/shinken/modules/webui_broker/webui_broker.py
+++ b/shinken/modules/webui_broker/webui_broker.py
@@ -71,6 +71,12 @@ class Webui_broker(BaseModule, Daemon):
 
         self.plugins = []
 
+        self.serveropts = {}
+        umask = getattr(modconf, 'umask')
+        if umask != None: self.serveropts['umask'] = int(umask)
+        bindAddress = getattr(modconf, 'bindAddress')
+        if bindAddress: self.serveropts['bindAddress'] = bindAddress
+
         self.port = int(getattr(modconf, 'port', '7767'))
         self.http_port = int(getattr(modconf, 'http_port', '7766'))
         self.host = getattr(modconf, 'host', '0.0.0.0')
@@ -210,7 +216,7 @@ class Webui_broker(BaseModule, Daemon):
         # handle of the Queue()? That's just because under Windows, select
         # only manage winsock (so network) file descriptor! What a shame!
         print "Starting WebUI application"
-        srv = run(host=self.host, port=self.port, server=self.http_backend)
+        srv = run(host=self.host, port=self.port, server=self.http_backend,**self.serveropts)
 
         # ^ IMPORTANT ^
         # We are not managing the lock at this


### PR DESCRIPTION
Hello Jean,
surprised by the freeze, but great to hear about 1.4!

Here I have sitting an option processing patch for webui_broker, which makes bindAddress and umask available from shinken specific. As this is not used besides on named pipe connections, so it should not provide harm to any existing installation.

Please tell me if I missed the coding style or something else - I asked about that option processing some time ago on the devel list but meanwhile found out it was simply not implemented.

As always many thanks,
greetings
  Hermann
