### PR TITLE
Update aws_import_arbiter.py

### DIFF
--- a/shinken/modules/aws_import_arbiter.py
+++ b/shinken/modules/aws_import_arbiter.py
@@ -122,7 +122,7 @@ class AWS_importer_arbiter(BaseModule):
             for (k, v) in n.extra.iteritems():
                 prop = '_EC2_'+k.upper()
                 if isinstance(v, list):
-                    h[prop] = ','.join(v)
+                    h[prop] = ','.join(filter(None,v))
                 elif isinstance(v, dict):
                     h[prop] = ','.join(['%s:%s' % (i, j) for (i,j) in v.iteritems()])
                 else:


### PR DESCRIPTION
Added filtering for NoneType, to avoid the following
[1374137157] Error :   Instance AWS raised an exception sequence item 0: expected string, NoneType found. Log and continue to run
[1374137157] Error :   Back trace of this remove: Traceback (most recent call last):
  File "/opt/shinken/local/lib/python2.7/site-packages/shinken/daemons/arbiterdaemon.py", line 285, in load_config_file
    r = inst.get_objects()
  File "/opt/shinken/local/lib/python2.7/site-packages/shinken/modules/aws_import_arbiter.py", line 126, in get_objects
    h[prop] = ','.join(v)
TypeError: sequence item 0: expected string, NoneType found
