### PR TITLE
Do not set master actions to inpoller

### DIFF
--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -615,10 +615,10 @@ class Scheduler:
 
                 # And now look for can launch or not :)
                 if a.status == 'scheduled' and a.is_launchable(now):
-                    a.status = 'inpoller'
-                    a.worker = worker_name
                     if not is_master:
                         # This is for child notifications and eventhandlers
+                        a.status = 'inpoller'
+                        a.worker = worker_name
                         new_a = a.copy_shell()
                         res.append(new_a)
         return res


### PR DESCRIPTION
Master notifications do not get sent to the reactionners but if they are set to inpoller the schedulers believe they have been. When they hit their timeout they the schedulers think the reactionners have not responded and throw a warning.
