### PR TITLE
UNKONWN is also a service state

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1461,7 +1461,7 @@ class SchedulingItem(Item):
         # State has to be set manually, as the service state attribute is only
         # set on a next scheduler step.
         output = service_template_string
-        mapping = {0: "OK", 1: "WARNING", 2: "CRITICAL"}
+        mapping = {0: "OK", 1: "WARNING", 2: "CRITICAL", 3: "UNKNOWN"}
         status = mapping[self.business_rule.get_state()]
         output = re.sub(r"\$STATUS\$", status, output, flags=re.I)
         short_status = self.status_to_short_status(status)


### PR DESCRIPTION
When a service that in part of a business rules is in UNKNOWN state, i get this exception in scheduler

2013-10-14 08:58:01,072 [1381733881] Critical : I got an unrecoverable error. I have to exit
2013-10-14 08:58:01,073 [1381733881] Critical : You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help
2013-10-14 08:58:01,097 [1381733881] Critical : Back trace of it: Traceback (most recent call last):
  File "/opt/shinken-sandbox/shinken/daemons/schedulerdaemon.py", line 405, in main
    self.do_mainloop()
  File "/opt/shinken-sandbox/shinken/daemon.py", line 244, in do_mainloop
    self.do_loop_turn()
  File "/opt/shinken-sandbox/shinken/daemons/schedulerdaemon.py", line 267, in do_loop_turn
    self.sched.run()
  File "/opt/shinken-sandbox/shinken/scheduler.py", line 1546, in run
    f()
  File "/opt/shinken-sandbox/shinken/scheduler.py", line 924, in manage_internal_checks
    c.ref.manage_internal_check(c)
  File "/opt/shinken-sandbox/shinken/objects/schedulingitem.py", line 1494, in manage_internal_check
    c.output = self.get_business_rule_output()
  File "/opt/shinken-sandbox/shinken/objects/schedulingitem.py", line 1453, in get_business_rule_output
    status = mapping[self.business_rule.get_state()]
KeyError: 3
