### PR TITLE
Fix: imp.load_compiled/load_source can raise OSError instead of ImportEr...

### DIFF
--- a/shinken/modulesctx.py
+++ b/shinken/modulesctx.py
@@ -64,7 +64,7 @@ class ModulesContext(object):
             sys.path.append(mod_dir)
         try:
             return load_it()
-        except ImportError as err:
+        except Exception as err:
             logger.warning("Importing module %s failed: %s ; backtrace=%s",
                            mod_name, err, traceback.format_exc())
             sys.path.remove(mod_dir)


### PR DESCRIPTION
...ror if file not found.

Just catch Exception.
