### PR TITLE
add syslog ident otherwise shinken will show up as "python"

### DIFF
--- a/modules/syslog/module.py
+++ b/modules/syslog/module.py
@@ -89,4 +89,5 @@ class Syslog_broker(BaseModule):
     # A log has just arrived, we send it to syslog
     def manage_log_brok(self, b):
         data = b.data
+        syslog.openlog("shinken")
         syslog.syslog(self.priority, data['log'].encode('UTF-8'))


### PR DESCRIPTION
here the small fix... patched it into our live system and its running fine. 
