### PR TITLE
fix: bad super call. would infinitely recurse if subclassed..

### DIFF
--- a/shinken/objects/resultmodulation.py
+++ b/shinken/objects/resultmodulation.py
@@ -66,7 +66,7 @@ class Resultmodulation(Item):
     # to be do at running
     def pythonize(self):
         # First apply Item pythonize
-        super(self.__class__, self).pythonize()
+        super(Resultmodulation, self).pythonize()
 
         # Then very special cases
         # Intify the exit_codes_match, and make list


### PR DESCRIPTION
```
Python 2.7.6 (default, Mar 22 2014, 22:59:56) 
[GCC 4.8.2] on linux2
Type "copyright", "credits" or "license()" for more information.
>>> class A(object):
    def x(self):
        return 42

>>> class B(A):
    def x(self):
        sup = super(self.__class__, self).x
        print("in B: ", sup)
        return sup()


>>> b = B()

## if not subclassed, then ok : 

>>> b.x()      
('in B: ', <bound method B.x of <__main__.B object at 0x7fb48fc28510>>)
42
>>> 

>>> class C(B): pass   # but if subclassed ..

>>> import sys
>>> sys.setrecursionlimit(50)
>>> 
>>> c = C()
>>> c.x()
('in B: ', <bound method C.x of <__main__.C object at 0x7fb48fc28a90>>)
('in B: ', <bound method C.x of <__main__.C object at 0x7fb48fc28a90>>)
('in B: ', <bound method C.x of <__main__.C object at 0x7fb48fc28a90>>)

Traceback (most recent call last):
  File "<pyshell#23>", line 1, in <module>
    c.x()
  File "<pyshell#13>", line 5, in x
    return sup()
  File "<pyshell#13>", line 5, in x
    return sup()
  File "<pyshell#13>", line 5, in x
    return sup()
  File "<pyshell#13>", line 4, in x
    print("in B: ", sup)
  File "/usr/lib/python2.7/idlelib/PyShell.py", line 1351, in write
    return self.shell.write(s, self.tags)
RuntimeError: maximum recursion depth exceeded while calling a Python object
>>> 


Always  use the "bare" or literal class of where is happening the super call , so here : 

>>> class B(A):
    def x(self):
        sup = super(B, self).x
        return sup() + 1

>>> class C(B): pass

>>> C().x()
43
>>> 
```
