### PR TITLE
Minor enhancement on business output processing.

### DIFF
--- a/test/etc/business_correlator_output/services.cfg
+++ b/test/etc/business_correlator_output/services.cfg
@@ -60,3 +60,11 @@ define service{
   service_description            formatted_bp_rule_output
   use                            generic-service
 }
+
+define service{
+  check_command                  bp_rule!3 of: test_host_01,srv1 & test_host_02,srv2 & test_host_03,srv3 & test_host_04
+  business_rule_output_template	 $STATUS$ $([$STATUS$: $FULL_NAME$] )$
+  host_name                      dummy
+  service_description            formatted_bp_rule_xof_output
+  use                            generic-service
+}

--- a/test/test_business_correlator_output.py
+++ b/test/test_business_correlator_output.py
@@ -112,6 +112,58 @@ class TestBusinesscorrelOutput(ShinkenTest):
         self.assert_(output.find("[OK: test_host_01/srv1]") == -1)
         self.assert_(output.startswith("CRITICAL"))
 
+    def test_bprule_xof_one_critical_output(self):
+        svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "formatted_bp_rule_xof_output")
+        self.assert_(svc_cor.got_business_rule is True)
+        self.assert_(svc_cor.business_rule is not None)
+        self.assert_(svc_cor.business_rule_output_template == "$STATUS$ $([$STATUS$: $FULL_NAME$] )$")
+
+        svc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv1")
+        svc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv2")
+        svc3 = self.sched.services.find_srv_by_name_and_hostname("test_host_03", "srv3")
+        hst4 = self.sched.hosts.find_by_name("test_host_04")
+
+        for i in range(2):
+            self.scheduler_loop(1, [
+                [svc1, 0, 'OK test_host_01/srv1'],
+                [svc2, 0, 'OK test_host_02/srv2'],
+                [svc3, 2, 'CRITICAL test_host_03/srv3'],
+                [hst4, 0, 'UP test_host_04']])
+
+        time.sleep(61)
+        self.sched.manage_internal_checks()
+        self.sched.consume_results()
+
+        # Performs checks
+        self.assert_(svc_cor.business_rule.get_state() == 0)
+        self.assert_(svc_cor.output == "OK [CRITICAL: test_host_03/srv3]")
+
+    def test_bprule_xof_all_ok_output(self):
+        svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "formatted_bp_rule_xof_output")
+        self.assert_(svc_cor.got_business_rule is True)
+        self.assert_(svc_cor.business_rule is not None)
+        self.assert_(svc_cor.business_rule_output_template == "$STATUS$ $([$STATUS$: $FULL_NAME$] )$")
+
+        svc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv1")
+        svc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv2")
+        svc3 = self.sched.services.find_srv_by_name_and_hostname("test_host_03", "srv3")
+        hst4 = self.sched.hosts.find_by_name("test_host_04")
+
+        for i in range(2):
+            self.scheduler_loop(1, [
+                [svc1, 0, 'OK test_host_01/srv1'],
+                [svc2, 0, 'OK test_host_02/srv2'],
+                [svc3, 0, 'OK test_host_03/srv3'],
+                [hst4, 0, 'UP test_host_04']])
+
+        time.sleep(61)
+        self.sched.manage_internal_checks()
+        self.sched.consume_results()
+
+        # Performs checks
+        self.assert_(svc_cor.business_rule.get_state() == 0)
+        self.assert_(svc_cor.output == "OK all checks were successful.")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch adds more details on business rules having an Xof: syntax.

With the previous patch alone, if an `Xof:` business rule had an `OK` state, but one
of its childs had a non `OK` state, the information was not displayed.
This patch adds this information in the output.
