### PR TITLE
return_code value is always 0

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -848,6 +848,9 @@ class SchedulingItem(Item):
 
         self.set_state_from_exit_status(c.exit_status)
 
+        # Set return_code to exit_status to fill the value in broks
+        self.return_code = c.exit_status
+
         # we change the state, do whatever we are or not in
         # an impact mode, we can put it
         self.state_changed_since_impact = True


### PR DESCRIPTION
When broker sends a host_check_result or service_check_result brok, the return_code value is always 0 (default value).

The return_code is interesting for archival and proof purpose, so I set it the the exit_status value.

I tested and it works fine. I hope that's the correct way to do this.