### PR TITLE
Use "original" sys.stdout.

### DIFF
--- a/test/shinken_test.py
+++ b/test/shinken_test.py
@@ -5,6 +5,8 @@
 #
 
 import sys
+from sys import stdout
+
 import time
 import datetime
 import os
@@ -318,7 +320,8 @@ class ShinkenTest(unittest.TestCase, _Unittest2CompatMixIn):
         for brok in sorted(broks.values(), lambda x, y: x.id - y.id):
             if brok.type == 'log':
                 brok.prepare()
-                print "LOG:", brok.data['log'].encode(sys.stdout.encoding, errors='xmlcharrefreplace')
+                encoding = stdout.encoding or 'ascii'
+                print "LOG:", brok.data['log'].encode(encoding, errors='xmlcharrefreplace')
         print "--- logs >>>----------------------------------"
 
 


### PR DESCRIPTION
Fix test: 
something could have replaced sys.stdout. 
So just make sure to use the original one by simply importing it early into the module and using it directly (without accessing it by/throuh 'sys').
Also check that encoding is set and default to ascii if not.
