### PR TITLE
Fix #1434 arbiter api does not update alive field when arbiter master fail

### DIFF
--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -696,6 +696,9 @@ class Arbiter(Daemon):
             now = time.time()
             if now - self.last_master_speack > master_timeout:
                 logger.info("Arbiter Master is dead. The arbiter %s take the lead", self.me.get_name())
+                for arb in self.conf.arbiters:
+                    if not arb.spare:
+                        arb.alive = False                
                 self.must_run = True
                 break
 


### PR DESCRIPTION
Test : 
stop arbiter master 
wait for 300s 
check master alive field
curl http://arbiter2:7770/get-all-states | python -m json.tool | more
start arbiter master 
check master alive field on both arbiters
curl http://arbiter1:7770/get-all-states | python -m json.tool | more

