### PR TITLE
Wrong % of services/hosts with status OK measure

### DIFF
--- a/shinken/misc/datamanager.py
+++ b/shinken/misc/datamanager.py
@@ -275,7 +275,7 @@ class DataManager(object):
         if len(all_services) == 0:
             res = 0
         else:
-            res = (100-(len(problem_services) *100)/len(all_services))
+            res = int(100-(len(problem_services) *100)/float(len(all_services)))
         return res
               
     # Get percent of all Hosts
@@ -286,7 +286,7 @@ class DataManager(object):
         if len(all_hosts) == 0:
             res = 0
         else:
-            res = (100-(len(problem_hosts) *100)/len(all_hosts))
+            res = int(100-(len(problem_hosts) *100)/float(len(all_hosts)))
         return res
               
 


### PR DESCRIPTION
Hi!

The algorithm to get the % of OK services and OK hosts is wrong. There is a problem rounding the result. You will always lose precision with an amount of services greater than 100.

Here's an example:

```
>>> all_services = 9000
>>> problem_services = 20
>>> 100-problem_services*100/all_services
100
>>> # WTF! I have critical services and my status is still 100% OK? Mmmmm
...
>>> int(100-problem_services*100/float(all_services))
99
```

This avoid confusions at the currently dashboard (and maybe in other parts of shinken)
