### PR TITLE
Implementation of special on-demand macros (isvalidtime & nextvalidtime)

### DIFF
--- a/test/etc/standard/timeperiods.cfg
+++ b/test/etc/standard/timeperiods.cfg
@@ -9,3 +9,13 @@ define timeperiod{
     friday          00:00-24:00
     saturday        00:00-24:00
 }
+
+define timeperiod{
+    timeperiod_name workhours
+    alias       Normal Work Hours
+    monday      09:00-17:00
+    tuesday     09:00-17:00
+    wednesday   09:00-17:00
+    thursday    09:00-17:00
+    friday      09:00-17:00
+    }

--- a/test/test_macroresolver.py
+++ b/test/test_macroresolver.py
@@ -210,9 +210,12 @@ class TestMacroResolver(ShinkenTest):
         data = hst.get_data_for_checks()
 
         # Get the 18 of December 2014 at 15:00, thursday
-        dec_the_18 = time.mktime(time.strptime("18 Dec 2014 15:00:00", "%d %b %Y %H:%M:%S"))
+        dec_the_18_15h = int(time.mktime(time.strptime("18 Dec 2014 15:00:00", "%d %b %Y %H:%M:%S")))
         # Get the 18 of December 2014 at 20:00, thursday
-        dec_the_18_20h = time.mktime(time.strptime("18 Dec 2014 20:00:00", "%d %b %Y %H:%M:%S"))
+        dec_the_18_20h = int(time.mktime(time.strptime("18 Dec 2014 20:00:00", "%d %b %Y %H:%M:%S")))
+        # Get the 18 of December 2014 at 09:00, friday
+        dec_the_19_9h = int(time.mktime(time.strptime("19 Dec 2014 09:00:00", "%d %b %Y %H:%M:%S")))
+
 
         #with a 24x7 timeperiod
         data = svc.get_data_for_checks()
@@ -224,7 +227,7 @@ class TestMacroResolver(ShinkenTest):
 
         #with workhours timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
         data = svc.get_data_for_checks()
-        dummy_call = "special_macro!$ISVALIDTIME:workhours:1418911200$"
+        dummy_call = "special_macro!$ISVALIDTIME:workhours:{0}$".format(dec_the_18_15h)
         cc = CommandCall(self.conf.commands, dummy_call)
         com = mr.resolve_command(cc, data)
         print com
@@ -232,7 +235,7 @@ class TestMacroResolver(ShinkenTest):
 
         #with a timestamp off workhours (equals to 18 Dec 2014 20:00:00)
         data = svc.get_data_for_checks()
-        dummy_call = "special_macro!$ISVALIDTIME:workhours:1418929200$"
+        dummy_call = "special_macro!$ISVALIDTIME:workhours:{0}$".format(dec_the_18_20h)
         cc = CommandCall(self.conf.commands, dummy_call)
         com = mr.resolve_command(cc, data)
         print com
@@ -249,29 +252,29 @@ class TestMacroResolver(ShinkenTest):
         # with a 24x7 timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
         # Next validtime will be equal to the timestamp
         data = svc.get_data_for_checks()
-        dummy_call = "special_macro!$NEXTVALIDTIME:24x7:1418911200$"
+        dummy_call = "special_macro!$NEXTVALIDTIME:24x7:{0}$".format(dec_the_18_15h)
         cc = CommandCall(self.conf.commands, dummy_call)
         com = mr.resolve_command(cc, data)
         print com
-        self.assertEqual('plugins/nothing 1418911200', com)
+        self.assertEqual('plugins/nothing {0}'.format(dec_the_18_15h), com)
 
         # with workhours timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
         # Next validtime will be equal to the timestamp
         data = svc.get_data_for_checks()
-        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:1418911200$"
+        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:{0}$".format(dec_the_18_15h)
         cc = CommandCall(self.conf.commands, dummy_call)
         com = mr.resolve_command(cc, data)
         print com
