### PR TITLE
Fixes to Windows template

### DIFF
--- a/etc/packs/os/windows/templates.cfg
+++ b/etc/packs/os/windows/templates.cfg
@@ -1,53 +1,49 @@
 # Windows template. Came with some custom macros
 
 define host{
-   name			windows
-   use            	generic-host
-   register       	0
+   name                             windows
+   use                              generic-host
+   register                         0
 
    # Macros. If not overload, it will use the etc/shinken/resources.cfg one
-   _DOMAIN   	    	$DOMAIN$
-   _DOMAINUSERSHORT 	$DOMAINUSERSHORT$
-   _DOMAINUSER		$_HOSTDOMAIN$\\$_HOSTDOMAINUSERSHORT$
-   _DOMAINPASSWORD	$DOMAINPASSWORD$
+   _DOMAIN                          $DOMAIN$
+   _DOMAINUSERSHORT                 $DOMAINUSERSHORT$
+   _DOMAINUSER                      $_HOSTDOMAIN$\\$_HOSTDOMAINUSERSHORT$
+   _DOMAINPASSWORD                  $DOMAINPASSWORD$
 
+   _WINDOWS_DISK_WARN               90
+   _WINDOWS_DISK_CRIT               95
+   _WINDOWS_EVENT_LOG_WARN          1
+   _WINDOWS_EVENT_LOG_CRIT          2
+   _WINDOWS_REBOOT_WARN             15min:
+   _WINDOWS_REBOOT_CRIT             5min:
+   _WINDOWS_MEM_WARN                80
+   _WINDOWS_MEM_CRIT                90
+   _WINDOWS_ALL_CPU_WARN            80
+   _WINDOWS_ALL_CPU_CRIT            90
+   _WINDOWS_CPU_WARN                80
+   _WINDOWS_CPU_CRIT                90
+   _WINDOWS_LOAD_WARN               10
+   _WINDOWS_LOAD_CRIT               20
+   _WINDOWS_EXCLUDED_AUTO_SERVICES
+   _WINDOWS_AUTO_SERVICES_WARN      0
+   _WINDOWS_AUTO_SERVICES_CRIT      1
+   _WINDOWS_BIG_PROCESSES_WARN      25
 
-   _WINDOWS_DISK_WARN    90
-   _WINDOWS_DISK_CRIT    95
-   _WINDOWS_EVENT_LOG_WARN    1
-   _WINDOWS_EVENT_LOG_CRIT    2
-   _WINDOWS_REBOOT_WARN    15min:
-   _WINDOWS_REBOOT_CRIT    5min:
-   _WINDOWS_MEM_WARN    80
-   _WINDOWS_MEM_CRIT    90
-   _WINDOWS_ALL_CPU_WARN    80
-   _WINDOWS_ALL_CPU_CRIT    90
-   _WINDOWS_CPU_WARN    80
-   _WINDOWS_CPU_CRIT    90
-   _WINDOWS_LOAD_WARN    10
-   _WINDOWS_LOAD_CRIT    20
-   _WINDOWS_EXCLUDED_AUTO_SERVICES    
-   _WINDOWS_AUTO_SERVICES_WARN    0
-   _WINDOWS_AUTO_SERVICES_CRIT    1
-   _WINDOWS_BIG_PROCESSES_WARN    25
-   
-   
    #Default Network Interface
-   _WINDOWS_NETWORK_INTERFACE      Ethernet
+   _WINDOWS_NETWORK_INTERFACE       Ethernet
 
-           
    # Now some alert level for a windows host
-   _WINDOWS_SHARE_WARN          90
-   _WINDOWS_SHARE_CRIT          95
-
+   _WINDOWS_SHARE_WARN              90
+   _WINDOWS_SHARE_CRIT              95
 
 }
 
 
 define service{
-   name			windows-service
-   use			generic-service
-   register		0
+   name                             windows-service
+   use                              generic-service
+   register                         0
    # By default a windows service will be in the system aggregation
-   aggregation	  	system
+   aggregation                      system
 }


### PR DESCRIPTION
Hello

Here is a trivial fix for the Windows template (missing underscore) and a whitespace reformat.
