### PR TITLE
change res of get_raw_stats from dict to list

### DIFF
--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -51,7 +51,7 @@ class IStats(Interface):
     doc = 'Get raw stats from the daemon'
     def get_raw_stats(self):
         app = self.app
-        res = {}
+        res = []
 
         insts = [inst for inst in app.modules_manager.instances if inst.is_external]
         for inst in insts:


### PR DESCRIPTION
when i invoke the web api of broker for `get_raw_stats` i get the error page saying that "dict doesn't have a method append". So, i think the auther may mean that the **res** variable in **brokerdaemon.py**'s **get_raw_stats** should be a list, since list has the method append. I have changed **res** to list and i finally get the correct output, something like "[{"module_name": "webui", "queue_size": 0}]" 
