### PR TITLE
Optimized macro based business rules expansion

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -291,6 +291,8 @@ class Host(SchedulingItem):
         # BUSINESS CORRELATOR PART
         # Say if we are business based rule or not
         'got_business_rule': BoolProp(default=False, fill_brok=['full_status']),
+        # Previously processed business rule (with macro expanded)
+        'processed_business_rule': StringProp(default="", fill_brok=['full_status']),
         # Our Dependency node for the business rule
         'business_rule': StringProp(default=None),
 

--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1394,9 +1394,16 @@ class SchedulingItem(Item):
                 data = self.get_data_for_checks()
                 m = MacroResolver()
                 rule = m.resolve_simple_macros_in_string(rule, data)
+                prev = getattr(self, "processed_business_rule", "")
+
+                if rule == prev:
+                    # Business rule did not change (no macro was modulated)
+                    return
+
                 fact = DependencyNodeFactory(self)
                 node = fact.eval_cor_pattern(rule, hosts, services, running)
                 #print "got node", node
+                self.processed_business_rule = rule
                 self.business_rule = node
 
 

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -260,6 +260,8 @@ class Service(SchedulingItem):
         # BUSINESS CORRELATOR PART
         # Say if we are business based rule or not
         'got_business_rule': BoolProp(default=False, fill_brok=['full_status']),
+        # Previously processed business rule (with macro expanded)
+        'processed_business_rule': StringProp(default="", fill_brok=['full_status']),
         # Our Dependency node for the business rule
         'business_rule': StringProp(default=None),
 

--- a/test/test_business_correlator_expand_expression.py
+++ b/test/test_business_correlator_expand_expression.py
@@ -228,6 +228,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "bprule_no_macro")
         self.assert_(svc_cor.got_business_rule is True)
         self.assert_(svc_cor.business_rule is not None)
+        self.assert_(svc_cor.processed_business_rule == "1 of: test_host_01,srv1 & test_host_02,srv2")
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
         self.assert_(bp_rule.of_values == ('1', '2', '2'))
@@ -265,6 +266,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "bprule_macro_expand")
         self.assert_(svc_cor.got_business_rule is True)
         self.assert_(svc_cor.business_rule is not None)
+        self.assert_(svc_cor.processed_business_rule == "1 of: test_host_01,srv1 & test_host_02,srv2")
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
         self.assert_(bp_rule.of_values == ('1', '2', '2'))
@@ -290,8 +292,9 @@ class TestBusinesscorrelExpand(ShinkenTest):
         # Forces business rule evaluation.
         self.scheduler_loop(2, [[svc_cor, None, None]], do_sleep=True)
 
-        # Business rule should have been re-evaluated (there's a macro)
-        self.assert_(svc_cor.business_rule is not bp_rule)
+        # Business rule should not have been re-evaluated (macro did not change
+        # value)
+        self.assert_(svc_cor.business_rule is bp_rule)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.get_state() == 0)
         self.assert_(svc_cor.last_hard_state_id == 0)
@@ -301,6 +304,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy_modulated", "bprule_macro_modulated")
         self.assert_(svc_cor.got_business_rule is True)
         self.assert_(svc_cor.business_rule is not None)
+        self.assert_(svc_cor.processed_business_rule == "2 of: test_host_01,srv1 & test_host_02,srv2")
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
         self.assert_(bp_rule.of_values == ('2', '2', '2'))
@@ -326,8 +330,9 @@ class TestBusinesscorrelExpand(ShinkenTest):
         # Forces business rule evaluation.
         self.scheduler_loop(2, [[svc_cor, None, None]], do_sleep=True)
 
-        # Business rule should have been re-evaluated (there's a macro)
-        self.assert_(svc_cor.business_rule is not bp_rule)
+        # Business rule should not have been re-evaluated (macro did not change
+        # value)
+        self.assert_(svc_cor.business_rule is bp_rule)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.get_state() == 2)
         self.assert_(svc_cor.last_hard_state_id == 2)
@@ -339,6 +344,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
         # Forces business rule evaluation.
         self.scheduler_loop(2, [[svc_cor, None, None]], do_sleep=True)
 
+        self.assert_(svc_cor.processed_business_rule == "1 of: test_host_01,srv1 & test_host_02,srv2")
         self.assert_(svc_cor.business_rule is not bp_rule)
         bp_rule = svc_cor.business_rule
         self.assert_(bp_rule.operand == 'of:')
@@ -352,6 +358,7 @@ class TestBusinesscorrelExpand(ShinkenTest):
         # Forces business rule evaluation.
         self.scheduler_loop(2, [[svc_cor, None, None]], do_sleep=True)
 
+        # Business rule should have been re-evaluated (macro was modulated)
         self.assert_(svc_cor.business_rule is bp_rule)
         self.assert_(svc_cor.last_hard_state_id == 3)
         self.assert_(svc_cor.output.startswith("Error while re-evaluating business rule"))


### PR DESCRIPTION
Business rules macro expansion has been added in #972.

The initial behavior is to re-evaluate business rule at each service check if it contains a macro, regardless of the resulting expanded business rule changes.

This patch caches the expanded expression string, and compares the re-evaluated string to only re-evaluate business rule objects if the resulting expanded string changed. It occurs if:
- The business rule is parsed for the first time
- The business rule contains a macro that has just been modulated

This way, the initial patch CPU overhead is almost eliminated.
