### PR TITLE
When replacing a daemon kill all processes in the group.

### DIFF
--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -455,7 +455,8 @@ class Daemon(object):
 
         self.debug_output.append("Replacing previous instance %d" % pid)
         try:
-            os.kill(pid, signal.SIGQUIT)
+            pgid = os.getpgid(pid)
+            os.killpg(pgid, signal.SIGQUIT)
         except os.error as err:
             if err.errno != errno.ESRCH:
                 raise


### PR DESCRIPTION
I found that when using the -r switch to reload the arbiter it would kill only the process with the pid in the pid file and leave the old child process alive. With this change all childs are killed as well.
