### PR TITLE
Added CLI option to pass the path to shinken.ini as parameter.

### DIFF
--- a/bin/shinken
+++ b/bin/shinken
@@ -321,8 +321,10 @@ if __name__ == '__main__':
                       dest="api_key", help=("Your API key for uploading the package to the Shinken.io website. If you don't have one, please go to your account page"))
     parser.add_option('-l', '--list', action='store_true',
                       dest="do_list", help=("List available commands"))
+    parser.add_option('-c', '--config', dest="iniconfig", default=DEFAULT_CFG,
+                      help=("Path to your shinken.ini file. Default: %s" % DEFAULT_CFG))
     parser.add_option('--init', action='store_true',
-                      dest="do_init", help=("Initialize/refill your ~/.shinken.ini file"))
+                      dest="do_init", help=("Initialize/refill your shinken.ini file"))
     parser.add_option('-D', action='store_true',
                       dest="do_debug", help=("Enable the debug mode"))
     parser.add_option('-v', action='store_true',
@@ -334,12 +336,15 @@ if __name__ == '__main__':
     if '-D' in sys.argv:
         logger.set_level(logger.DEBUG)
 
+    # Global command parsing
+    opts, args = parser.parse_args()
+
     cfg = None
-    if not os.path.exists(DEFAULT_CFG):
+    if not os.path.exists(opts.iniconfig):
         logger.debug('Missing configuration file!')
     else:
         cfg = ConfigParser.ConfigParser()
-        cfg.read(DEFAULT_CFG)
+        cfg.read(opts.iniconfig)
         for section in cfg.sections():
             if not section in CONFIG:
                 CONFIG[section] = {}
@@ -371,9 +376,6 @@ if __name__ == '__main__':
     # We will remove specific commands from the sys.argv list and keep
     # them for parsing them after
     command_args = hack_sys_argv()
-
-    # Global command parsing
-    opts, args = parser.parse_args()
 
     # If the user explicitely set the proxy, take it!
     if opts.proxy:
@@ -426,8 +428,8 @@ if __name__ == '__main__':
                     modify = True
                 #print new_cfg.items(s)
         if modify:
-            print "Saving the new configuration file", DEFAULT_CFG
-            with open(DEFAULT_CFG, 'wb') as configfile:
+            print "Saving the new configuration file", opts.iniconfig
+            with open(opts.iniconfig, 'wb') as configfile:
                 new_cfg.write(configfile)
         sys.exit(0)
 


### PR DESCRIPTION
Hi,

the default ~/.shinken.ini is fine when calling the script interactively.

But when using with a config management tools (eg. Puppet, Chef) or through a script, the user it is executed as might not be consistent.
It those cases, passing the path to shinken.ini as an argument allows to make sure the proper config is being used and avoid warnings.

This pull request allows it.
The code is a bit of a hack, but since the script itself has a disclaimer saying it's ugly... ;)
