### PR TITLE
Added the ability to disable host/service dependency

### DIFF
--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -122,6 +122,7 @@ class Service(SchedulingItem):
         'time_to_orphanage':       IntegerProp(default="300", fill_brok=['full_status']),
         'merge_host_contacts': 	   BoolProp(default='0', fill_brok=['full_status']),
         'labels':                  ListProp(default='', fill_brok=['full_status']),
+        'depends_host':            BoolProp(default='1', fill_brok=['full_status']),
 
         # BUSINESS CORRELATOR PART
         # Business rules output format template
@@ -465,10 +466,11 @@ class Service(SchedulingItem):
 
     # The service is dependent of his father dep
     # Must be AFTER linkify
+    # TODO: implement "not host dependent" feature.
     def fill_daddy_dependency(self):
         #  Depend of host, all status, is a networkdep
         # and do not have timeperiod, and follow parents dep
-        if self.host is not None:
+        if self.host is not None and self.depends_host:
             # I add the dep in MY list
             self.act_depend_of.append((self.host,
                                         ['d', 'u', 's', 'f'],

--- a/test/etc/dependencies/services.cfg
+++ b/test/etc/dependencies/services.cfg
@@ -88,3 +88,15 @@ define service{
   use                            generic-service
   service_dependencies		 test_host_1,test_parent_svc
 }
+
+#Now test disabled host/service dependencies
+
+define service{
+  check_command                  check_service!ok
+  check_interval                 1
+  host_name                      test_host_0
+  retry_interval                 1
+  service_description            test_ok_0_disbld_hst_dep
+  depends_host                   0
+  use                            generic-service
+}

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -193,7 +193,15 @@ class TestConfig(ShinkenTest):
         # But he should raise a problem (C here) of we ask for its parents
         self.assert_(host_D.do_i_raise_dependency('d', inherit_parents=True) == True)
 
-
+    def test_disabled_host_service_dependencies(self):
+        self.print_header()
+        now = time.time()
+        test_host_0 = self.sched.hosts.find_by_name("test_host_0")
+        test_host_0.checks_in_progress = []
+        test_host_0.act_depend_of = []  # ignore the router
+        test_host_0_test_ok_0_d = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "test_ok_0_disbld_hst_dep")
+        self.assert_(len(test_host_0_test_ok_0_d.act_depend_of) == 0)
+        self.assert_(test_host_0_test_ok_0_d not in [x[0] for x in test_host_0.act_depend_of_me])
 
 
 if __name__ == '__main__':

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -808,6 +808,7 @@ class TestService(PropertiesTester, ShinkenTest, unittest.TestCase):
         ('business_rule_smart_notifications', '0'),
         ('business_rule_downtime_as_ack', '0'),
         ('labels', ''),
+        ('depends_host', '1'),
         ])
 
     def setUp(self):


### PR DESCRIPTION
This allows to define services that do not rely on its host state, as proposed in #1011.

This is mainly useful for volatile services that should always raise alerts, even if host is detected down by shinken.

This is done by setting the `depends_host` attribute to `0` on the service side.
