### PR TITLE
add setup.py install --exclude-doc option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,8 @@ class install(_install):
                 'change group for etc/*, var, run and log folders (default: %s)' % DEFAULT_GROUP
             )
         ),
+        ('exclude-doc',  None, "do not install source documentation files"),
     ]
-
 
     def initialize_options(self):
         _install.initialize_options(self)
@@ -136,6 +136,7 @@ class install(_install):
         self.plugins_path = None
         self.owner = None
         self.group = None
+        self.exclude_doc = None
 
 
     def finalize_options(self):
@@ -154,7 +155,21 @@ class install(_install):
             self.owner = DEFAULT_OWNER
         if self.group is None:
             self.group = DEFAULT_GROUP
-
+        if self.exclude_doc is 1:
+            # self.distribution.data_files is list of tuples,
+            # each tuple is a (directory name, [list of files]).
+            # we remove here all files that start with 'doc/'
+            for data_tuple in self.distribution.data_files:
+                data_file_list = data_tuple[1]
+                for data_file in data_file_list:
+                    if data_file.startswith('doc/'):
+                        print "removing doc file {0}".format(data_file)
+                        data_file_list.remove(data_file)
+            # finally cleanup list of data files to remove empty dirs
+            self.distribution.data_files = [(data_dir, data_files) \
+                                               for data_dir, data_files \
+                                               in self.distribution.data_files \
+                                               if len(data_files) != 0 ]
 
 class build_config(Command):
     description = "build the shinken config files"


### PR DESCRIPTION
Add a new option --exclude-doc to install command of setup.py in order
to avoid installing the source files of the documentation (*.rst and
associated binary files).

Beware this is a workaround! The logic has been added in install class
since the documentation files must be considered as data files for
shinken cli and automatic build of documentation at module installation
time.

This option should be relatively helpful to distro packagers though.
