### PR TITLE
escape | in plugin output response

### DIFF
--- a/shinken/action.py
+++ b/shinken/action.py
@@ -126,17 +126,19 @@ class __Action(object):
         #print "Get only," , max_plugins_output_length, "bytes"
         # Squeeze all output after max_plugins_output_length
         out = out[:max_plugins_output_length]
+        # manage escaped pipes
+        out = out.replace('\|', '___PROTECT_PIPE___')
         # Then cuts by lines
         elts = out.split('\n')
         # For perf data
         elts_line1 = elts[0].split('|')
         # First line before | is output, and strip it
-        self.output = elts_line1[0].strip()
+        self.output = elts_line1[0].strip().replace('___PROTECT_PIPE___', '|')
         # Init perfdata as void
         self.perf_data = ''
         # After | is perfdata, and strip it
         if len(elts_line1) > 1:
-            self.perf_data = elts_line1[1].strip()
+            self.perf_data = elts_line1[1].strip().replace('___PROTECT_PIPE___', '|')
         # Now manage others lines. Before the | it's long_output
         # And after it's all perf_data, \n join
         long_output = []
@@ -144,14 +146,14 @@ class __Action(object):
         for line in elts[1:]:
             # if already in perfdata, direct append
             if in_perfdata:
-                self.perf_data += ' ' + line.strip()
+                self.perf_data += ' ' + line.strip().replace('___PROTECT_PIPE___', '|')
             else:  # not already in? search for the | part :)
                 elts = line.split('|', 1)
                 # The first part will always be long_output
-                long_output.append(elts[0].strip())
+                long_output.append(elts[0].strip().replace('___PROTECT_PIPE___', '|'))
                 if len(elts) > 1:
                     in_perfdata = True
-                    self.perf_data += ' ' + elts[1].strip()
+                    self.perf_data += ' ' + elts[1].strip().replace('___PROTECT_PIPE___', '|')
         # long_output is all non output and perfline, join with \n
         self.long_output = '\n'.join(long_output)
 


### PR DESCRIPTION
I added management for escaping | character in plugin_output response.
We have a plugin that returns a string into perf_data. But this string can sometimes contain a |. We have tried to not modify shinken by writing perf_data on several lines like

[text]|\n|[perf_data with |]

It works into shinken but livestatus doesn't provide the perf_data at all (empty).
So the only choice we have is to provide a patch for escaping | preceded by \
