### PR TITLE
Update init script to write initial Arbiter logs

### DIFF
--- a/bin/init.d/shinken
+++ b/bin/init.d/shinken
@@ -296,13 +296,12 @@ do_start() {
     else
         if ! test "$SHINKENSPECIFICCFG"
         then
-            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" $DEBUGCMD 2>&1)
+            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" $DEBUGCMD 2>&1) >> $LOG/${mod}d.log
         else
-            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" -c "$SHINKENSPECIFICCFG" $DEBUGCMD 2>&1)
+            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" -c "$SHINKENSPECIFICCFG" $DEBUGCMD 2>&1) >> $LOG/${mod}d.log
         fi
+        # Arbiter doesn't write logs in its initial phase - Issue #1320 - Let's force it to the logfile
         rc=$?
-        # Arbiter doesn't write logs in its initial phase - Issue #1320
-        echo "$output" >> $LOG/${mod}d.log
     fi
     # debug:
     #resfile="/tmp/bad_start_for_$mod"


### PR DESCRIPTION
This is a fix/workaround for the issue #1320
