### PR TITLE
MongoDB logstore index is suboptimal

### DIFF
--- a/shinken/modules/logstore_mongodb.py
+++ b/shinken/modules/logstore_mongodb.py
@@ -144,7 +144,7 @@ class LiveStatusLogStoreMongoDB(BaseModule):
                 else:
                     self.conn = pymongo.Connection(self.mongodb_uri)
             self.db = self.conn[self.database]
-            self.db[self.collection].ensure_index([('time', pymongo.ASCENDING), ('lineno', pymongo.ASCENDING)], name='time_idx')
+            self.db[self.collection].ensure_index([('host_name', pymongo.ASCENDING), ('time', pymongo.ASCENDING), ('lineno', pymongo.ASCENDING)], name='logs_idx')
             if self.replica_set:
                 pass
                 # This might be a future option prefer_secondary


### PR DESCRIPTION
Hello

The MongoDB logstore module uses a suboptimal indexes, thus the query uses a BasicCursor. Here is a patch creating an index that will make the query use a BtreeCursor exclusively.

I don't know what we should do with the old "time_idx" index. Detect it and remove it, mention it in the documentation, write a script in contrib that removes it, leave it in the database?
