### PR TITLE
Disable SSLv3 for CherryPy backend

### DIFF
--- a/shinken/http_daemon.py
+++ b/shinken/http_daemon.py
@@ -42,6 +42,19 @@ try:
     from cherrypy import wsgiserver as cheery_wsgiserver
 except ImportError:
     cheery_wsgiserver = None
+try:
+    from OpenSSL import SSL
+    from cherrypy.wsgiserver.ssl_pyopenssl import pyOpenSSLAdapter
+    # Create 'safe' SSL adapter by disabling SSLv2/SSLv3 connections
+    class pyOpenSSLAdapterSafe(pyOpenSSLAdapter):
+        def get_context(self):
+            c = pyOpenSSLAdapter.get_context(self)
+            c.set_options(SSL.OP_NO_SSLv2 |
+                          SSL.OP_NO_SSLv3)
+            return c
+except ImportError:
+    SSL = None
+    pyOpenSSLAdapterSafe = None
 
 from wsgiref import simple_server
 
@@ -76,7 +89,8 @@ class CherryPyServer(bottle.ServerAdapter):
         ca_cert = self.options['ca_cert']
         ssl_cert = self.options['ssl_cert']
         ssl_key = self.options['ssl_key']
-
+        if SSL and pyOpenSSLAdapterSafe and use_ssl:
+            server.ssl_adapter = pyOpenSSLAdapterSafe(ssl_cert, ssl_key, ca_cert)
         if use_ssl:
             server.ssl_certificate = ssl_cert
             server.ssl_private_key = ssl_key

--- a/test/etc/test_sslv3_disabled/arbiter-master.cfg
+++ b/test/etc/test_sslv3_disabled/arbiter-master.cfg
@@ -1,0 +1,49 @@
+#===============================================================================
+# ARBITER
+#===============================================================================
+# Description: The Arbiter is responsible for:
+# - Loading, manipulating and dispatching the configuration
+# - Validating the health of all other Shinken daemons
+# - Issuing global directives to Shinken daemons (kill, activate-spare, etc.)
+# http://www.shinken-monitoring.org/wiki/official/configuringshinken/configobjects/arbiter
+#===============================================================================
+# IMPORTANT: If you use several arbiters you MUST set the host_name on each
+# servers to its real DNS name ('hostname' command).
+#===============================================================================
+define arbiter {
+    arbiter_name    arbiter-master
+    #host_name       node1       ; CHANGE THIS if you have several Arbiters
+    address         localhost   ; DNS name or IP
+    port            9997
+    spare           0           ; 1 = is a spare, 0 = is not a spare
+
+    ## Interesting modules:
+    # - CommandFile             = Open the named pipe shinken.cmd
+    # - Mongodb                 = Load hosts from a mongodb database
+    # - PickleRetentionArbiter  = Save data before exiting
+    # - NSCA                    = NSCA server
+    # - VMWare_auto_linking     = Lookup at Vphere server for dependencies
+    # - GLPI                    = Import hosts from GLPI
+    # - TSCA                    = TSCA server
+    # - MySQLImport             = Load configuration from a MySQL database
+    # - WS_Arbiter              = WebService for pushing results to the arbiter
+    # - Collectd                = Receive collectd perfdata
+    # - SnmpBooster             = Snmp bulk polling module, configuration linker
+    # - Landscape		= Import hosts from Landscape (Ubuntu/Canonical management tool)
+    # - AWS			= Import hosts from Amazon AWS (here EC2)
+    # - IpTag			= Tag an host based on it's IP range
+    # - FileTag			= Tag an host if it's on a flat file
+    # - CSVTag			= Tag an host from the content of a CSV file
+
+    modules    	 
+    #modules     CommandFile, Mongodb, NSCA, VMWare_auto_linking, WS_Arbiter, Collectd, Landscape, SnmpBooster, AWS
+
+    use_ssl	     1
+
+    ## Uncomment these lines in a HA architecture so the master and slaves know
+    ## how long they may wait for each other.
+    #timeout              3   ; Ping timeout
+    #data_timeout         120 ; Data send timeout
+    #max_check_attempts   3   ; If ping fails N or more, then the node is dead
+    #check_interval       60  ; Ping node every N seconds
+}

