### PR TITLE
Moved ExternalCommandManager initialization to init

### DIFF
--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -103,6 +103,12 @@ class Receiver(Satellite):
         self.istats = IStats(self)
         self.ibroks = IBroks(self)
 
+        # Now create the external commander. It's just here to dispatch
+        # the commands to schedulers
+        e = ExternalCommandManager(None, 'receiver')
+        e.load_receiver(self)
+        self.external_command = e
+
     # Schedulers have some queues. We can simplify call by adding
     # elements into the proper queue just by looking at their type
     # Brok -> self.broks
@@ -255,15 +261,6 @@ class Receiver(Satellite):
             logger.info("Setting our timezone to %s" % use_timezone)
             os.environ['TZ'] = use_timezone
             time.tzset()
-
-
-        # Now create the external commander. It's just here to dispatch
-        # the commands to schedulers
-        e = ExternalCommandManager(None, 'receiver')
-        e.load_receiver(self)
-        self.external_command = e
-
-
 
     # Take all external commands, make packs and send them to
     # the schedulers

--- a/test/test_external_commands.py
+++ b/test/test_external_commands.py
@@ -172,12 +172,6 @@ class TestConfig(ShinkenTest):
         receiverdaemon.direct_routing = True
         receiverdaemon.accept_passive_unknown_check_results = True
 
-        # Now create the external commander. It's just here to dispatch
-        # the commands to schedulers. Pasted from setup_new_conf()
-        e = ExternalCommandManager(None, 'receiver')
-        e.load_receiver(receiverdaemon)
-        receiverdaemon.external_command = e
-
         # Receiver receives unknown host external command
         excmd = ExternalCommand('[%d] PROCESS_SERVICE_CHECK_RESULT;test_host_0;unknownservice;1;Bobby is not happy|rtt=9999;5;10;0;10000' % time.time())
         receiverdaemon.unprocessed_external_commands.append(excmd)


### PR DESCRIPTION
From what I understand, there is no reason to create a new ExternalCommandManager every time we change conf.
