### PR TITLE
Fix PDF doctree

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,10 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+===================================
 Welcome to Shinken's documentation!
 ===================================
-
-Contents:
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Readthedocs will now generate the doctree in PDF format
