### PR TITLE
Avoids collisions of Downtime.id between schedulers

### DIFF
--- a/shinken/downtime.py
+++ b/shinken/downtime.py
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
+import datetime, time
 from shinken.comment import Comment
 from shinken.property import BoolProp, IntegerProp, StringProp
 from shinken.brok import Brok
@@ -68,8 +68,9 @@ class Downtime:
     }
 
     def __init__(self, ref, start_time, end_time, fixed, trigger_id, duration, author, comment):
-        self.id = self.__class__.id
-        self.__class__.id += 1
+        now = datetime.datetime.now()
+        self.id = int(time.mktime(now.timetuple())*1e6 + now.microsecond)
+        self.__class__.id = self.id + 1
         self.ref = ref  # pointer to srv or host we are apply
         self.activate_me = []  # The other downtimes i need to activate
         self.entry_time = int(time.time())


### PR DESCRIPTION
Each scheduler starts Downtime.id from 1 and increments it by 1 at each
downtime creation. So, when running multiple schedulers, multiple
downtimes will have the same ID. Commands like DEL_SVC_DOWNTIME are
broadcasted to all schedulers for execution. When deleting a downtime,
if the ID is not unique, all the downtimes that have the same ID will be
deleted. By using microseconds since 1970-01-01 as an ID, the probability
of collision is reduced.

We used this patch for the last few days, it works fine for us. It has been tested with Thruk and our internal software that manages downtimes.
