### PR TITLE
Tests: livestatus: Explicitly call prepare_log_db_table (if it exists) a...

### DIFF
--- a/test/shinken_modules.py
+++ b/test/shinken_modules.py
@@ -109,6 +109,8 @@ class ShinkenModulesTest(ShinkenTest):
 
         #--- livestatus_broker.do_main
         self.livestatus_broker.db.open()
+        if hasattr(self.livestatus_broker.db, 'prepare_log_db_table'):
+            self.livestatus_broker.db.prepare_log_db_table()
         #--- livestatus_broker.do_main
 
 


### PR DESCRIPTION
...fter db.open.

Because logstore-sqlite open() doesn't create it anymore automatically (explicity better than implicit).
