### PR TITLE
fix doc contact

### DIFF
--- a/doc/source/08_configobjects/contact.rst
+++ b/doc/source/08_configobjects/contact.rst
@@ -57,8 +57,8 @@ Example Definition
       host_notification_period        24x7
       service_notification_options    w,u,c,r
       host_notification_options       d,u,r
-      service_notification_commands   notify-by-email
-      host_notification_commands      host-notify-by-email
+      service_notification_commands   notify-service-by-email
+      host_notification_commands      notify-host-by-email
       email                           jdoe@localhost.localdomain
       pager                           555-5555@pagergateway.localhost.localdomain
       address1                        xxxxx.xyyy@icq.com


### PR DESCRIPTION
The command's name is not "notify-by-mail anymore. In the config folder /etc/shinken/commands/ I have notify-host-by-email and notify-service-by-email
