### PR TITLE
Upgrade Vsphere SDK Version for cehck_esx3.pl

### DIFF
--- a/install.d/shinken.conf
+++ b/install.d/shinken.conf
@@ -183,7 +183,7 @@ case $CODE in
 esac
 
 #export VSPHERESDKAPTPKGS="libssl-dev perl-doc liburi-perl libxml-libxml-perl libcrypt-ssleay-perl ia32-libs libclass-methodmaker-perl libsoap-lite-perl libsoap-lite-perl libuuid-perl make libnagios-plugin-perl"
-export VSPHERESDKVER="4.0.0-161974"
+export VSPHERESDKVER="5.1.0-780721"
 export VSPHERESDK="http://www.shinken-monitoring.org/archives/VMware-vSphere-SDK-for-Perl-$VSPHERESDKVER.$ARCH.tar.gz"
 export CHECK_ESX3_SCRIPT="http://www.shinken-monitoring.org/archives/check_esx3.pl"
 if [ "$ARCH" = "x86_64" ]


### PR DESCRIPTION
Quite easy.

The two tar.gz must be uploaded to http://www.shinken-monitoring.org/archives/ before merging this.

I have them if you want.

It was tested en Debian and works fine.

check_esx3.pl still works properly

May by, it needs a little more tests to be sure

Why upgrade version ?

I wrote plugins that use vsphere sdk
