### PR TITLE
FIX: Fixes filter related fuctions (in business rules processing)

### DIFF
--- a/shinken/util.py
+++ b/shinken/util.py
@@ -674,6 +674,8 @@ def filter_none(name):
 def filter_host_by_name(name):
 
     def inner_filter(host):
+        if host is None:
+            return False
         return host.host_name == name
 
     return inner_filter
@@ -683,6 +685,8 @@ def filter_host_by_regex(regex):
     host_re = re.compile(regex)
 
     def inner_filter(host):
+        if host is None:
+            return False
         return host_re.match(host.host_name) is not None
 
     return inner_filter
@@ -691,6 +695,8 @@ def filter_host_by_regex(regex):
 def filter_host_by_group(group):
 
     def inner_filter(host):
+        if host is None:
+            return False
         return group in [g.hostgroup_name for g in host.hostgroups]
 
     return inner_filter
@@ -699,6 +705,8 @@ def filter_host_by_group(group):
 def filter_service_by_name(name):
 
     def inner_filter(service):
+        if service is None:
+            return False
         return service.service_description == name
 
     return inner_filter
@@ -708,6 +716,8 @@ def filter_service_by_regex_name(regex):
     host_re = re.compile(regex)
 
     def inner_filter(service):
+        if service is None:
+            return False
         return host_re.match(service.service_description) is not None
 
     return inner_filter
@@ -716,6 +726,8 @@ def filter_service_by_regex_name(regex):
 def filter_service_by_host_name(host_name):
 
     def inner_filter(service):
+        if service is None or service.host is None:
+            return False
         return service.host.host_name == host_name
 
     return inner_filter
@@ -725,6 +737,8 @@ def filter_service_by_regex_host_name(regex):
     host_re = re.compile(regex)
 
     def inner_filter(service):
+        if service is None or service.host is None:
+            return False
         return host_re.match(service.host.host_name) is not None
 
     return inner_filter
@@ -733,6 +747,8 @@ def filter_service_by_regex_host_name(regex):
 def filter_service_by_hostgroup_name(group):
 
     def inner_filter(service):
+        if service is None or service.host is None:
+            return False
         return group in [g.hostgroup_name for g in service.host.hostgroups]
 
     return inner_filter
@@ -741,6 +757,8 @@ def filter_service_by_hostgroup_name(group):
 def filter_service_by_servicegroup_name(group):
 
     def inner_filter(service):
+        if service is None:
+            return False
         return group in [g.servicegroup_name for g in service.servicegroups]
 
     return inner_filter
@@ -749,6 +767,8 @@ def filter_service_by_servicegroup_name(group):
 def filter_host_by_bp_rule_label(label):
 
     def inner_filter(host):
+        if host is None:
+            return False
         return label in host.labels
 
     return inner_filter
@@ -757,6 +777,8 @@ def filter_host_by_bp_rule_label(label):
 def filter_service_by_host_bp_rule_label(label):
 
     def inner_filter(service):
+        if service is None or service.host is None:
+            return False
         return label in service.host.labels
 
     return inner_filter
@@ -765,6 +787,8 @@ def filter_service_by_host_bp_rule_label(label):
 def filter_service_by_bp_rule_label(label):
 
     def inner_filter(service):
+        if service is None:
+            return False
         return label in service.labels
 
     return inner_filter


### PR DESCRIPTION
When configuration is incorrect (unknown or wrong host/service parameter), exceptions may be risen by business rules parsing in `filter*` callbacks related functions (passed host/service may be None) before error massage can be displayed.

This fixes this issue by checking that all required parameters are set.
