### PR TITLE
Fix template self use

### DIFF
--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -709,6 +709,14 @@ Like temporary attributes such as "imported_from", etc.. """
                 dmp[prop] = getattr(self, prop)
         return dmp
 
+    def _get_name(self):
+        if hasattr(self, 'get_name'):
+            return self.get_name()
+        name = getattr(self, 'name', None)
+        host_name = getattr(self, 'host_name', None)
+        return '%s(host_name=%s)' % (name or 'no-name', host_name or '')
+
+
 
 class Items(object):
     def __init__(self, items, index_items=True):
@@ -992,6 +1000,7 @@ class Items(object):
             all_tags.extend(self.get_all_tags(t))
         return list(set(all_tags))
 
+
     def linkify_item_templates(self, item):
         tpls = []
         tpl_names = item.get_templates()
@@ -1002,13 +1011,13 @@ class Items(object):
                 # TODO: Check if this should not be better to report as an error ?
                 self.configuration_warnings.append(
                     "%s %r use/inherit from an unknown template (%r) ! Imported from: %s" % (
-                        type(item).__name__, item.name, name, item.imported_from                                                                                              )
-                )
+                        type(item).__name__, item._get_name(), name, item.imported_from
+                ))
             else:
                 if t is item:
                     self.configuration_errors.append(
                         '%s %r use/inherits from itself ! Imported from: %s' % (
-                            type(item).__name__, item.name, item.imported_from
+                            type(item).__name__, item._get_name(), item.imported_from
                     ))
                 else:
                     tpls.append(t)

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -998,7 +998,13 @@ class Items(object):
 
         for name in tpl_names:
             t = self.find_tpl_by_name(name)
-            if t is not None:
+            if t is None:
+                # TODO: Check if this should not be better to report as an error ?
+                self.configuration_warnings.append(
+                    "%s %r use/inherit from an unknown template (%r) ! Imported from: %s" % (
+                        type(item).__name__, item.name, name, item.imported_from                                                                                              )
+                )
+            else:
                 if t is item:
                     self.configuration_errors.append(
                         '%s %r use/inherits from itself ! Imported from: %s' % (

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -999,7 +999,13 @@ class Items(object):
         for name in tpl_names:
             t = self.find_tpl_by_name(name)
             if t is not None:
-                tpls.append(t)
+                if t is item:
+                    self.configuration_errors.append(
+                        '%s %r use/inherits from itself ! Imported from: %s' % (
+                            type(item).__name__, item.name, item.imported_from
+                    ))
+                else:
+                    tpls.append(t)
         item.templates = tpls
 
     # We will link all templates, and create the template

--- a/test/bad_template.py
+++ b/test/bad_template.py
@@ -1,0 +1,18 @@
+
+from shinken_test import ShinkenTest
+
+
+class TestConfig(ShinkenTest):
+
+    def setUp(self):
+        pass # force no setUp for this class.
+
+    def test_bad_template_use_itself(self):
+        self.setup_with_file('etc/bad_template_use_itself.cfg')
+        self.assertIn(u"Host u'bla' use/inherits from itself ! Imported from: etc/bad_template_use_itself.cfg:1",
+                      self.conf.hosts.configuration_errors)
+
+    def test_bad_host_use_undefined_template(self):
+        self.setup_with_file('etc/bad_host_use_undefined_template.cfg')
+        self.assertIn(u"Host u'bla' use/inherit from an unknown template (u'undefined') ! Imported from: etc/bad_host_use_undefined_template.cfg:2",
+                      self.conf.hosts.configuration_warnings)

--- a/test/etc/bad_host_use_undefined_template.cfg
+++ b/test/etc/bad_host_use_undefined_template.cfg
@@ -1,0 +1,5 @@
+
+define host {
+    host_name bla
+    use     undefined
+}

--- a/test/etc/bad_template_use_itself.cfg
+++ b/test/etc/bad_template_use_itself.cfg
@@ -1,0 +1,5 @@
+define host {
+    name    bla
+    use     bla
+    register 0
+}


### PR DESCRIPTION
+ Prevent infinite recursion (and so crash) if a template use itself -> configuration error.
+ Report (at leasta ) configuration warning if an item use an unknown template.