### PR TITLE
Fix mapping for configuration column interval_length in scheduler.

### DIFF
--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -1184,6 +1184,7 @@ class Scheduler:
                 "instance_id": self.instance_id,
                 "instance_name": self.instance_name,
                 "last_alive": now,
+                "interval_length": self.conf.interval_length,
                 "program_start": self.program_start,
                 "pid": os.getpid(),
                 "daemon_mode": 1,


### PR DESCRIPTION
I've start to look in the livestatus module because when I checked the interval_length column in livestatus by Telenet, it given me always 0. The probleme is rather in the shinken core. I've made an issue in the livestatus module repository.
https://github.com/shinken-monitoring/mod-livestatus/issues/1
