### PR TITLE
Added so webui cares about HTTP_X_FORWARDED_PROTO header

### DIFF
--- a/shinken/webui/bottlewebui.py
+++ b/shinken/webui/bottlewebui.py
@@ -765,6 +765,8 @@ class Bottle(object):
         """ The bottle WSGI-interface. """
         try:
             environ['bottle.app'] = self
+            if environ.has_key('HTTP_X_FORWARDED_PROTO'):
+                environ['wsgi.url_scheme'] = environ['HTTP_X_FORWARDED_PROTO']
             request.bind(environ)
             response.bind()
             out = self._cast(self._handle(environ), request, response)


### PR DESCRIPTION
With this patch the webui module will care about the HTTP_X_FORWARDED_PROTO header. This is very useful if the webui for some reason is behind a proxy that is doing SSL offload. Without this patch all pages was redirected back to http:// instead of https://.

I am running Shinken webui behind a nginx proxy using SSL and that works fine.
