### PR TITLE
Return the hash containing all components state instead of only the brok...

### DIFF
--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -145,7 +145,7 @@ class IForArbiter(Interface):
                                 print exp
                     lst.append(e)
                         
-        return lst
+        return res
     get_all_states.doc = doc
     
     


### PR DESCRIPTION
Hi,

Just a typo into the code that make the 'get_all_states' unusable right now.

Regards,
