### PR TITLE
Update init script to write initial Arbiter logs

### DIFF
--- a/bin/init.d/shinken
+++ b/bin/init.d/shinken
@@ -294,11 +294,12 @@ do_start() {
         output=$($PYTHON "$modfilepath" -d -c "${modinifile}" $DEBUGCMD 2>&1)
         rc=$?
     else
+        arbiterlogfile=$(cat $SHINKENCFG | grep local_log | cut -d'=' -f2)
         if ! test "$SHINKENSPECIFICCFG"
         then
-            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" $DEBUGCMD 2>&1)
+            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" $DEBUGCMD 2>&1) >> $arbiterlogfile
         else
-            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" -c "$SHINKENSPECIFICCFG" $DEBUGCMD 2>&1)
+            output=$($PYTHON "$modfilepath" -d -c "$SHINKENCFG" -c "$SHINKENSPECIFICCFG" $DEBUGCMD 2>&1) >> $arbiterlogfile
         fi
         rc=$?
     fi


### PR DESCRIPTION
This is a fix/workaround for the issue #1320

We have it changed and working at this moment in our project.
We got the full start log (depending on the log level in the shinken.cfg config file) in the configured log file of the Arbiter Service, by default its output is dumped to _/var/log/shinken/arbiterd.log_
