### PR TITLE
Allow specifying minimum number of days a certificate has to be valid

### DIFF
--- a/etc/packs/network/services/http/commands.cfg
+++ b/etc/packs/network/services/http/commands.cfg
@@ -16,5 +16,5 @@ define command {
 # Look at a SSL certificate
 define command {
    command_name   check_https_certificate
-   command_line   $PLUGINSDIR$/check_http -H $_HOSTCHECK_HTTPS_DOMAIN_NAME$ -C 30 --sni -p $_HOSTCHECK_HTTPS_PORT$ --authorization=$_HOSTCHECK_HTTPS_AUTH$
+   command_line   $PLUGINSDIR$/check_http -H $_HOSTCHECK_HTTPS_DOMAIN_NAME$ -C $_HOSTCHECK_HTTPS_MINIMUM_DAYS$ --sni -p $_HOSTCHECK_HTTPS_PORT$ --authorization=$_HOSTCHECK_HTTPS_AUTH$
 }

--- a/etc/packs/network/services/http/templates.cfg
+++ b/etc/packs/network/services/http/templates.cfg
@@ -3,10 +3,10 @@ define host{
    use            generic-host
    register       0
 
-   _CHECK_HTTP_DOMAIN_NAME    $HOSTADDRESS$
-   _CHECK_HTTP_PORT           80
-   _CHECK_HTTP_URI            /
-   _CHECK_HTTP_AUTH           #login:password
+   _CHECK_HTTP_DOMAIN_NAME         $HOSTADDRESS$
+   _CHECK_HTTP_PORT                80
+   _CHECK_HTTP_URI                 /
+   _CHECK_HTTP_AUTH                #login:password
 }
 
 
@@ -17,8 +17,9 @@ define host{
    use            generic-host
    register       0
 
-   _CHECK_HTTPS_DOMAIN_NAME   $HOSTADDRESS$
-   _CHECK_HTTPS_PORT          443
-   _CHECK_HTTPS_URI           /
-   _CHECK_HTTPS_AUTH          #login:password
+   _CHECK_HTTPS_DOMAIN_NAME        $HOSTADDRESS$
+   _CHECK_HTTPS_PORT               443
+   _CHECK_HTTPS_URI                /
+   _CHECK_HTTPS_AUTH               #login:password
+   _CHECK_HTTPS_MINIMUM_DAYS       30
 }


### PR DESCRIPTION
Hello

check_https_certificate has a hardcoded value for the minimum number of days a certificate has to be valid.

This adds a new custom value allowing to change it.
