### PR TITLE
Don't commit on tearDown.

### DIFF
--- a/test/shinken_modules.py
+++ b/test/shinken_modules.py
@@ -136,7 +136,6 @@ class TestConfig(ShinkenModulesTest):
 
     def tearDown(self):
         self.stop_nagios()
-        self.livestatus_broker.db.commit()
         self.livestatus_broker.db.close()
         if os.path.exists(self.livelogs):
             os.remove(self.livelogs)


### PR DESCRIPTION
1) this is overkill to commit in a test.tearDown().
2) unfortunately, due to complexity of livestatus :
   the db handle might already be closed -> error if commit.

and this is required for https://github.com/shinken-monitoring/mod-livestatus/pull/43
