### PR TITLE
Added bp_rule child notification options enforcement

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -135,6 +135,9 @@ class Host(SchedulingItem):
         'business_rule_smart_notifications': BoolProp(default='0', fill_brok=['full_status']),
         # Treat downtimes as acknowledgements in smart notifications
         'business_rule_downtime_as_ack': BoolProp(default='0', fill_brok=['full_status']),
+        # Enforces child nodes notification options
+        'business_rule_host_notification_options':    ListProp(default='', fill_brok=['full_status']),
+        'business_rule_service_notification_options': ListProp(default='', fill_brok=['full_status']),
 
         # Business impact value
         'business_impact':      IntegerProp(default='2', fill_brok=['full_status']),

--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1580,6 +1580,13 @@ class SchedulingItem(Item):
                 #print "I register to the element", e.get_name()
                 # all states, every timeperiod, and inherit parents
                 e.add_business_rule_act_dependency(self, ['d', 'u', 's', 'f', 'c', 'w'], None, True)
+                # Enforces child hosts/services notification options if told to
+                # do so (business_rule_(host|service)_notification_options)
+                # set.
+                if e.my_type == "host" and self.business_rule_host_notification_options:
+                    e.notification_options = self.business_rule_host_notification_options
+                if e.my_type == "service" and self.business_rule_service_notification_options:
+                    e.notification_options = self.business_rule_service_notification_options
 
 
     def rebuild_ref(self):

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -130,6 +130,9 @@ class Service(SchedulingItem):
         'business_rule_smart_notifications': BoolProp(default='0', fill_brok=['full_status']),
         # Treat downtimes as acknowledgements in smart notifications
         'business_rule_downtime_as_ack': BoolProp(default='0', fill_brok=['full_status']),
+        # Enforces child nodes notification options
+        'business_rule_host_notification_options':    ListProp(default='', fill_brok=['full_status']),
+        'business_rule_service_notification_options': ListProp(default='', fill_brok=['full_status']),
 
         # Easy Service dep definition
         'service_dependencies':   ListProp(default=''), # TODO: find a way to brok it?

--- a/test/etc/business_correlator_notifications/services.cfg
+++ b/test/etc/business_correlator_notifications/services.cfg
@@ -53,3 +53,12 @@ define service{
   use                                generic-service
   business_rule_smart_notifications  1
 }
+
+define service{
+  check_command                              bp_rule!test_host_01,srv1 & test_host_02
+  host_name                                  dummy
+  service_description                        bp_rule_child_notif
+  use                                        generic-service
+  business_rule_host_notification_options    d,u,r,s
+  business_rule_service_notification_options w,u,c,r,s
+}

--- a/test/test_business_correlator_notifications.py
+++ b/test/test_business_correlator_notifications.py
@@ -57,9 +57,6 @@ class TestBusinesscorrelNotifications(ShinkenTest):
 
         self.assert_(svc_cor.business_rule.get_state() == 2)
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('DOWNTIME') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
 
     def test_bprule_smart_notifications_ack(self):
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "bp_rule_smart_notif")
@@ -79,8 +76,6 @@ class TestBusinesscorrelNotifications(ShinkenTest):
 
         self.assert_(svc_cor.business_rule.get_state() == 2)
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
 
         now = time.time()
         cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_02;srv2;2;1;1;lausser;blablub" % (now)
@@ -91,8 +86,6 @@ class TestBusinesscorrelNotifications(ShinkenTest):
         self.scheduler_loop(1, [[svc_cor, None, None]])
 
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is True)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
 
     def test_bprule_smart_notifications_ack_downtime(self):
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "bp_rule_smart_notif")
@@ -113,9 +106,6 @@ class TestBusinesscorrelNotifications(ShinkenTest):
 
         self.assert_(svc_cor.business_rule.get_state() == 2)
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('DOWNTIME') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
 
         duration = 600
         now = time.time()
@@ -128,9 +118,6 @@ class TestBusinesscorrelNotifications(ShinkenTest):
         self.assert_(svc2.scheduled_downtime_depth > 0)
 
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('DOWNTIME') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
 
         svc_cor.business_rule_downtime_as_ack = True
 
@@ -138,9 +125,18 @@ class TestBusinesscorrelNotifications(ShinkenTest):
         self.scheduler_loop(1, [[svc_cor, None, None]])
 
         self.assert_(svc_cor.notification_is_blocked_by_item('PROBLEM') is True)
-        self.assert_(svc_cor.notification_is_blocked_by_item('ACKNOWLEDGEMENT') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('DOWNTIME') is False)
-        self.assert_(svc_cor.notification_is_blocked_by_item('RECOVERY') is False)
+
+    def test_bprule_child_notification_options(self):
+        svc_cor = self.sched.services.find_srv_by_name_and_hostname("dummy", "bp_rule_child_notif")
+        svc_cor.act_depend_of = []
+        self.assert_(svc_cor.got_business_rule is True)
+        self.assert_(svc_cor.business_rule is not None)
+
+        svc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv1")
+        hst2 = self.sched.hosts.find_by_name("test_host_02")
+
+        self.assert_(svc1.notification_options == ['w', 'u', 'c', 'r', 's'])
+        self.assert_(hst2.notification_options == ['d', 'u', 'r', 's'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -538,6 +538,8 @@ class TestHost(PropertiesTester, ShinkenTest, unittest.TestCase):
         ('business_rule_smart_notifications', '0'),
         ('business_rule_downtime_as_ack', '0'),
         ('labels', ''),
+        ('business_rule_host_notification_options', ''),
+        ('business_rule_service_notification_options', ''),
         ])
 
     def setUp(self):
@@ -808,6 +810,8 @@ class TestService(PropertiesTester, ShinkenTest, unittest.TestCase):
         ('business_rule_smart_notifications', '0'),
         ('business_rule_downtime_as_ack', '0'),
         ('labels', ''),
+        ('business_rule_host_notification_options', ''),
+        ('business_rule_service_notification_options', ''),
         ])
 
     def setUp(self):


### PR DESCRIPTION
This patch adds childs notification options enforcement to business rules.

The main purpose is to allow to easily build consolidated checks through business rules.

It adds two attributes named `business_rule_host_notification_options` and `business_rule_service_notification_options`. If set, all hosts/services composing the business rule will be set the `notification_options` parameter to this value.

**Example**

A cluster is composed of many hosts, all using a template from a pack allowing to check CPU usage. You want to have a consolidated notification giving the list of servers that are eating too much CPU, rather than having dozens of notifications at the same time. You may write the configuration as follows:

```
define host {
    ...
    use                        ...,linux,...
    host_name                  www-001
    hostgroups                 www
    ...
}
define host {
    ...
    use                        ...,linux,...
    host_name                  www-002
    hostgroups                 www
    ...
}
...
define service {
    ...
    service_description                           Consolidated CPU
    check_command                                 bp_rule!g:www,Cpu
    business_rule_service_notification_options    n
    ...
}
```

This will automatically set `notification_options` to `n` on all hosts of `www` hostgroup, and alert only once when at least one host eats too much CPU.
