### PR TITLE
Added reversed (negative) Xof business rules.

### DIFF
--- a/test/etc/business_correlator/services.cfg
+++ b/test/etc/business_correlator/services.cfg
@@ -103,11 +103,24 @@ define service{
   use                            generic-service
 }
 
+define service{
+  check_command                  bp_rule!-1 of: test_host_0,db1|test_host_0,db2
+  host_name                      test_host_0
+  service_description            Simple_1Of_neg
+  use                            generic-service
+}
 
 define service{
   check_command                  bp_rule!50% of: test_host_0,db1|test_host_0,db2
   host_name                      test_host_0
   service_description            Simple_1Of_pct
+  use                            generic-service
+}
+
+define service{
+  check_command                  bp_rule!-50% of: test_host_0,db1|test_host_0,db2
+  host_name                      test_host_0
+  service_description            Simple_1Of_pct_neg
   use                            generic-service
 }
 
@@ -197,6 +210,15 @@ define service{
   use                            generic-service
 }
 
+
+define service{
+  check_command                  bp_rule!-1 of: test_host_0|test_router_0
+  host_name                      test_host_0
+  service_description            Simple_1Of_with_host_neg
+  use                            generic-service
+}
+
+
 define service{
   check_command                  bp_rule!50% of: test_host_0|test_router_0
   host_name                      test_host_0
@@ -205,6 +227,12 @@ define service{
 }
 
 
+define service{
+  check_command                  bp_rule!-50% of: test_host_0|test_router_0
+  host_name                      test_host_0
+  service_description            Simple_1Of_with_host_pct_neg
+  use                            generic-service
+}
 
 
 define service{

--- a/test/test_business_correlator.py
+++ b/test/test_business_correlator.py
@@ -223,13 +223,22 @@ class TestBusinesscorrel(ShinkenTest):
 
     # We will try a simple 1of: bd1 OR/AND db2
     def test_simple_1of_business_correlator(self):
-        self.run_simple_1of_business_correlator(with_pct=False)
-    # We will try a simple 1of: bd1 OR/AND db2
+        self.run_simple_1of_business_correlator()
 
+    # We will try a simple -1of: bd1 OR/AND db2
+    def test_simple_1of_neg_business_correlator(self):
+        self.run_simple_1of_business_correlator(with_neg=True)
+
+    # We will try a simple 50%of: bd1 OR/AND db2
     def test_simple_1of_pct_business_correlator(self):
         self.run_simple_1of_business_correlator(with_pct=True)
 
-    def run_simple_1of_business_correlator(self, with_pct=False):
+    # We will try a simple -50%of: bd1 OR/AND db2
+    def test_simple_1of_pct_neg_business_correlator(self):
+        self.run_simple_1of_business_correlator(with_pct=True, with_neg=True)
+
+
+    def run_simple_1of_business_correlator(self, with_pct=False, with_neg=False):
         #
         # Config is not correct because of a wrong relative path
         # in the main config file
@@ -252,19 +261,35 @@ class TestBusinesscorrel(ShinkenTest):
         svc_bd2 = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "db2")
         self.assert_(svc_bd2.got_business_rule == False)
         self.assert_(svc_bd2.business_rule is None)
-        if with_pct == False:
-            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of")
+        if with_pct is True:
+            if with_neg is True:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_pct_neg")
+            else:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_pct")
         else:
-            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_pct")
+            if with_neg is True:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_neg")
+            else:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of")
         self.assert_(svc_cor.got_business_rule == True)
         self.assert_(svc_cor.business_rule is not None)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
         # Simple 1of: so in fact a triple ('1','2','2') (1of and MAX,MAX
-        if with_pct == False:
-            self.assert_(bp_rule.of_values == ('1', '2', '2'))
+        if with_pct is True:
+            if with_neg is True:
+                self.assert_(bp_rule.of_values == ('-50%', '2', '2'))
+            else:
+                self.assert_(bp_rule.of_values == ('50%', '2', '2'))
         else:
-            self.assert_(bp_rule.of_values == ('50%', '2', '2'))
+            if with_neg is True:
+                self.assert_(bp_rule.of_values == ('-1', '2', '2'))
+            else:
+                self.assert_(bp_rule.of_values == ('1', '2', '2'))
 
         sons = bp_rule.sons
         print "Sons,", sons
@@ -328,13 +353,21 @@ class TestBusinesscorrel(ShinkenTest):
 
     # We will try a simple 1of: test_router_0 OR/AND test_host_0
     def test_simple_1of_business_correlator_with_hosts(self):
-        self.run_simple_1of_business_correlator_with_hosts(with_pct=False)
+        self.run_simple_1of_business_correlator_with_hosts()
+
+    # We will try a simple -1of: test_router_0 OR/AND test_host_0
+    def test_simple_1of_neg_business_correlator_with_hosts(self):
+        self.run_simple_1of_business_correlator_with_hosts(with_neg=True)
 
     # We will try a simple 50%of: test_router_0 OR/AND test_host_0
     def test_simple_1of_pct_business_correlator_with_hosts(self):
         self.run_simple_1of_business_correlator_with_hosts(with_pct=True)
 
-    def run_simple_1of_business_correlator_with_hosts(self, with_pct=False):
+    # We will try a simple -50%of: test_router_0 OR/AND test_host_0
+    def test_simple_1of_pct_neg_business_correlator_with_hosts(self):
+        self.run_simple_1of_business_correlator_with_hosts(with_pct=True, with_neg=True)
+
+    def run_simple_1of_business_correlator_with_hosts(self, with_pct=False, with_neg=False):
         #
         # Config is not correct because of a wrong relative path
         # in the main config file
@@ -347,20 +380,35 @@ class TestBusinesscorrel(ShinkenTest):
         router = self.sched.hosts.find_by_name("test_router_0")
         router.checks_in_progress = []
         router.act_depend_of = []  # ignore the router
-
-        if with_pct == False:
-            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_with_host")
+        if with_pct is True:
+            if with_neg is True:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_with_host_pct_neg")
+            else:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_with_host_pct")
         else:
-            svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_1Of_with_host_pct")
+            if with_neg is True:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_with_host_neg")
+            else:
+                svc_cor = self.sched.services.find_srv_by_name_and_hostname(
+                        "test_host_0", "Simple_1Of_with_host")
         self.assert_(svc_cor.got_business_rule == True)
         self.assert_(svc_cor.business_rule is not None)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
         # Simple 1of: so in fact a triple ('1','2','2') (1of and MAX,MAX
-        if with_pct == False:
-            self.assert_(bp_rule.of_values == ('1', '2', '2'))
+        if with_pct is True:
+            if with_neg is True:
+                self.assert_(bp_rule.of_values == ('-50%', '2', '2'))
+            else:
+                self.assert_(bp_rule.of_values == ('50%', '2', '2'))
         else:
-            self.assert_(bp_rule.of_values == ('50%', '2', '2'))
+            if with_neg is True:
+                self.assert_(bp_rule.of_values == ('-1', '2', '2'))
+            else:
+                self.assert_(bp_rule.of_values == ('1', '2', '2'))
 
         sons = bp_rule.sons
         print "Sons,", sons

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -56,6 +56,8 @@ class PropertiesTester(object):
             self.assertIn(name, item.properties,
                           msg='property %r not found in %s' % (name, self.item.my_type))
             if hasattr(item.properties[name], 'default'):
+                if item.properties[name].default != value:
+                    print "%s, %s: %s, %s" % (name, value, item.properties[name].default, value)
                 self.assertEqual(item.properties[name].default, value)
 
     def test_all_props_are_tested(self):
@@ -533,8 +535,8 @@ class TestHost(PropertiesTester, ShinkenTest, unittest.TestCase):
         ('custom_views', ''),
         ('service_overrides', ''),
         ('business_rule_output_template', ''),
-        ('business_rule_smart_notifications', False),
-        ('business_rule_downtime_as_ack', False),
+        ('business_rule_smart_notifications', '0'),
+        ('business_rule_downtime_as_ack', '0'),
         ])
 
     def setUp(self):
@@ -802,8 +804,8 @@ class TestService(PropertiesTester, ShinkenTest, unittest.TestCase):
         ('custom_views', ''),
         ('merge_host_contacts', '0'),
         ('business_rule_output_template', ''),
-        ('business_rule_smart_notifications', False),
-        ('business_rule_downtime_as_ack', False),
+        ('business_rule_smart_notifications', '0'),
+        ('business_rule_downtime_as_ack', '0'),
         ])
 
     def setUp(self):


### PR DESCRIPTION
Standard `Xof:` business rules are used to express idioms such as _at least X services OK_, or _at least X hosts UP_.

Negative business rules allow to use the reversed form to express idioms such as _at most X services WARNING or CRITICAL_ or _at most X hosts DOWN_. In some situations, it allows to write business rules in a more natural way.

Example:

A business rule using an hostgroup composed of `10` hosts in which only `1` is authorized to fail may be written `9 of: g:hostghoup`, or `-1 of: g:hostghoup` which is exactly equivalent. If the hostgroup grows, there is still only one failure authorized in the second form, the first needs to be manually updated.

Also factorised `Xof` elements processing using an inner function. Finally, fixed `test_properties_defaults.py` (forgot to update it in previous pull request).
