### PR TITLE
Fix: alias is not required

### DIFF
--- a/doc/source/08_configobjects/host.rst
+++ b/doc/source/08_configobjects/host.rst
@@ -20,7 +20,7 @@ Bold directives are required, while the others are optional.
 ========================================== ======================================
 define host{
 **host_name**                              ***host_name***
-**alias**                                  ***alias***
+alias                                      alias
 display_name                               *display_name*
 **address**                                ***address***
 parents                                    *host_names*


### PR DESCRIPTION
As far as I can tell, alias is not required. Am I wrong?
