### PR TITLE
Logging workaround / Added alert to console_logger

### DIFF
--- a/shinken/log.py
+++ b/shinken/log.py
@@ -265,7 +265,7 @@ class __ConsoleLogger:
     def critical(self, msg, *args, **kwargs):
         self._log(Log.CRITICAL, msg, *args, **kwargs)
 
-    def nagios(self, msg, *args, **kwargs):
+    def alert(self, msg, *args, **kwargs):
         kwargs.setdefault('display_level', False)
         self._log(Log.CRITICAL, msg, *args, **kwargs)
 

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -680,7 +680,7 @@ class Host(SchedulingItem):
     # Add a log entry with a HOST ALERT like:
     # HOST ALERT: server;DOWN;HARD;1;I don't know what to say...
     def raise_alert_log_entry(self):
-        console_logger.nagios('HOST ALERT: %s;%s;%s;%d;%s'
+        console_logger.alert('HOST ALERT: %s;%s;%s;%d;%s'
                             % (self.get_name(),
                                self.state, self.state_type,
                                self.attempt, self.output))
@@ -717,7 +717,7 @@ class Host(SchedulingItem):
         else:
             state = self.state
         if self.__class__.log_notifications:
-            console_logger.nagios("HOST NOTIFICATION: %s;%s;%s;%s;%s"
+            console_logger.alert("HOST NOTIFICATION: %s;%s;%s;%s;%s"
                                 % (contact.get_name(), self.get_name(),
                                    state, command.get_name(), self.output))
 
@@ -725,7 +725,7 @@ class Host(SchedulingItem):
     # HOST NOTIFICATION: superadmin;server;UP;notify-by-rss;no output
     def raise_event_handler_log_entry(self, command):
         if self.__class__.log_event_handlers:
-            console_logger.nagios("HOST EVENT HANDLER: %s;%s;%s;%s;%s"
+            console_logger.alert("HOST EVENT HANDLER: %s;%s;%s;%s;%s"
                                 % (self.get_name(),
                                    self.state, self.state_type,
                                    self.attempt, command.get_name()))
@@ -733,7 +733,7 @@ class Host(SchedulingItem):
     # Raise a log entry with FLAPPING START alert like
     # HOST FLAPPING ALERT: server;STARTED; Host appears to have started flapping (50.6% change >= 50.0% threshold)
     def raise_flapping_start_log_entry(self, change_ratio, threshold):
-        console_logger.nagios("HOST FLAPPING ALERT: %s;STARTED; "
+        console_logger.alert("HOST FLAPPING ALERT: %s;STARTED; "
                             "Host appears to have started flapping "
                             "(%.1f%% change >= %.1f%% threshold)"
                             % (self.get_name(), change_ratio, threshold))
@@ -741,7 +741,7 @@ class Host(SchedulingItem):
     # Raise a log entry with FLAPPING STOP alert like
     # HOST FLAPPING ALERT: server;STOPPED; host appears to have stopped flapping (23.0% change < 25.0% threshold)
     def raise_flapping_stop_log_entry(self, change_ratio, threshold):
-        console_logger.nagios("HOST FLAPPING ALERT: %s;STOPPED; "
+        console_logger.alert("HOST FLAPPING ALERT: %s;STOPPED; "
                             "Host appears to have stopped flapping "
                             "(%.1f%% change < %.1f%% threshold)"
                             % (self.get_name(), change_ratio, threshold))
@@ -755,21 +755,21 @@ class Host(SchedulingItem):
     # Raise a log entry when a downtime begins
     # HOST DOWNTIME ALERT: test_host_0;STARTED; Host has entered a period of scheduled downtime
     def raise_enter_downtime_log_entry(self):
-        console_logger.nagios("HOST DOWNTIME ALERT: %s;STARTED; "
+        console_logger.alert("HOST DOWNTIME ALERT: %s;STARTED; "
                             "Host has entered a period of scheduled downtime"
                             % (self.get_name()))
 
     # Raise a log entry when a downtime has finished
     # HOST DOWNTIME ALERT: test_host_0;STOPPED; Host has exited from a period of scheduled downtime
     def raise_exit_downtime_log_entry(self):
-        console_logger.nagios("HOST DOWNTIME ALERT: %s;STOPPED; Host has "
+        console_logger.alert("HOST DOWNTIME ALERT: %s;STOPPED; Host has "
                             "exited from a period of scheduled downtime"
                             % (self.get_name()))
 
     # Raise a log entry when a downtime prematurely ends
     # HOST DOWNTIME ALERT: test_host_0;CANCELLED; Service has entered a period of scheduled downtime
     def raise_cancel_downtime_log_entry(self):
-        console_logger.nagios("HOST DOWNTIME ALERT: %s;CANCELLED; "
+        console_logger.alert("HOST DOWNTIME ALERT: %s;CANCELLED; "
                             "Scheduled downtime for host has been cancelled."
                             % (self.get_name()))
 

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -696,7 +696,7 @@ class Service(SchedulingItem):
     # Add a log entry with a SERVICE ALERT like:
     # SERVICE ALERT: server;Load;UNKNOWN;HARD;1;I don't know what to say...
     def raise_alert_log_entry(self):
-        console_logger.nagios('SERVICE ALERT: %s;%s;%s;%s;%d;%s'
+        console_logger.alert('SERVICE ALERT: %s;%s;%s;%s;%d;%s'
                             % (self.host.get_name(), self.get_name(),
                                self.state, self.state_type,
                                self.attempt, self.output))
@@ -733,7 +733,7 @@ class Service(SchedulingItem):
         else:
             state = self.state
         if self.__class__.log_notifications:
-            console_logger.nagios("SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s"
+            console_logger.alert("SERVICE NOTIFICATION: %s;%s;%s;%s;%s;%s"
                                 % (contact.get_name(),
                                    self.host.get_name(), self.get_name(), state,
                                    command.get_name(), self.output))
@@ -742,7 +742,7 @@ class Service(SchedulingItem):
     # SERVICE EVENT HANDLER: test_host_0;test_ok_0;OK;SOFT;4;eventhandler
     def raise_event_handler_log_entry(self, command):
         if self.__class__.log_event_handlers:
-            console_logger.nagios("SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s"
+            console_logger.alert("SERVICE EVENT HANDLER: %s;%s;%s;%s;%s;%s"
                                 % (self.host.get_name(), self.get_name(),
                                    self.state, self.state_type,
                                    self.attempt, command.get_name()))
@@ -750,7 +750,7 @@ class Service(SchedulingItem):
     # Raise a log entry with FLAPPING START alert like
     # SERVICE FLAPPING ALERT: server;LOAD;STARTED; Service appears to have started flapping (50.6% change >= 50.0% threshold)
     def raise_flapping_start_log_entry(self, change_ratio, threshold):
-        console_logger.nagios("SERVICE FLAPPING ALERT: %s;%s;STARTED; "
+        console_logger.alert("SERVICE FLAPPING ALERT: %s;%s;STARTED; "
                             "Service appears to have started flapping "
                             "(%.1f%% change >= %.1f%% threshold)"
                             % (self.host.get_name(), self.get_name(),
@@ -759,7 +759,7 @@ class Service(SchedulingItem):
     # Raise a log entry with FLAPPING STOP alert like
     # SERVICE FLAPPING ALERT: server;LOAD;STOPPED; Service appears to have stopped flapping (23.0% change < 25.0% threshold)
     def raise_flapping_stop_log_entry(self, change_ratio, threshold):
-        console_logger.nagios("SERVICE FLAPPING ALERT: %s;%s;STOPPED; "
+        console_logger.alert("SERVICE FLAPPING ALERT: %s;%s;STOPPED; "
                             "Service appears to have stopped flapping "
                             "(%.1f%% change < %.1f%% threshold)"
                             % (self.host.get_name(), self.get_name(),
@@ -774,7 +774,7 @@ class Service(SchedulingItem):
     # Raise a log entry when a downtime begins
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;STARTED; Service has entered a period of scheduled downtime
     def raise_enter_downtime_log_entry(self):
-        console_logger.nagios("SERVICE DOWNTIME ALERT: %s;%s;STARTED; "
+        console_logger.alert("SERVICE DOWNTIME ALERT: %s;%s;STARTED; "
                             "Service has entered a period of scheduled "
                             "downtime"
                             % (self.host.get_name(), self.get_name()))
@@ -782,14 +782,14 @@ class Service(SchedulingItem):
     # Raise a log entry when a downtime has finished
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;STOPPED; Service has exited from a period of scheduled downtime
     def raise_exit_downtime_log_entry(self):
-        console_logger.nagios("SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service "
+        console_logger.alert("SERVICE DOWNTIME ALERT: %s;%s;STOPPED; Service "
                             "has exited from a period of scheduled downtime"
                             % (self.host.get_name(), self.get_name()))
 
     # Raise a log entry when a downtime prematurely ends
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;CANCELLED; Service has entered a period of scheduled downtime
     def raise_cancel_downtime_log_entry(self):
-        console_logger.nagios("SERVICE DOWNTIME ALERT: %s;%s;CANCELLED; "
+        console_logger.alert("SERVICE DOWNTIME ALERT: %s;%s;CANCELLED; "
                             "Scheduled downtime for service has been cancelled."
                             % (self.host.get_name(), self.get_name()))
 


### PR DESCRIPTION
No need for logging level INFO in the scheduler anymore. This was a massiv improvement in our case.
