### PR TITLE
Test: services: fix non-deterministic assert.

### DIFF
--- a/test/test_services.py
+++ b/test/test_services.py
@@ -194,10 +194,12 @@ class TestService(ShinkenTest):
         self.assertEqual('OK', svc.last_hard_state)
 
         # now go hard!
+        time.sleep(2)
         now = int(time.time())
+        self.assertLess(svc.last_hard_state_change, now)
         self.scheduler_loop(1, [[svc, 2, 'CRITICAL | bibi=99%']])
         print "FUCK", svc.state_type
-        self.assertEqual(now, svc.last_hard_state_change)
+        self.assertGreaterEqual(svc.last_hard_state_change, now)
         self.assertEqual('CRITICAL', svc.last_hard_state)
         print "Last hard state id", svc.last_hard_state_id
         self.assertEqual(2, svc.last_hard_state_id)


### PR DESCRIPTION
From time to time the previous assert failed (see below) because:

 svc.last_hard_state_change is equal to 'now+1'

because scheduler_loop() work load is spread over 2 seconds.

Now make sure that svc.last_hard_state_change is really changed.

From: https://travis-ci.org/gst/shinken/jobs/46895695 :

test_service_last_hard_state (test_services.TestService) ... FAIL
======================================================================
FAIL: test_service_last_hard_state (test_services.TestService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/gst/shinken/test/test_services.py", line 200, in test_service_last_hard_state
    self.assertEqual(now, svc.last_hard_state_change)
AssertionError: 1421178531 != 1421178532