--- a/test/etc/test_sslv3_disabled/reactionner-master.cfg
+++ b/test/etc/test_sslv3_disabled/reactionner-master.cfg
@@ -1,0 +1,40 @@
+#===============================================================================
+# REACTIONNER (S1_Reactionner)
+#===============================================================================
+# Description: The reactionner is responsible for:
+# - Executing notification actions
+# - Executing event handler actions
+# https://shinken.readthedocs.org/en/latest/08_configobjects/reactionner.html
+#===============================================================================
+define reactionner {
+    reactionner_name    reactionner-master
+    address             localhost
+    port                7769
+    spare               0
+
+    ## Optionnal
+    manage_sub_realms   0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers         1   ; Starts with N processes (0 = 1 per CPU)
+    max_workers         15  ; No more than N processes (0 = 1 per CPU)
+    polling_interval    1   ; Get jobs from schedulers each 1 second
+    timeout             3   ; Ping timeout
+    data_timeout        120 ; Data send timeout
+    max_check_attempts  3   ; If ping fails N or more, then the node is dead
+    check_interval      60  ; Ping node every N seconds
+    passive             1
+
+    ## Modules
+    modules     
+
+    # Reactionner tags are the tag that the reactionner will manage. Use None as tag name to manage
+    # untaggued notification/event handlers
+    #reactionner_tags     None
+
+    # Enable https or not
+    use_ssl	          1
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check   0
+
+    ## Advanced
+    realm   All
+}

--- a/test/etc/test_sslv3_disabled/scheduler-master.cfg
+++ b/test/etc/test_sslv3_disabled/scheduler-master.cfg
@@ -1,0 +1,50 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# http://www.shinken-monitoring.org/wiki/official/configuringshinken/configobjects/scheduler
+#===============================================================================
+define scheduler {
+    scheduler_name      scheduler-master ; Just the name
+    address             localhost   ; IP or DNS address of the daemon
+    port                9998        ; TCP port of the daemon
+    ## Optional
+    spare               0   ; 1 = is a spare, 0 = is not a spare
+    weight              1   ; Some schedulers can manage more hosts than others
+    timeout             3   ; Ping timeout
+    data_timeout        120 ; Data send timeout
+    max_check_attempts  3   ; If ping fails N or more, then the node is dead
+    check_interval      60  ; Ping node every N seconds
+
+    ## Interesting modules that can be used:
+    # - PickleRetention     = Save data before exiting in flat-file
+    # - MemcacheRetention   = Same, but in a MemCache server
+    # - RedisRetention      = Same, but in a Redis server
+    # - MongodbRetention    = Same, but in a MongoDB server
+    # - NagiosRetention     = Read retention info from a Nagios retention file
+    #                         (does not save, only read)
+    # - SnmpBooster             = Snmp bulk polling module
+    modules   
+
+    ## Advanced Features
+    # Realm is for multi-datacenters
+    realm   All
+
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it!
+    skip_initial_broks  0
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:1772, reactionner-1=1.2.3.5:1773, ...
+
+    use_ssl	     1
+}

--- a/test/etc/test_sslv3_disabled/schedulerd.ini
+++ b/test/etc/test_sslv3_disabled/schedulerd.ini
@@ -1,0 +1,37 @@
+[daemon]
+
+# The daemon will chdir into the directory workdir when launched
+workdir = .
+logdir  = .
+
+pidfile=%(workdir)s/schedulerd.pid
+
+port=9998
+#host=0.0.0.0
+#user=shinken
+#group=shinken
+idontcareaboutsecurity=0
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+# Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+#-- SSL configuration --
+#-- WARNING : SSL is currently only available under Pyro3 version, not Pyro4 --
+use_ssl=1
+ca_cert=../etc/certs/ca.pem
+server_cert=../etc/certs/server.cert
+server_key=../etc/certs/server.key
+hard_ssl_name_check=0
+http_backend=auto
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=%(logdir)s/schedulerd.log
+
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING

