### PR TITLE
Added test for sending unconfigured host check results to a receiver

### DIFF
--- a/test/shinken_test.py
+++ b/test/shinken_test.py
@@ -45,6 +45,7 @@ from shinken.brok import Brok
 from shinken.daemons.schedulerdaemon import Shinken
 from shinken.daemons.brokerdaemon import Broker
 from shinken.daemons.arbiterdaemon import Arbiter
+from shinken.daemons.receiverdaemon import Receiver
 from logging import ERROR
 
 # Modules are by default on the ../modules


### PR DESCRIPTION
Previously, only the scheduler was tested.
They are different code paths.
