### PR TITLE
Ensure that livestatus client close its connections

### DIFF
--- a/shinken/clients/livestatus.py
+++ b/shinken/clients/livestatus.py
@@ -397,6 +397,7 @@ class LSConnectionPool(object):
                 r = q.result
                 logger.debug(str(r))
                 res.extend(r)
+            c.handle_close()
         return res
 
 


### PR DESCRIPTION
The LSConnectionPool does not close the connections after the end of the
requests. On long running process doing regular livestatus request, it
quickly saturate the maximum allowed file descriptor. The commit ensures
that connections are closed after the results have been read.