### PR TITLE
Added LogEvent, a class to parse monitoring logs

### DIFF
--- a/shinken/misc/logevent.py
+++ b/shinken/misc/logevent.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014 - Savoir-Faire Linux inc.
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+event_type_pattern = re.compile('^\[[0-9]{10}] (?:HOST|SERVICE) (ALERT|NOTIFICATION|FLAPPING|DOWNTIME|EVENT)(?: ALERT)?:.*')
+event_types = {
+    'NOTIFICATION': {  # ex: "[1402515279] SERVICE NOTIFICATION: admin;localhost;check-ssh;CRITICAL;notify-service-by-email;Connection refused"
+        'pattern': '\[([0-9]{10})\] (HOST|SERVICE) (NOTIFICATION): ([^\;]*);([^\;]*);(?:([^\;]*);)?([^\;]*);([^\;]*);(ACKNOWLEDGEMENT)?.*',
+        'properties': [
+            'time',
+            'notification_type',  # 'SERVICE' (or could be 'HOST')
+            'event_type',  # 'NOTIFICATION'
+            'contact',  # 'admin'
+            'hostname',  # 'localhost'
+            'service_desc',  # 'check-ssh' (or could be None)
+            'state',  # 'CRITICAL'
+            'notification_method',  # 'notify-service-by-email'
+            'acknownledgement',  # None or 'ACKNOWLEDGEMENT'
+        ]
+    },
+    'ALERT': {  # ex: "[1329144231] SERVICE ALERT: dfw01-is02-006;cpu load maui;WARNING;HARD;4;WARNING - load average: 5.04, 4.67, 5.04"
+        'pattern': '^\[([0-9]{10})] (HOST|SERVICE) (ALERT): ([^\;]*);(?:([^\;]*);)?([^\;]*);([^\;]*);([^\;]*);([^\;]*)',
+        'properties': [
+            'time',
+            'alert_type',  # 'SERVICE' (or could be 'HOST')
+            'event_type',  # 'ALERT'
+            'hostname',  # 'localhost'
+            'service_desc',  # 'cpu load maui' (or could be None)
+            'state',  # 'WARNING'
+            'state_type',  # 'HARD'
+            'attempts',  # '4'
+            'output',  # 'WARNING - load average: 5.04, 4.67, 5.04'
+        ]
+    },
+    'DOWNTIME': {  # ex: "[1279250211] HOST DOWNTIME ALERT: maast64;STARTED; Host has entered a period of scheduled downtime"
+        'pattern': '^\[([0-9]{10})\] (HOST|SERVICE) (DOWNTIME) ALERT: ([^\;]*);(STARTED|STOPPED|CANCELLED);(.*)',
+        'properties': [
+            'time',
+            'downtime_type',  # '(SERVICE or could be 'HOST')
+            'event_type',  # 'DOWNTIME'
+            'hostname',  # 'maast64'
+            'state',  # 'STARTED'
+            'output',  # 'Host has entered a period of scheduled downtime'
+        ]
+    }
+}
+
+
+# Class for parsing event logs
+# Populates self.data with the log type's properties
+class LogEvent:
+
+    def __init__(self, log):
+        self.data = {}
+
+        #Find the type of event
+        event_type_match = event_type_pattern.match(log)
+
+        if event_type_match:
+            #parse it with it's pattern
+            event_type = event_types[event_type_match.group(1)]
+            properties_match = re.match(event_type['pattern'], log)
+
+            if properties_match:
+                # Populate self.data with the event's properties
+                for i, p in enumerate(event_type['properties']):
+                    self.data[p] = properties_match.group(i+1)
+
+                # Convert the time to int
+                self.data['time'] = int(self.data['time'])
+
+                if 'attempts' in self.data:
+                    self.data['attempts'] = int(self.data['attempts'])
+
+    def __iter__(self):
+        return self.data.iteritems()
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __contains__(self, key):
+        return key in self.data
+
+    def __str__(self):
+        return str(self.data)

