### PR TITLE
Allow wildcard service_description in serviceescalation

### DIFF
--- a/shinken/objects/escalation.py
+++ b/shinken/objects/escalation.py
@@ -207,12 +207,18 @@ class Escalations(Items):
             if '' in (es_hname.strip(), sdesc.strip()):
                 continue
             for hname in strip_and_uniq(es_hname.split(',')):
-                for sname in strip_and_uniq(sdesc.split(',')):
-                    s = services.find_srv_by_name_and_hostname(hname, sname)
-                    if s is not None:
-                        #print "Linking service", s.get_name(), 'with me', es.get_name()
-                        s.escalations.append(es)
-                                #print "Now service", s.get_name(), 'have', s.escalations
+                if sdesc.strip() == '*':
+                    slist = services.find_srvs_by_hostname(hname)
+                    if slist is not None:
+                        for s in slist:
+                            s.escalations.append(es)
+                else:
+                    for sname in strip_and_uniq(sdesc.split(',')):
+                        s = services.find_srv_by_name_and_hostname(hname, sname)
+                        if s is not None:
+                            #print "Linking service", s.get_name(), 'with me', es.get_name()
+                            s.escalations.append(es)
+                                    #print "Now service", s.get_name(), 'have', s.escalations
 
 
     # Will register escalations into host.escalations

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -487,6 +487,10 @@ class Host(SchedulingItem):
                 return s
         return None
 
+    # Return all of the services on a host
+    def get_services(self):
+        return self.services
+
     # For get a nice name
     def get_name(self):
         if not self.is_tpl():

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -1026,6 +1026,15 @@ class Services(Items):
                     return s.id
         return None
 
+    # Search for all of the services in a host
+    def find_srvs_by_hostname(self, host_name):
+        if hasattr(self, 'hosts'):
+            h = self.hosts.find_by_name(host_name)
+            if h is None:
+                return None
+            return h.get_services()
+        return None
+
     # Search a service by it's name and hot_name
     def find_srv_by_name_and_hostname(self, host_name, name):
         if hasattr(self, 'hosts'):


### PR DESCRIPTION
This adds the feature described @ https://shinken.readthedocs.org/en/latest/07_advanced/objecttricks.html#all-services-on-same-host

and fixes he bug report @ https://github.com/naparuba/shinken/issues/1161

I have been running with this code in production for the last two months without any issues.

I hope this doesn't look too bad, with my limited python skills I couldn't see a more elegant way of doing it.
