### PR TITLE
test: IsNot(None, X) -> IsNotNone(X)

### DIFF
--- a/test/test_discovery_def.py
+++ b/test/test_discovery_def.py
@@ -32,7 +32,7 @@ class TestDiscoveryConf(ShinkenTest):
 
     def test_look_for_discorule(self):
         genhttp = self.sched.conf.discoveryrules.find_by_name('GenHttp')
-        self.assertIsNot(None, genhttp)
+        self.assertIsNotNone(genhttp)
         self.assertEqual('service', genhttp.creation_type)
         self.assertEqual('80,443', genhttp.matches['openports'])
         self.assertEqual('windows', genhttp.matches['os'])
@@ -85,10 +85,10 @@ class TestDiscoveryConf(ShinkenTest):
     # Look for good definition and call of a discoveryrun
     def test_look_for_discorun(self):
         nmap = self.sched.conf.discoveryruns.find_by_name('nmap')
-        self.assertIsNot(None, nmap)
+        self.assertIsNotNone(nmap)
         nmapcmd = self.sched.conf.commands.find_by_name('nmap_runner')
-        self.assertIsNot(None, nmapcmd)
-        self.assertIsNot(None, nmap.discoveryrun_command)
+        self.assertIsNotNone(nmapcmd)
+        self.assertIsNotNone(nmap.discoveryrun_command)
         # Launch it
         nmap.launch()
         for i in xrange(1, 5):
@@ -103,7 +103,7 @@ class TestDiscoveryConf(ShinkenTest):
 
     def test_look_for_host_discorule(self):
         genhttp = self.sched.conf.discoveryrules.find_by_name('GenHttpHost')
-        self.assertIsNot(None, genhttp)
+        self.assertIsNotNone(genhttp)
         self.assertEqual('host', genhttp.creation_type)
         self.assertEqual('^80$', genhttp.matches['openports'])
 
@@ -135,7 +135,7 @@ class TestDiscoveryConf(ShinkenTest):
 
     def test_look_for_host_discorule_and_delete(self):
         genhttp = self.sched.conf.discoveryrules.find_by_name('GenHttpHostRemoveLinux')
-        self.assertIsNot(None, genhttp)
+        self.assertIsNotNone(genhttp)
         self.assertEqual('host', genhttp.creation_type)
         self.assertEqual('^80$', genhttp.matches['openports'])
 
@@ -169,7 +169,7 @@ class TestDiscoveryConf(ShinkenTest):
 
     def test_discorun_matches(self):
         linux = self.sched.conf.discoveryruns.find_by_name('linux')
-        self.assertIsNot(None, linux)
+        self.assertIsNotNone(linux)
         print linux.__dict__
         self.assertEqual({u'osvendor': u'linux'}, linux.matches)
 


### PR DESCRIPTION
fix not best regex used in dd8c305fa7662a808d1ca2540958ad82f4363498

damn, should have re-read myself a bit earlier ;)
but was not that bad.
