### PR TITLE
Fix missing modules folder in the pip installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 recursive-include shinken *.*
 recursive-include shinken/webui *.*
-recursive-include etc *.*
+recursive-include etc *
 recursive-include windows .bat .reg
 recursive-include bin *.* *-* shinken
 recursive-include libexec *.*


### PR DESCRIPTION
When installing via "pip install shinken" on CentOS, and then trying to start with "service shinken start", you get an error due to missing /etc/shinken/modules folder:

```
[root@build64-el6 ~]# service shinken start
Starting scheduler:
Starting poller:                                           [  OK  ]
Starting reactionner:                                      [  OK  ]
Starting broker:                                           [  OK  ]
Starting receiver:                                         [  OK  ]
Starting arbiter:                                          [  OK  ]
FAILED: ***> One or more problems was encountered while processing the config files... (full output is in /tmp/bad_start_for_arbiter)
[root@build64-el6 ~]#                                      [FAILED]
```

This is due to the MANIFESTS.in only including files with extensions (_._), or having being written by a Windows bobby (_._ is known to match even files without extensions for some Windows commands hehe)

This patch fixes the problem by changing "_._" to "*" so the folder is correctly included. Actually since distutils sdist does not really support including folders only - it will include etc/modules/__for_git - but that's fine it makes it work at least! The other way around would be to create a file with an extension within modules that gets included thus implicitly including the modules folder.

I'll leave it with you!
Will do another PR soon to fix the init.d script unless someone else already did, since it throws the OK and FAIL on the wrong line as you can see above!