-        self.assertEqual('plugins/nothing 1418911200', com)
+        self.assertEqual('plugins/nothing {0}'.format(dec_the_18_15h), com)
 
         # with a timestamp off workhours (equals to 18 Dec 2014 20:00:00)
-        # Next valid time will be 1418976000 (19 Dec 2014 08:00:00)
+        # Next valid time will be 1418976000 (19 Dec 2014 09:00:00)
         data = svc.get_data_for_checks()
-        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:1418929200$"
+        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:{0}$".format(dec_the_18_20h)
         cc = CommandCall(self.conf.commands, dummy_call)
         com = mr.resolve_command(cc, data)
         print com
-        self.assertEqual('plugins/nothing 1418976000', com)
+        self.assertEqual('plugins/nothing {0}'.format(dec_the_19_9h), com)
 
         # with bad timestamp
         data = svc.get_data_for_checks()

--- a/test/test_macroresolver.py
+++ b/test/test_macroresolver.py
@@ -201,8 +201,86 @@ class TestMacroResolver(ShinkenTest):
         com = mr.resolve_command(cc, data)
         print com
         self.assertEqual('plugins/nothing you should not pass', com)
-                                                
-                                                
+
+
+    # Look at special on demand macros (ISVALIDTIME and NEXTVALIDTIME)
+    def test_validtime_ondemand_macros(self):
+        mr = self.get_mr()
+        (svc, hst) = self.get_hst_svc()
+        data = hst.get_data_for_checks()
+
+        # Get the 18 of December 2014 at 15:00, thursday
+        dec_the_18 = time.mktime(time.strptime("18 Dec 2014 15:00:00", "%d %b %Y %H:%M:%S"))
+        # Get the 18 of December 2014 at 20:00, thursday
+        dec_the_18_20h = time.mktime(time.strptime("18 Dec 2014 20:00:00", "%d %b %Y %H:%M:%S"))
+
+        #with a 24x7 timeperiod
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$ISVALIDTIME:24x7$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 1', com)
+
+        #with workhours timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$ISVALIDTIME:workhours:1418911200$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 1', com)
+
+        #with a timestamp off workhours (equals to 18 Dec 2014 20:00:00)
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$ISVALIDTIME:workhours:1418929200$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 0', com)
+
+        # with bad timestamp
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$ISVALIDTIME:workhours:t$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing', com)
+
+        # with a 24x7 timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
+        # Next validtime will be equal to the timestamp
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$NEXTVALIDTIME:24x7:1418911200$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 1418911200', com)
+
+        # with workhours timeperiod and a timestamp (equals to 18 Dec 2014 15:00:00)
+        # Next validtime will be equal to the timestamp
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:1418911200$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 1418911200', com)
+
+        # with a timestamp off workhours (equals to 18 Dec 2014 20:00:00)
+        # Next valid time will be 1418976000 (19 Dec 2014 08:00:00)
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:1418929200$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 1418976000', com)
+
+        # with bad timestamp
+        data = svc.get_data_for_checks()
+        dummy_call = "special_macro!$NEXTVALIDTIME:workhours:string$"
+        cc = CommandCall(self.conf.commands, dummy_call)
+        com = mr.resolve_command(cc, data)
+        print com
+        self.assertEqual('plugins/nothing 0', com)
+
 
     # Look at on demand macros
     def test_hostadressX_macros(self):


### PR DESCRIPTION
I noticed that 2 on-demand macros are not implemented :
- ISVALIDTIME (https://shinken.readthedocs.org/en/latest/05_thebasics/macrolist.html#isvalidtime)
- NEXTVALIDTIME (https://shinken.readthedocs.org/en/latest/05_thebasics/macrolist.html#nextvalidtime)

They were always empty when I tried to use them in event handlers or command.

I suggest here an implementation of these 2 macros. As I'm not really familiar with shinken code, I tried to implement them in the best location (i.e in [shinken/macroresolver.py] (https://github.com/naparuba/shinken/blob/master/shinken/macroresolver.py)).
The idea was to test them before any other on-demand macros (services or hosts).
Let me know what you think.
