### PR TITLE
Add a MongoDB index for time based queries

### DIFF
--- a/modules/logstore_mongodb/module.py
+++ b/modules/logstore_mongodb/module.py
@@ -153,6 +153,7 @@ class LiveStatusLogStoreMongoDB(BaseModule):
                     self.conn = pymongo.Connection(self.mongodb_uri)
             self.db = self.conn[self.database]
             self.db[self.collection].ensure_index([('host_name', pymongo.ASCENDING), ('time', pymongo.ASCENDING), ('lineno', pymongo.ASCENDING)], name='logs_idx')
+            self.db[self.collection].ensure_index([('time', pymongo.ASCENDING), ('lineno', pymongo.ASCENDING)], name='time_1_lineno_1')
             if self.replica_set:
                 pass
                 # This might be a future option prefer_secondary


### PR DESCRIPTION
Hello

I realized that for purely time based queries, like Thruk's alerts history, we didn't use an index, so I added one. The performance increase is very good: from more than 1 second per query, I get about 80ms now.

I tested the maximum Thruk's pages I could, analysed resulting queries and they all use an index. I couldn't test with other front-ends.

The best way to do it would be having an exhaustive list of possible livestatus api queries, launch them and make sure they all use an index, but this is a start and I hope that with the two indexes we will cover almost all queries.
