### PR TITLE
Cleaned pyro references from most python files.

### DIFF
--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -673,7 +673,7 @@ class Broker(BaseSatellite):
                 return
             self.setup_new_conf()
 
-        # Now we check if arbiter speak to us in the pyro_daemon.
+        # Now we check if arbiter speak to us.
         # If so, we listen for it
         # When it pushes conf to us, we reinit connections
         self.watch_for_new_conf(0.0)

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -335,7 +335,7 @@ class Receiver(Satellite):
         # Begin to clean modules
         self.check_and_del_zombie_modules()
 
-        # Now we check if arbiter speak to us in the pyro_daemon.
+        # Now we check if arbiter speak to us.
         # If so, we listen for it
         # When it push us conf, we reinit connections
         self.watch_for_new_conf(0.0)

--- a/shinken/http_daemon.py
+++ b/shinken/http_daemon.py
@@ -94,7 +94,7 @@ class CherryPyBackend(object):
             msg = "Error: Sorry, the port %d is not free: %s" % (self.port, str(exp))
             raise PortNotFree(msg)
         except Exception, e:
-            # must be a problem with pyro workdir:
+            # must be a problem with workdir:
             raise InvalidWorkDir(e)
 
 
@@ -165,7 +165,7 @@ class WSGIREFBackend(object):
             msg = "Error: Sorry, the port %d is not free: %s" % (port, str(exp))
             raise PortNotFree(msg)
         except Exception, e:
-            # must be a problem with pyro workdir:
+            # must be a problem with workdir:
             raise e
 
 

--- a/shinken/satellite.py
+++ b/shinken/satellite.py
@@ -241,7 +241,7 @@ class BaseSatellite(Daemon):
         self.external_commands_lock = threading.RLock()
 
 
-    # The arbiter can resent us new conf in the pyro_daemon port.
+    # The arbiter can resent us new conf in our communication channel.
     # We do not want to loose time about it, so it's not a blocking
     # wait, timeout = 0s
     # If it send us a new conf, we reinit the connections of all schedulers
@@ -793,7 +793,7 @@ class Satellite(BaseSatellite):
                 return
             self.setup_new_conf()
 
-        # Now we check if arbiter speak to us in the pyro_daemon.
+        # Now we check if arbiter speak to us.
         # If so, we listen to it
         # When it push a conf, we reinit connections
         # Sleep in waiting a new conf :)


### PR DESCRIPTION
Replaced 'pyro' by 'communication' everywhere. 
Not sure but there could be a better term ? if yes then I could use it if someone provide it.

Still libexec/check_shinken.py to be converted to new communication mode..
