### PR TITLE
Adding support for custom network interfaces on NetworkUsage(s) services

### DIFF
--- a/etc/packs/os/aix/commands.cfg
+++ b/etc/packs/os/aix/commands.cfg
@@ -27,5 +27,5 @@ define command {
 
 define command {
         command_name     check_aix_network_usage
-        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "en\d+" -f -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"
+        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES" -f -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"
 }

--- a/etc/packs/os/aix/templates.cfg
+++ b/etc/packs/os/aix/templates.cfg
@@ -15,6 +15,7 @@ define host{
    _CPU_CRIT                    90
    _MEMORY_WARN                 90,20
    _MEMORY_CRIT                 95,50
+   _NET_IFACES                  en\d+
    _NET_WARN                    90,90,0,0,0,0
    _NET_CRIT                    0,0,0,0,0,0
 }

--- a/etc/packs/os/hpux/commands.cfg
+++ b/etc/packs/os/hpux/commands.cfg
@@ -23,5 +23,5 @@ define command {
 
 define command {
         command_name     check_hpux_network_usage
-        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "lan\d+" -f -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"
+        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES" -f -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"
 }

--- a/etc/packs/os/hpux/templates.cfg
+++ b/etc/packs/os/hpux/templates.cfg
@@ -15,6 +15,7 @@ define host{
    _CPU_CRIT                    3.8,3.8,3.8
    _MEMORY_WARN                 50
    _MEMORY_CRIT                 40
+   _NET_IFACES                  lan\d+
    _NET_WARN                    90,90,0,0,0,0
    _NET_CRIT                    0,0,0,0,0,0
 }

--- a/etc/packs/os/linux/commands.cfg
+++ b/etc/packs/os/linux/commands.cfg
@@ -22,7 +22,7 @@ define command {
 
 define command {
         command_name     check_linux_network_usage
-        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "eth\d+|em\d+" -f -e -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"  -o $_HOSTSNMP_MSG_MAX_SIZE$
+        command_line     $PLUGINSDIR$/check_netint.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES" -f -e -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"  -o $_HOSTSNMP_MSG_MAX_SIZE$
 }
 
 define command {

--- a/etc/packs/os/linux/templates.cfg
+++ b/etc/packs/os/linux/templates.cfg
@@ -19,6 +19,7 @@ define host{
    _CPU_CRIT                    90
    _MEMORY_WARN                 90,20
    _MEMORY_CRIT                 95,50
+   _NET_IFACES                  eth\d+|em\d+
    _NET_WARN                    90,90,0,0,0,0
    _NET_CRIT                    0,0,0,0,0,0
 


### PR DESCRIPTION
While trying to monitor different ifaces on my linux machine (virbr\d+, br0), I have been blocked by the lack of customization in interface names (-n) argument given to check_netint.pl

This commit fixes this issues by using a new _NET_IFACES host macro, defaulting to old values.
