### PR TITLE
FIX: Fixed a bug on single service override attribute.

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -125,7 +125,7 @@ class Host(SchedulingItem):
         'escalations':          StringProp(default='', fill_brok=['full_status']),
         'maintenance_period':   StringProp(default='', brok_transformation=to_name_if_possible, fill_brok=['full_status']),
         'time_to_orphanage':    IntegerProp(default='300', fill_brok=['full_status']),
-        'service_overrides':    ListProp(default=''),
+        'service_overrides':    ListProp(default='', split_on_coma=False),
         'labels':               ListProp(default='', fill_brok=['full_status']),
 
         # BUSINESS CORRELATOR PART

--- a/shinken/property.py
+++ b/shinken/property.py
@@ -58,7 +58,7 @@ class Property(object):
                  fill_brok=None, conf_send_preparation=None,
                  brok_transformation=None, retention=False,
                  retention_preparation=None, to_send=False,
-                 override=False, managed=True):
+                 override=False, managed=True, split_on_coma=True):
 
         """
         `default`: default value to be used if this property is not set.
@@ -78,6 +78,9 @@ class Property(object):
         `retention`: if set, we will save this property in the retention files
         `retention_preparation`: function, if set, will go this function before
                      being save to the retention data
+        `split_on_coma`: indicates that list property value should not be
+                     splitted on coma delimiter (values conain comas that
+                     we want to keep).
 
         Only for the initial call:
 
@@ -114,6 +117,7 @@ class Property(object):
         self.override = override
         self.managed = managed
         self.unused = False
+        self.split_on_coma = split_on_coma
 
 
 class UnusedProp(Property):
@@ -206,7 +210,7 @@ class ListProp(Property):
 
     #@staticmethod
     def pythonize(self, val):
-        return to_split(val)
+        return to_split(val, self.split_on_coma)
 
 
 class LogLevelProp(StringProp):

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -184,9 +184,11 @@ def to_char(val):
     return val[0]
 
 
-def to_split(val):
+def to_split(val, split_on_coma=True):
     if isinstance(val, list):
         return val
+    if not split_on_coma:
+        return [val]
     val = val.split(',')
     if val == ['']:
         val = []


### PR DESCRIPTION
When a single `service_overrides` attribute is set on a host, it is splitted on comma used as host/service delimiter, and attribute value get false.

This patch adds an additional property attribute named `split_on_coma` that indicates if a single value should be splitted on coma delimiter.

The `service_overrides` attribute is explicitely declared as non splitted.
