### PR TITLE
Removed extra version check

### DIFF
--- a/bin/shinken-arbiter
+++ b/bin/shinken-arbiter
@@ -45,9 +45,7 @@ if os.name != 'nt':
     # on the Python version and the process limit "stack size".
     # The factors used were acquired by testing a broad range of installations
     stacksize_soft, stacksize_hard = resource.getrlimit(3)
-    if sys.version_info < (2, 6):
-        sys.setrecursionlimit(int(stacksize_soft * 0.65 + 1100))
-    elif sys.version_info < (3,):
+    if sys.version_info < (3,):
         sys.setrecursionlimit(int(stacksize_soft * 1.9 + 3200))
     else:
         sys.setrecursionlimit(int(stacksize_soft * 2.4 + 3200))

--- a/bin/shinken-scheduler
+++ b/bin/shinken-scheduler
@@ -77,9 +77,7 @@ if os.name != 'nt':
     # on the Python version and the process limit "stack size".
     # The factors used were acquired by testing a broad range of installations
     stacksize_soft, stacksize_hard = resource.getrlimit(3)
-    if sys.version_info < (2, 6):
-        sys.setrecursionlimit(int(stacksize_soft * 0.65 + 1100))
-    elif sys.version_info < (3,):
+    if sys.version_info < (3,):
         sys.setrecursionlimit(int(stacksize_soft * 1.9 + 3200))
     else:
         sys.setrecursionlimit(int(stacksize_soft * 2.4 + 3200))

--- a/shinken/bin.py
+++ b/shinken/bin.py
@@ -35,6 +35,7 @@ VERSION = "2.0.3"
 
 
 # Make sure people are using Python 2.6 or higher
+# This is the canonical python version check
 if sys.version_info < (2, 6):
     sys.exit("Shinken requires as a minimum Python 2.6.x, sorry")
 elif sys.version_info >= (3,):

--- a/shinken/misc/importlib.py
+++ b/shinken/misc/importlib.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import
 
 import sys
 
-if sys.version_info[:2] <= (2, 6):
-    try: # still try to import it from system:
+# importlib was introduced in 2.7. It is also available as a backport
+if sys.version_info[:2] < (2, 7):
+    try: # try to import the system-wide backported module
         from importlib import *
-    except ImportError:
+    except ImportError: # load our bundled backported module
         from ._importlib import *
 else:
     from importlib import *

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -542,11 +542,7 @@ class Config(Item):
                     self.packs_dirs.append(cfg_dir_name)
 
                     # Now walk for it.
-                    # BEWARE : we can follow symlinks only for python 2.6 and higher
-                    args = {}
-                    if sys.version_info >= (2, 6):
-                        args['followlinks'] = True
-                    for root, dirs, files in os.walk(cfg_dir_name, **args):
+                    for root, dirs, files in os.walk(cfg_dir_name, followlinks=True):
                         for file in files:
                             if re.search("\.cfg$", file):
                                 if self.read_config_silent == 0:

--- a/test/test_conf_in_symlinks.py
+++ b/test/test_conf_in_symlinks.py
@@ -36,10 +36,6 @@ class TestConfigWithSymlinks(ShinkenTest):
     def test_symlinks(self):
         if os.name == 'nt':
             return
-        if sys.version_info < (2 , 6):
-            print "************* WARNING********"*200
-            print "On python 2.4 and 2.5, the symlinks following is NOT managed"
-            return
         svc = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "test_HIDDEN")
         self.assertIsNot(svc, None)
 


### PR DESCRIPTION
Shinken requires version 2.6, so it is unnecessary to check if the python version is higher or equal to 2.6, as it will always be true.

This PR removes that extra version check.