### PR TITLE
Let's change the included files in the bin/ hierarchy. We want to includ...

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include shinken *.*
 recursive-include shinken/webui *.*
 recursive-include etc *
 recursive-include windows .bat .reg
-recursive-include bin *.* *-* shinken
+recursive-include bin *
 recursive-include libexec *.*
 recursive-include modules *.*
 recursive-include doc *.*


### PR DESCRIPTION
...e all files

under both init.d and rc.d for the source distribution. While the rc.d files are
for BSD, the init.d files are for Linux distributions. When installing a source
distribution this will install the data_files (cf. setup.py) needed for the specific
target the we are installing on.

This should fix pip on FreeBSD.