### PR TITLE
Fix: graphite install on debian need pycairo

### DIFF
--- a/install.d/shinken.conf
+++ b/install.d/shinken.conf
@@ -276,7 +276,7 @@ export CARBON_GITHUB="https://github.com/graphite-project/carbon.git -b 0.9.x"
 export GRAPHITE_WEB_GITHUB="https://github.com/graphite-project/graphite-web.git -b 0.9.x"
 export WHISPER_GITHUB="https://github.com/graphite-project/whisper.git -b 0.9.x"
 export GRAPHITEPKG="txamqp twisted django django-tagging"
-export GRAPHITEPKGDEB="libapache2-mod-wsgi"
+export GRAPHITEPKGDEB="libapache2-mod-wsgi python-cairo"
 
 export NAGVIS="http://downloads.sourceforge.net/project/nagvis/NagVis%201.6/nagvis-1.6.3.tar.gz"
 export NAGVISPREFIX="/usr/local/nagvis"


### PR DESCRIPTION
As say in #1015 pycairo is needed in order to display graph.
