### PR TITLE
Fix: properly change locale

### DIFF
--- a/bin/init.d/shinken
+++ b/bin/init.d/shinken
@@ -64,6 +64,7 @@ test "$ETC" || ETC=$(cd $curpath/../../etc && pwd)
 
 export PATH="${PATH:+$PATH:}/usr/sbin:/bin:/sbin"
 export LANG=en_US.UTF8
+export LC_ALL=en_US.UTF8
 export PYTHONIOENCODING=utf8
 
 # We try to find the LAST possible Python VERSION


### PR DESCRIPTION
Hello

I had a problem with the output of some plugins (check_http, check_dns) due to my locale.

Here are my current settings:

```
LANG=C
LANGUAGE=
LC_CTYPE="fr_FR.UTF-8"
LC_NUMERIC="fr_FR.UTF-8"
LC_TIME="fr_FR.UTF-8"
LC_COLLATE="fr_FR.UTF-8"
LC_MONETARY="fr_FR.UTF-8"
LC_MESSAGES="fr_FR.UTF-8"
LC_PAPER="fr_FR.UTF-8"
LC_NAME="fr_FR.UTF-8"
LC_ADDRESS="fr_FR.UTF-8"
LC_TELEPHONE="fr_FR.UTF-8"
LC_MEASUREMENT="fr_FR.UTF-8"
LC_IDENTIFICATION="fr_FR.UTF-8"
LC_ALL=fr_FR.UTF-8
```

 These plugins honor LC_NUMERIC and thus output floats with a comma separator instead of a dot. This causes graphite (and maybe other tools) to truncate float values to their integer part.

This patch sets all locale variables to `en_US.UTF8` so that plugin output is set to US format.

Example of perfdata with french locale:

```
 time=3,263679s;;;0,000000 size=27885B;;;0 
```

Same command but with US locale (works fine with graphite):

```
time=2.176169s;;;0.000000 size=27886B;;;0 
```
