### PR TITLE
FIX: Fixed default template notification options.

### DIFF
--- a/etc/templates.cfg
+++ b/etc/templates.cfg
@@ -117,7 +117,6 @@ define service{
         notifications_enabled           1                       ; Service notifications are enabled
         notification_interval           1440
         notification_period             workhours
-        notification_options            w,u,c,r,f
         event_handler_enabled           0                       ; Service event handler is enabled
         flap_detection_enabled          1                       ; Flap detection is enabled
         failure_prediction_enabled      1                       ; Failure prediction is enabled


### PR DESCRIPTION
Fixed a misconfiguration detected in #1023. Default service template had notification options set twice. With #984, it was interpreted as `['w,u,c,r,f', 'w,u,c,r']`, not `['w','u','c','r']`.