--- a/test/etc/test_sslv3_disabled/shinken.cfg
+++ b/test/etc/test_sslv3_disabled/shinken.cfg
@@ -1,0 +1,127 @@
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+cfg_file=../core/commands.cfg
+cfg_file=../core/timeperiods.cfg
+#cfg_file=../core/escalations.cfg
+#cfg_file=../core/dependencies.cfg
+cfg_file=../core/contacts.cfg
+
+# Now templates of hosts, services and contacts
+cfg_file=../core/templates.cfg
+cfg_file=../core/time_templates.cfg
+cfg_file=arbiter-master.cfg
+cfg_file=scheduler-master.cfg
+cfg_file=reactionner-master.cfg
+# Now groups
+cfg_file=../core/servicegroups.cfg
+cfg_file=../core/hostgroups.cfg
+cfg_file=../core/contactgroups.cfg
+
+# And now real hosts, services, packs and discovered hosts
+# They are directory, and we will load all .cfg file into them, and 
+# their sub-directory
+cfg_dir=../core/hosts
+cfg_dir=../core/services
+#cfg_dir=../core/packs
+#cfg_dir=../core/objects/discovery
+#cfg_dir=../core/modules
+
+#cfg_dir=../core/arbiters
+#cfg_dir=../core/schedulers
+cfg_dir=../core/pollers
+#cfg_dir=../core/reactionners
+cfg_dir=../core/brokers
+cfg_dir=../core/receivers
+cfg_dir=../core/realms
+
+# You will find global MACROS into this file
+#resource_file=resource.cfg
+
+# The path to the modules directory
+modules_dir=/var/lib/shinken/modules
+
+# Number of minutes between 2 retention save, here 1hour
+retention_update_interval=60
+
+# Number of interval (5min by default) to spread the first checks
+# for hosts and services
+max_service_check_spread=5
+max_host_check_spread=5
+
+# after 10s, checks are killed and exit with CRITICAL state (RIP)
+service_check_timeout=10
+
+
+# flap_history is the lengh of history states we keep to look for
+# flapping.
+# 20 by default, can be useful to increase it. Each flap_history
+# increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+flap_history=20
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+max_plugins_output_length=65536
+
+
+# Enable or not the state change on impact detection (like
+# an host going unreach if a parent is DOWN for example). It's for
+# services and hosts.
+# Remark: if this option is absent, the default is 0 (for Nagios
+# old behavior compatibility)
+enable_problem_impacts_states_change=1
+
+
+# Lock file (with pid) for Arbiterd
+lock_file=tmp/arbiterd.pid
+workdir=tmp/
+
+# if 1, disable all notice and warning messages at
+# configuration checking
+disable_old_nagios_parameters_whining=0
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=FR/Paris
+
+# Disabling env macros is good for performances. If you really need it, enable it.
+enable_environment_macros=0
+
+# If not need, don't dump initial states into logs
+log_initial_states=0
+
+# User that will be used by the arbiter.
+# If commented, run as current user (root?)
+#shinken_user=shinken
+#shinken_group=shinken
+
+
+
+#-- Security using SSL --
+# Only enabled when used with Pyro3
+use_ssl=1
+# WARNING : Put full paths for certs
+ca_cert=../../etc/certs/ca.pem
+server_cert=../../etc/certs/server.cert
+server_key=../../etc/certs/server.key
+hard_ssl_name_check=0
+http_backend=auto
+
+# The arbiter can have it's own local log
+local_log=/dev/null
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default N4G105 behavior
+no_event_handlers_during_downtimes=1
+
+
+# [Optionnal], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=pack_distribution.dat
+
+
+# Set to 0 if you want to make this daemon (arbiter) NOT run
+daemon_enabled=1
+

--- a/test/test_sslv3_disabled.py
+++ b/test/test_sslv3_disabled.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Copyright (C) 2009-2014:
+#    Gabes Jean, naparuba@gmail.com
+#    Gerhard Lausser, Gerhard.Lausser@consol.de
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# This test checks that sslv3 is disabled when SSL is used with a cherrypy backend to secure against the Poodle vulnerability (https://poodlebleed.com)
+
+import subprocess
+from time import sleep
+
+import httplib
+import ssl
+try:
+    import OpenSSL
+except ImportError:
+    OpenSSL = None
+from shinken_test import *
+
+import shinken.log as shinken_log
+
+from shinken.daemons.schedulerdaemon import Shinken
+from shinken.daemons.arbiterdaemon import Arbiter
+
+daemons_config = {
+    Shinken:      "etc/test_sslv3_disabled/schedulerd.ini",
+    Arbiter:    ["etc/test_sslv3_disabled/shinken.cfg"]
+}
+
+
+class testSchedulerInit(ShinkenTest):
+    def setUp(self):
+        time_hacker.set_real_time()
+
+    def create_daemon(self):
+        cls = Shinken
+        return cls(daemons_config[cls], False, True, False, None, '')
+    @unittest.skipIf(OpenSSL is None, "Test requires OpenSSL")
+    def test_scheduler_init(self):
+
+        shinken_log.local_log = None  # otherwise get some "trashs" logs..
+        d = self.create_daemon()
+
+        d.load_config_file()
+
+        d.http_backend = 'cherrypy'
+        d.do_daemon_init_and_start(fake=True)
+        d.load_modules_manager()
+
+        # Launch an arbiter so that the scheduler get a conf and init
+        subprocess.Popen(["../bin/shinken-arbiter", "-c", daemons_config[Arbiter][0], "-d"])
+        ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv3)
+        ctx.check_hostname=False
+        ctx.verify_mode=ssl.CERT_NONE
+        self.conn = httplib.HTTPSConnection("localhost:9998",context=ctx)
+        self.assertRaises(ssl.SSLError,self.conn.connect)
+        try:
+            self.conn.connect()
+        except ssl.SSLError as e:
+            assert e.reason == 'SSLV3_ALERT_HANDSHAKE_FAILURE'
+        sleep(2)
+        pid = int(file("tmp/arbiterd.pid").read())
+        print ("KILLING %d" % pid)*50
+        os.kill(int(file("tmp/arbiterd.pid").read()), 2)
+        d.do_stop()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Takes care of Poodle (https://www.poodlescan.com/) when SSL is used with cherrypy.
My instance was even allowing SSLv2, but that might be a Debian Wheezy issue.
Happy to clean / improve code further based on suggestions.