### PR TITLE
Add Oracle Server install support for 5.x and 6 to 6.4

### DIFF
--- a/install.d/shinken.conf
+++ b/install.d/shinken.conf
@@ -80,6 +80,18 @@ case $DIST in
                 HTTPDUSER="apache"
                 HTTPDGROUP="apache"
         ;;
+    EnterpriseEnterpriseServer)
+        export CODE="REDHAT"
+                export WEBSERVER="httpd"
+                HTTPDUSER="apache"
+                HTTPDGROUP="apache"
+        ;;
+    OracleServer)
+        export CODE="REDHAT"
+                export WEBSERVER="httpd"
+                HTTPDUSER="apache"
+                HTTPDGROUP="apache"
+        ;;
     Scientific)
         export CODE="REDHAT"
                 export WEBSERVER="httpd"


### PR DESCRIPTION
Hi,

this patch add install support via install script for Oracle Server distrib 5.x to 6.4

Nero
