### PR TITLE
Expands bp_rules t flag from tags rather than use

### DIFF
--- a/shinken/dependencynode.py
+++ b/shinken/dependencynode.py
@@ -25,14 +25,14 @@
 
 import re
 from shinken.util import filter_any, filter_none
-from shinken.util import filter_host_by_name, filter_host_by_regex, filter_host_by_group, filter_host_by_template
+from shinken.util import filter_host_by_name, filter_host_by_regex, filter_host_by_group, filter_host_by_tag
 from shinken.util import filter_service_by_name
 from shinken.util import filter_service_by_regex_name
 from shinken.util import filter_service_by_regex_host_name
 from shinken.util import filter_service_by_host_name
 from shinken.util import filter_service_by_bp_rule_label
 from shinken.util import filter_service_by_hostgroup_name
-from shinken.util import filter_service_by_host_template_name
+from shinken.util import filter_service_by_host_tag_name
 from shinken.util import filter_service_by_servicegroup_name
 from shinken.util import filter_host_by_bp_rule_label
 from shinken.util import filter_service_by_host_bp_rule_label
@@ -566,7 +566,7 @@ class DependencyNodeFactory(object):
         if expr == "*":
             return [filter_any]
         match = re.search(r"^([%s]+):(.*)" % self.host_flags, expr)
-        
+
         if match is None:
             return [filter_host_by_name(expr)]
         flags, expr = match.groups()
@@ -577,7 +577,7 @@ class DependencyNodeFactory(object):
         elif "l" in flags:
             return [filter_host_by_bp_rule_label(expr)]
         elif "t" in flags:
-            return [filter_host_by_template(expr)]
+            return [filter_host_by_tag(expr)]
         else:
             return [filter_none]
 
@@ -598,7 +598,7 @@ class DependencyNodeFactory(object):
         elif "l" in flags:
             return [filter_service_by_host_bp_rule_label(expr)]
         elif "t" in flags:
-            return [filter_service_by_host_template_name(expr)]
+            return [filter_service_by_host_tag_name(expr)]
         else:
             return [filter_none]
 

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -759,12 +759,12 @@ def filter_host_by_group(group):
     return inner_filter
 
 
-def filter_host_by_template(tpl):
+def filter_host_by_tag(tpl):
 
     def inner_filter(host):
         if host is None:
             return False
-        return tpl in [t.strip() for t in host.use]
+        return tpl in [t.strip() for t in host.tags]
 
     return inner_filter
 
@@ -822,12 +822,12 @@ def filter_service_by_hostgroup_name(group):
     return inner_filter
 
 
-def filter_service_by_host_template_name(tpl):
+def filter_service_by_host_tag_name(tpl):
 
     def inner_filter(service):
         if service is None or service.host is None:
             return False
-        return tpl in [t.strip() for t in service.host.use]
+        return tpl in [t.strip() for t in service.host.tags]
 
     return inner_filter
 


### PR DESCRIPTION
Tags are now recursed, which is not the case for templates in the `use` parameter.

This patch expands the `t` flag in business rules expand expressions against `tags` rather than direct templates in `use`.
