### PR TITLE
[duplicate_foreach with event_handler]

### DIFF
--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -561,7 +561,7 @@ class Service(SchedulingItem):
                                 safe_key_value = re.sub(r'[' + "`~!$%^&*\"|'<>?,()=" + ']+', '_', key_value[key])
                                 new_s.service_description = self.service_description.replace('$' + key + '$', safe_key_value)
                         # Here is a list of property where we will expand the $KEY$ by the value
-                        _the_expandables = ['check_command', 'aggregation', 'service_dependencies']
+                        _the_expandables = ['check_command', 'aggregation', 'service_dependencies', 'event_handler']
                         for prop in _the_expandables:
                             if hasattr(self, prop):
                                 # here we can replace VALUE, VALUE1, VALUE2,...


### PR DESCRIPTION
Hi,

I need the ability to use the "duplicate_foreach" property with the item event_handler.

see below for an example:

define service{
   service_description  PRC_$KEY$
   use                  linux-nrpe-service
   register             0  
   host_name            linux-nrpe
   check_command        check_nrpe_args!check_procs!$_HOSTPROC_WARN$!$_HOSTPROC_CRIT$!$KEY$
   event_handler       launch_nrpe_args!launch_procs!$KEY$!restart!
   duplicate_foreach    _prc
}

By default the $KEY$ for event_handler is not instanciated.

If we look further in the shinken code, there's a place where this can be done easily (objects/services.py).

 # Here is a list of property where we will expand the $KEY$ by the value
  _the_expandables = ['check_command', 'aggregation', 'service_dependencies']

just add 'event_handler' to the list to do the job.

Hope this helps.
Regards,
