### PR TITLE
Added percentage support to Xof: business rules.

### DIFF
--- a/test/etc/business_correlator/services.cfg
+++ b/test/etc/business_correlator/services.cfg
@@ -105,6 +105,14 @@ define service{
 
 
 define service{
+  check_command                  bp_rule!50% of: test_host_0,db1|test_host_0,db2
+  host_name                      test_host_0
+  service_description            Simple_1Of_pct
+  use                            generic-service
+}
+
+
+define service{
   check_command                  bp_rule!(test_host_0,db1|test_host_0,db2) & (test_host_0,web1|test_host_0,web2) & (test_host_0,lvs1|test_host_0,lvs2)
   host_name                      test_host_0
   service_description            ERP
@@ -164,6 +172,13 @@ define service{
   use                            generic-service
 }
 
+define service{
+  check_command                  bp_rule!100%,20%,20% of: test_host_0,A|test_host_0,B|test_host_0,C|test_host_0,D|test_host_0,E
+  host_name                      test_host_0
+  service_description            Complex_ABCOf_pct
+  use                            generic-service
+}
+
 
 
 
@@ -179,6 +194,13 @@ define service{
   check_command                  bp_rule!1 of: test_host_0|test_router_0
   host_name                      test_host_0
   service_description            Simple_1Of_with_host
+  use                            generic-service
+}
+
+define service{
+  check_command                  bp_rule!50% of: test_host_0|test_router_0
+  host_name                      test_host_0
+  service_description            Simple_1Of_with_host_pct
   use                            generic-service
 }
 

--- a/test/test_business_correlator.py
+++ b/test/test_business_correlator.py
@@ -223,6 +223,13 @@ class TestBusinesscorrel(ShinkenTest):
 
     # We will try a simple 1of: bd1 OR/AND db2
     def test_simple_1of_business_correlator(self):
+        self.run_simple_1of_business_correlator(with_pct=False)
+    # We will try a simple 1of: bd1 OR/AND db2
+
+    def test_simple_1of_pct_business_correlator(self):
+        self.run_simple_1of_business_correlator(with_pct=True)
+
+    def run_simple_1of_business_correlator(self, with_pct=False):
         #
         # Config is not correct because of a wrong relative path
         # in the main config file
@@ -245,13 +252,19 @@ class TestBusinesscorrel(ShinkenTest):
         svc_bd2 = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "db2")
         self.assert_(svc_bd2.got_business_rule == False)
         self.assert_(svc_bd2.business_rule is None)
-        svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of")
+        if with_pct == False:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of")
+        else:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_pct")
         self.assert_(svc_cor.got_business_rule == True)
         self.assert_(svc_cor.business_rule is not None)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
-        # Simple 1of: so in fact a triple (1,2,2) (1of and MAX,MAX
-        self.assert_(bp_rule.of_values == (1, 2, 2))
+        # Simple 1of: so in fact a triple ('1','2','2') (1of and MAX,MAX
+        if with_pct == False:
+            self.assert_(bp_rule.of_values == ('1', '2', '2'))
+        else:
+            self.assert_(bp_rule.of_values == ('50%', '2', '2'))
 
         sons = bp_rule.sons
         print "Sons,", sons
@@ -315,6 +328,13 @@ class TestBusinesscorrel(ShinkenTest):
 
     # We will try a simple 1of: test_router_0 OR/AND test_host_0
     def test_simple_1of_business_correlator_with_hosts(self):
+        self.run_simple_1of_business_correlator_with_hosts(with_pct=False)
+
+    # We will try a simple 50%of: test_router_0 OR/AND test_host_0
+    def test_simple_1of_pct_business_correlator_with_hosts(self):
+        self.run_simple_1of_business_correlator_with_hosts(with_pct=True)
+
+    def run_simple_1of_business_correlator_with_hosts(self, with_pct=False):
         #
         # Config is not correct because of a wrong relative path
         # in the main config file
@@ -328,13 +348,19 @@ class TestBusinesscorrel(ShinkenTest):
         router.checks_in_progress = []
         router.act_depend_of = []  # ignore the router
 
-        svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_with_host")
+        if with_pct == False:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_with_host")
+        else:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_with_host_pct")
         self.assert_(svc_cor.got_business_rule == True)
         self.assert_(svc_cor.business_rule is not None)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
-        # Simple 1of: so in fact a triple (1,2,2) (1of and MAX,MAX
-        self.assert_(bp_rule.of_values == (1, 2, 2))
+        # Simple 1of: so in fact a triple ('1','2','2') (1of and MAX,MAX
+        if with_pct == False:
+            self.assert_(bp_rule.of_values == ('1', '2', '2'))
+        else:
+            self.assert_(bp_rule.of_values == ('50%', '2', '2'))
 
         sons = bp_rule.sons
         print "Sons,", sons
@@ -880,6 +906,13 @@ class TestBusinesscorrel(ShinkenTest):
 
     # We will try a simple 1of: bd1 OR/AND db2
     def test_complex_ABCof_business_correlator(self):
+        self.run_complex_ABCof_business_correlator(with_pct=False)
+
+    # We will try a simple 1of: bd1 OR/AND db2
+    def test_complex_ABCof_pct_business_correlator(self):
+        self.run_complex_ABCof_business_correlator(with_pct=True)
+
+    def run_complex_ABCof_business_correlator(self, with_pct=False):
         #
         # Config is not correct because of a wrong relative path
         # in the main config file
@@ -912,12 +945,18 @@ class TestBusinesscorrel(ShinkenTest):
         self.assert_(E.got_business_rule == False)
         self.assert_(E.business_rule is None)
 
-        svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Complex_ABCOf")
+        if with_pct == False:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Complex_ABCOf")
+        else:
+            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Complex_ABCOf_pct")
         self.assert_(svc_cor.got_business_rule == True)
         self.assert_(svc_cor.business_rule is not None)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
-        self.assert_(bp_rule.of_values == (5, 1, 1))
+        if with_pct == False:
+            self.assert_(bp_rule.of_values == ('5', '1', '1'))
+        else:
+            self.assert_(bp_rule.of_values == ('100%', '20%', '20%'))
 
         sons = bp_rule.sons
         print "Sons,", sons
@@ -1003,15 +1042,24 @@ class TestBusinesscorrel(ShinkenTest):
         # 5,2,1 -> OK (we want warning only if we got 2 bad states, so not here)
         self.scheduler_loop(2, [[A, 1, 'WARNING'], [B, 0, 'OK']])
         # 4 of: -> 4,5,5
-        bp_rule.of_values = (4, 5, 5)
+        if with_pct == False:
+            bp_rule.of_values = ('4', '5', '5')
+        else:
+            bp_rule.of_values = ('80%', '100%', '100%')
         bp_rule.is_of_mul = False
         self.assert_(bp_rule.get_state() == 0)
         # 5,1,1
-        bp_rule.of_values = (5, 1, 1)
+        if with_pct == False:
+            bp_rule.of_values = ('5', '1', '1')
+        else:
+            bp_rule.of_values = ('100%', '20%', '20%')
         bp_rule.is_of_mul = True
         self.assert_(bp_rule.get_state() == 1)
         # 5,2,1
-        bp_rule.of_values = (5, 2, 1)
+        if with_pct == False:
+            bp_rule.of_values = ('5', '2', '1')
+        else:
+            bp_rule.of_values = ('100%', '40%', '20%')
         bp_rule.is_of_mul = True
         self.assert_(bp_rule.get_state() == 0)
 
@@ -1020,11 +1068,17 @@ class TestBusinesscorrel(ShinkenTest):
         # 4,1,1 -> Critical (2 states raise the waring, but on raise critical, so worse state is critical)
         self.scheduler_loop(2, [[A, 1, 'WARNING'], [B, 2, 'Crit']])
         # 4 of: -> 4,5,5
-        bp_rule.of_values = (4, 5, 5)
+        if with_pct == False:
+            bp_rule.of_values = ('4', '5', '5')
+        else:
+            bp_rule.of_values = ('80%', '100%', '100%')
         bp_rule.is_of_mul = False
         self.assert_(bp_rule.get_state() == 2)
         # 4,1,1
-        bp_rule.of_values = (4, 1, 1)
+        if with_pct == False:
+            bp_rule.of_values = ('4', '1', '1')
+        else:
+            bp_rule.of_values = ('40%', '20%', '20%')
         bp_rule.is_of_mul = True
         self.assert_(bp_rule.get_state() == 2)
 
@@ -1034,15 +1088,24 @@ class TestBusinesscorrel(ShinkenTest):
         # * 4,1,3 -> warning (the warning rule is raised, but the critical is not)
         self.scheduler_loop(2, [[A, 1, 'WARNING'], [B, 2, 'Crit'], [C, 2, 'Crit']])
         # * 2 of: 2,5,5
-        bp_rule.of_values = (2, 5, 5)
+        if with_pct == False:
+            bp_rule.of_values = ('2', '5', '5')
+        else:
+            bp_rule.of_values = ('40%', '100%', '100%')
         bp_rule.is_of_mul = False
         self.assert_(bp_rule.get_state() == 0)
         # * 4,1,1
-        bp_rule.of_values = (4, 1, 1)
+        if with_pct == False:
+            bp_rule.of_values = ('4', '1', '1')
+        else:
+            bp_rule.of_values = ('80%', '20%', '20%')
         bp_rule.is_of_mul = True
         self.assert_(bp_rule.get_state() == 2)
         # * 4,1,3
-        bp_rule.of_values = (4, 1, 3)
+        if with_pct == False:
+            bp_rule.of_values = ('4', '1', '3')
+        else:
+            bp_rule.of_values = ('80%', '20%', '60%')
         bp_rule.is_of_mul = True
         self.assert_(bp_rule.get_state() == 1)
 
@@ -1200,7 +1263,7 @@ class TestBusinesscorrel(ShinkenTest):
         self.assert_(svc_bd1 in svc_cor.parent_dependencies)
         self.assert_(svc_bd2 in svc_cor.parent_dependencies)
         self.assert_(router in svc_cor.parent_dependencies)
-        
+
 
         sons = bp_rule.sons
         print "Sons,", sons
@@ -1239,8 +1302,8 @@ class TestBusinesscorrel(ShinkenTest):
         self.assert_(son0_1_1_0.sons[0] == svc_lvs1)
         self.assert_(son0_1_1_1.operand == 'service')
         self.assert_(son0_1_1_1.sons[0] == svc_lvs2)
-                
-        
+
+
         # Now state working on the states
         self.scheduler_loop(1, [[svc_bd2, 0, 'OK | value1=1 value2=2'], [svc_bd1, 0, 'OK | rtt=10'],
                                 [svc_lvs1, 0, 'OK'], [svc_lvs2, 0, 'OK'], [router, 0, 'UP'] ])
@@ -1307,7 +1370,7 @@ class TestBusinesscorrel(ShinkenTest):
         self.assert_(router.state == 'DOWN')
         self.assert_(router.state_type == 'HARD')
         self.assert_(router.last_hard_state_id == 1)
-        
+
         # Must be CRITICAL (CRITICAL VERSUS DOWN -> DOWN)
         state = bp_rule.get_state()
         self.assert_(state == 2)
@@ -1317,7 +1380,7 @@ class TestBusinesscorrel(ShinkenTest):
         for p in svc_cor.source_problems:
             print p.get_full_name()
         self.assert_(router in svc_cor.source_problems)
-                                                        
+
 
 
 
@@ -1342,7 +1405,7 @@ class TestBusinesscorrel(ShinkenTest):
         host.act_depend_of = []  # ignore the router
         A = self.sched.hosts.find_by_name("test_darthelmet_A")
         B = self.sched.hosts.find_by_name("test_darthelmet_B")
-        
+
         self.assert_(host.got_business_rule == True)
         self.assert_(host.business_rule is not None)
         bp_rule = host.business_rule

--- a/test/test_business_correlator_expand_expression.py
+++ b/test/test_business_correlator_expand_expression.py
@@ -50,7 +50,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             bp_rule = svc_cor.business_rule
             self.assert_(bp_rule.operand == '&')
             self.assert_(bp_rule.not_value is False)
-            self.assert_(bp_rule.of_values == (2, 2, 2))
+            self.assert_(bp_rule.of_values == ('2', '2', '2'))
 
             srv1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv1")
             srv2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv1")
@@ -71,7 +71,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             bp_rule = svc_cor.business_rule
             self.assert_(bp_rule.operand == 'of:')
             self.assert_(bp_rule.not_value is False)
-            self.assert_(bp_rule.of_values == (1, 2, 2))
+            self.assert_(bp_rule.of_values == ('1', '2', '2'))
 
             srv1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv1")
             srv2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv1")
@@ -92,7 +92,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             bp_rule = svc_cor.business_rule
             self.assert_(bp_rule.operand == '&')
             self.assert_(bp_rule.not_value is False)
-            self.assert_(bp_rule.of_values == (2, 2, 2))
+            self.assert_(bp_rule.of_values == ('2', '2', '2'))
 
             sons = bp_rule.sons
             self.assert_(len(sons) == 2)
@@ -100,7 +100,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             for son in sons:
                 self.assert_(son.operand == '&')
                 self.assert_(son.not_value is False)
-                self.assert_(son.of_values == (2, 2, 2))
+                self.assert_(son.of_values == ('2', '2', '2'))
                 self.assert_(len(son.sons) == 2)
                 self.assert_(son.sons[0].operand == 'service')
                 self.assert_(son.sons[1].operand == 'service')
@@ -123,7 +123,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             bp_rule = svc_cor.business_rule
             self.assert_(bp_rule.operand == '|')
             self.assert_(bp_rule.not_value is False)
-            self.assert_(bp_rule.of_values == (2, 2, 2))
+            self.assert_(bp_rule.of_values == ('2', '2', '2'))
 
             sons = bp_rule.sons
             self.assert_(len(sons) == 2)
@@ -131,7 +131,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             for son in sons:
                 self.assert_(son.operand == '&')
                 self.assert_(son.not_value is False)
-                self.assert_(son.of_values == (2, 2, 2))
+                self.assert_(son.of_values == ('2', '2', '2'))
                 self.assert_(len(son.sons) == 2)
                 self.assert_(son.sons[0].operand == 'service')
                 self.assert_(son.sons[1].operand == 'service')
@@ -154,7 +154,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
             bp_rule = svc_cor.business_rule
             self.assert_(bp_rule.operand == '&')
             self.assert_(bp_rule.not_value is False)
-            self.assert_(bp_rule.of_values == (2, 2, 2))
+            self.assert_(bp_rule.of_values == ('2', '2', '2'))
 
             hst1 = self.sched.hosts.find_by_name("test_host_01")
             hst2 = self.sched.hosts.find_by_name("test_host_02")


### PR DESCRIPTION
This patch adds percentage support to Xof: business rules.

With it, it is possible to write rules that consistently checks that a fixed portion of hosts or services are ok. It is particulary useful combined with hostgroups or regex expansion described in https://github.com/naparuba/shinken/pull/956, as even if the hostgroup or expanded regex content grows, the percentage checked remains the same (no need to manually update the business rule).

Examples:
- A `bp_rule` looking like `25% of: host1,srv1 & host2,srv2 & host3,srv3 & host4,srv4` is exactly equivalent to `1 of: host1,srv1 & host2,srv2 & host3,srv3 & host4,srv4`
- With an hostgroup `hstgrp` containing `host1` and `host2`, a `bp_rule` looking like `50% of: g:hstgrp` is exactly equivalent to `1 of: host1,srv1 & host2,srv2`
- If the same hostgroup grows to contain `host1`, `host2`, `host3` and `host4`, the same `bp_rule` is equivalent to `2 of: host1,srv1 & host2,srv2 & host3,srv3 & host4,srv4`.
