### PR TITLE
Small refactoring in realm.py

### DIFF
--- a/shinken/external_command.py
+++ b/shinken/external_command.py
@@ -1695,7 +1695,7 @@ class ExternalCommandManager:
         self.arbiter.dispatcher.satellites.append(p)
         r.pollers.append(p)
         r.count_pollers()
-        r.fill_potential_pollers()
+        r.fill_potential_satellites_by_type('pollers')
         logger.debug("Poller %s added" % poller_name)
         logger.debug("Potential %s" % str(r.get_potential_satellites_by_type('poller')))
 

--- a/shinken/objects/realm.py
+++ b/shinken/objects/realm.py
@@ -148,17 +148,6 @@ class Realm(Itemgroup):
                 if not reactionner.spare and reactionner.manage_sub_realms:
                     self.nb_reactionners += 1
 
-
-    def fill_potential_reactionners(self):
-        self.potential_reactionners = []
-        for reactionner in self.reactionners:
-            self.potential_reactionners.append(reactionner)
-        for realm in self.higher_realms:
-            for reactionner in realm.reactionners:
-                if reactionner.manage_sub_realms:
-                    self.potential_reactionners.append(reactionner)
-
-
     def count_pollers(self):
         self.nb_pollers = 0
         for poller in self.pollers:
@@ -168,17 +157,6 @@ class Realm(Itemgroup):
             for poller in realm.pollers:
                 if not poller.spare and poller.manage_sub_realms:
                     self.nb_pollers += 1
-
-
-    def fill_potential_pollers(self):
-        self.potential_pollers = []
-        for poller in self.pollers:
-            self.potential_pollers.append(poller)
-        for realm in self.higher_realms:
-            for poller in realm.pollers:
-                if poller.manage_sub_realms:
-                    self.potential_pollers.append(poller)
-
 
     def count_brokers(self):
         self.nb_brokers = 0
@@ -190,17 +168,6 @@ class Realm(Itemgroup):
                 if not broker.spare and broker.manage_sub_realms:
                     self.nb_brokers += 1
 
-
-    def fill_potential_brokers(self):
-        self.potential_brokers = []
-        for broker in self.brokers:
-            self.potential_brokers.append(broker)
-        for realm in self.higher_realms:
-            for broker in realm.brokers:
-                if broker.manage_sub_realms:
-                    self.potential_brokers.append(broker)
-
-
     def count_receivers(self):
         self.nb_receivers = 0
         for receiver in self.receivers:
@@ -211,17 +178,6 @@ class Realm(Itemgroup):
                 if not receiver.spare and receiver.manage_sub_realms:
                     self.nb_receivers += 1
 
-
-    def fill_potential_receivers(self):
-        self.potential_receivers = []
-        for broker in self.receivers:
-            self.potential_receivers.append(broker)
-        for realm in self.higher_realms:
-            for broker in realm.receivers:
-                if broker.manage_sub_realms:
-                    self.potential_receivers.append(broker)
-
-
     # Return the list of satellites of a certain type
     # like reactionner -> self.reactionners
     def get_satellties_by_type(self, type):
@@ -230,6 +186,16 @@ class Realm(Itemgroup):
         else:
             logger.debug("[realm] do not have this kind of satellites: %s" % type)
             return []
+
+    def fill_potential_satellites_by_type(self, sat_type):
+        setattr(self, 'potential_%s' % sat_type, [])
+        for satellite in getattr(self, sat_type):
+            getattr(self, 'potential_%s' % sat_type).append(satellite)
+        for realm in self.higher_realms:
+            for satellite in getattr(realm, sat_type):
+                if satellite.manage_sub_realms:
+                    getattr(self, 'potential_%s' % sat_type).append(satellite)
+
 
 
     # Return the list of potentials satellites of a certain type
@@ -273,13 +239,13 @@ class Realm(Itemgroup):
         self.to_satellites_managed_by['receiver'] = {}
 
         self.count_reactionners()
-        self.fill_potential_reactionners()
+        self.fill_potential_satellites_by_type('reactionners')
         self.count_pollers()
-        self.fill_potential_pollers()
+        self.fill_potential_satellites_by_type('pollers')
         self.count_brokers()
-        self.fill_potential_brokers()
+        self.fill_potential_satellites_by_type('brokers')
         self.count_receivers()
-        self.fill_potential_receivers()
+        self.fill_potential_satellites_by_type('receivers')
 
         s = "%s: (in/potential) (schedulers:%d) (pollers:%d/%d) (reactionners:%d/%d) (brokers:%d/%d) (receivers:%d/%d)" % \
             (self.get_name(),


### PR DESCRIPTION
realm.py already had  `***_by_type` functions.

Replaced `get_all_subs_[type]` functions by `get_all_subs_satellites_by_type(sat_type)`
This merges 2 functions into 1.

Replaced `fill_potential_[type]` functions by `fill_potential_satellites_by_type`
This merges 4 functions into 1.
