### PR TITLE
Prevent duplicate members in contactgroup

### DIFF
--- a/shinken/misc/regenerator.py
+++ b/shinken/misc/regenerator.py
@@ -369,6 +369,7 @@ class Regenerator(object):
             # contacts into it
             if cg:
                 cg.members.extend(inpcg.members)
+                cg.members = list(set(cg.members))
             else:  # else take the new one
                 self.contactgroups[inpcg.id] = inpcg
         # We can declare contactgroups done


### PR DESCRIPTION
With respect to : https://github.com/naparuba/shinken/issues/993

The livestatus module ( and possibly others ) uses the Regenerator class and merging contactgroup members from multiple schedulers which was resulting in duplicate members.
