### PR TITLE
Name of shinken install file was wrong in Method 3

### DIFF
--- a/doc/source/02_gettingstarted/installations/shinken_installation.rst
+++ b/doc/source/02_gettingstarted/installations/shinken_installation.rst
@@ -79,9 +79,9 @@ Download last stable `Shinken tarball`_ archive (or get the latest `git snapshot
 ::
 
   adduser shinken
-  wget http://www.shinken-monitoring.org/pub/shinken-2.0.tar.gz
-  tar -xvzf shinken-2.0.tar.gz
-  cd shinken-2.0
+  wget http://www.shinken-monitoring.org/pub/shinken-2.0-RC.tar.gz
+  tar -xvzf shinken-2.0-RC.tar.gz
+  cd shinken-2.0-RC
   python setup.py install
 
 


### PR DESCRIPTION
Under Method 3, the file in the shinken site pub directory should be shinken-2.0-RC.tar.gz instead of shinken-2.0.tar.gz. Likewise, extracting the tar should reflect this change.