--- a/test/test_parse_logevent.py
+++ b/test/test_parse_logevent.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014 - Savoir-Faire Linux inc.
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+from shinken_test import *
+from shinken.misc.logevent import LogEvent
+
+
+class TestParseLogEvent(ShinkenTest):
+
+    def test_notification_service(self):
+        log = '[1402515279] SERVICE NOTIFICATION: admin;localhost;check-ssh;CRITICAL;notify-service-by-email;Connection refused'
+        expected = {
+            'hostname': 'localhost',
+            'acknownledgement': None,
+            'event_type': 'NOTIFICATION',
+            'service_desc': 'check-ssh',
+            'state': 'CRITICAL',
+            'contact': 'admin',
+            'time': 1402515279,
+            'notification_method': 'notify-service-by-email',
+            'notification_type': 'SERVICE'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+    def test_notification_host(self):
+        log = '[1402515279] HOST NOTIFICATION: admin;localhost;CRITICAL;notify-service-by-email;Connection refused'
+        expected = {
+            'hostname': 'localhost',
+            'acknownledgement': None,
+            'event_type': 'NOTIFICATION',
+            'service_desc': None,
+            'state': 'CRITICAL',
+            'contact': 'admin',
+            'time': 1402515279,
+            'notification_method': 'notify-service-by-email',
+            'notification_type': 'HOST'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+    def test_alert_service(self):
+        log = '[1329144231] SERVICE ALERT: dfw01-is02-006;cpu load maui;WARNING;HARD;4;WARNING - load average: 5.04, 4.67, 5.04'
+        expected = {
+            'alert_type': 'SERVICE',
+            'event_type': 'ALERT',
+            'service_desc': 'cpu load maui',
+            'attempts': 4,
+            'state_type': 'HARD',
+            'state': 'WARNING',
+            'time': 1329144231,
+            'output': 'WARNING - load average: 5.04, 4.67, 5.04',
+            'hostname': 'dfw01-is02-006'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+    def test_alert_host(self):
+        log = '[1329144231] HOST ALERT: dfw01-is02-006;WARNING;HARD;4;WARNING - load average: 5.04, 4.67, 5.04'
+        expected = {
+            'alert_type': 'HOST',
+            'event_type': 'ALERT',
+            'service_desc': None,
+            'attempts': 4,
+            'state_type': 'HARD',
+            'state': 'WARNING',
+            'time': 1329144231,
+            'output': 'WARNING - load average: 5.04, 4.67, 5.04',
+            'hostname': 'dfw01-is02-006'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+    def test_downtime_alert_host(self):
+        log = '[1279250211] HOST DOWNTIME ALERT: maast64;STARTED; Host has entered a period of scheduled downtime'
+        expected = {
+            'event_type': 'DOWNTIME',
+            'hostname': 'maast64',
+            'state': 'STARTED',
+            'time': 1279250211,
+            'output': ' Host has entered a period of scheduled downtime',
+            'downtime_type': 'HOST'
+        }
+        event = LogEvent(log)
+        self.assertEqual(event.data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Just like shinken.misc.perfdata parses perfdata, shinken.misc.logevent parses monitoring logs.

For a given log:

```
[1329144231] SERVICE ALERT: dfw01-is02-006;cpu load maui;WARNING;HARD;4;WARNING - load average: 5.04, 4.67, 5.04
```

logevent.data will contain:

```
{
    'alert_type': 'SERVICE',
    'event_type': 'ALERT',
    'service_desc': 'cpu load maui',
    'attempts': 4,
    'state_type': 'HARD',
    'state': 'WARNING',
    'time': 1329144231,
    'output': 'WARNING - load average: 5.04, 4.67, 5.04',
    'hostname': 'dfw01-is02-006'
}
```

For example, I intend to use this with my broker module in `manage_log_brok`.
