### PR TITLE
Jenkins and python26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pycurl
+importlib

--- a/shinken/dependencies
+++ b/shinken/dependencies
@@ -1,4 +1,0 @@
-python >= 2.6
-pycurl
-importlib
-mock  # only used for livestatus test

--- a/test/jenkins/new_runtest.sh
+++ b/test/jenkins/new_runtest.sh
@@ -19,14 +19,54 @@
 #along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
 
+#############################################################################
+#
+# the following env variables can be used
+# to configure this script behavior:
+#
+# JENKINS_PYTHON : set the path to the python interpreter you want to use
+#                  default to system one (which python)
+# SKIP_CORE : if == 1 then will skip the core tests.
+# FAILFAST : if == 1 then will failfast
+# DEBUG_BASH_SCRIPT : if == 1 then will activate more debug of this script
+#
+#############################################################################
 
 
+
+enable_debug() {
+    test "$DEBUG_BASH_SCRIPT" = "1" && set -x
+}
+disable_debug() {
+    set +x
+}
+
+cat << END
+========================================
++ Launched from: $PWD
++ datetime: $(date)
++ argv[0]: $0
++ argv[*]: $@
+* environ: $(env)
+========================================
+END
+
+
+enable_debug
 
 
 MODULELIST=$(readlink -f $2)
 COVERAGE=$3
 PYLINT=$4
 PEP8=$5
+
+# NB:
+# if env variable JENKINS_PYTHON is defined then that's the python
+# that'll be used for setting up with the virtualenv.
+
+test "$JENKINS_PYTHON" || JENKINS_PYTHON=$(which python)
+PY_VERSION=$("$JENKINS_PYTHON" -c "import sys; print('.'.join(map(str, sys.version_info[:3])))")
+SHORT_PY_VERSION=$("$JENKINS_PYTHON" -c "import sys; print(''.join(map(str, sys.version_info[:2])))")
 
 if test "$6"
 then
@@ -50,6 +90,7 @@ SHINKENDIR=$(readlink -f "$DIR/../..")
 RESULTSDIR="results"
 SHINKENCLI=$SHINKENDIR/bin/shinken
 
+
 #Check virtualenv, pip and nosetests
 function check_req {
     if [[ "$(which virtualenv)" == "" ]];then
@@ -68,101 +109,195 @@ function check_req {
 # If the reqs match the previous, copy the previous environment
 # Otherwise, create a new one, calc the hash and before going anywhere, copy it under here.
 function prepare_environment {
+    local virtualenv_args="-p $JENKINS_PYTHON"
 
-    HASH=$(cat requirements.tests.freeze|md5sum|cut -d' ' -f1)
-    if [ -e last_env_hash ]; then
-        OLDHASH=$(cat last_env_hash)
+    local all_requirements_inputs="requirements.txt ../requirements.txt ../../requirements.txt"
+    local all_requirements
+
+    # order is important !
+    for f in $all_requirements_inputs
+    do
+    	all_requirements="$all_requirements $DIR/$f"
+    done
+    # now look for specific requirements for this python version:
+    for dir in . .. ../..
+    do
+        f="$DIR/$dir/requirements.py${SHORT_PY_VERSION}.txt"
+        test -f "$f" && all_requirements="$all_requirements $f"
+    done
+
+    HASH=$(cat $all_requirements | md5sum | cut -d' ' -f1)
+    if [ -e last_env_hash_${PY_VERSION} -a -f "last_env${PY_VERSION}/bin/activate" ]
+    then
+        OLDHASH=$(cat last_env_hash_${PY_VERSION})
     else
         OLDHASH=""
     fi
 
-    echo $HASH > last_env_hash
-
-    echo OLD REQS HASH AND NEW REQS HASH: $OLDHASH $HASH
-
+    echo "OLD REQS HASH AND NEW REQS HASH: $OLDHASH vs $HASH"
 
     # Cache the environment if it hasn't changed.
     if [ "$OLDHASH" != "$HASH" ]; then
         echo "ENVIRONMENT SPECS CHANGED - CREATING A NEW ENVIRONMENT"
-        virtualenv --distribute env
-        . env/bin/activate
-        pip install --upgrade pip
-        pip install -r requirements.tests.freeze
-        rm -rf last_env
-        cp -ar env last_env
+        rm -rf "env${PY_VERSION}" || true
+        virtualenv --distribute $virtualenv_args env${PY_VERSION}
+        . env${PY_VERSION}/bin/activate || {
+            echo "Failed to activate the fresh env !"
+            rm -rf "env${PY_VERSION}/" || true
+            return 3
+        }
+        pip install --upgrade pip || {
+            echo "Failed upgrading pip ! Trying to continue.."
+        }
+        for req in $all_requirements
+        do
+            pip install --upgrade -r $req || {
+                echo "Failed upgrading $req .."
+                return 2
+            }
+        done
     else
         echo "ENVIRONMENT SPECS HAVE NOT CHANGED - USING CACHED ENVIRONMENT"
-        cp -ar last_env env
-        . env/bin/activate
+        . env${PY_VERSION}/bin/activate || {
+            echo "FAILED to activate the virtualenv !"
+            rm -rf "last_env${PY_VERSION}" "env${PY_VERSION}"
+            return 2
+        }
     fi
 
-    pip install -e $SHINKENDIR
     echo "Done Installing"
+    echo $HASH > last_env_hash_${PY_VERSION}
 }
 
 
 # Launch the given test with nose test. Nose test has a different behavior than the standard unit test.
 function launch_and_assert {
+    local res
     SCRIPT=$1
     NAME=$(echo $(basename $SCRIPT) | sed s/\\.py$//g | tr [a-z] [A-Z])
+    cat << END
+-------------------------------
+-> launch_and_assert $SCRIPT
+-> pwd=$PWD
+-------------------------------
+END
+    local start=$(date +%s)
     if test $COVERAGE == "NOCOVERAGE"; then
       ${PYTHONTOOLS}/nosetests -v -s --with-xunit ./$SCRIPT --xunit-file="$RESULTSDIR/xml/$NAME.xml"
+      res=$?
     else
       ${PYTHONTOOLS}/nosetests -v -s --with-xunit --with-coverage ./$SCRIPT --xunit-file="$RESULTSDIR/xml/$NAME.xml"
+      res=$?
       mv .coverage .coverage.$COUNT
       COUNT=$((COUNT + 1))
     fi
-    if [ $? != 0 ]
-        then
+    local stop=$(date +%s)
+    local duration="$((( $stop-$start ) / 60)):$((( $stop - $start ) % 60))"
+    cat << END
+-----------------------------------------
+-> launch_and_assert $SCRIPT finished with result=$res runtime=$duration
+END
+    if [ $res != 0 ]
+    then
         echo "Error: the test $SCRIPT failed"
         return 2
     else
         echo "test $SCRIPT succeeded, next one"
     fi
+    echo -----------------------------------------
+    return $res
 }
 
 
-# Put into a file the test list
-function generate_all_tests {
-    echo "#All tests in the tests directory are listed below" >  $DIR/all_tests.txt
-    echo "#### AUTOGENERATED ####" >> $DIR/all_tests.txt
-
-    for file in test_*.py; do
-        echo "$file" >>  $DIR/all_tests.txt
+function test_core {
+    # REGEXPCMD is ; or grep -v blabla
+    # If ;, we are in normal mode
+    if test "$SKIP_CORE" = "1"
+    then
+        echo "SKIP_CORE is set, skipping core tests"
+        return 0
+    fi
+    for test in $(eval "ls test_*.py $REGEXPCMD")
+    do
+        launch_and_assert $test
+        test $? -eq 0 || {
+            cat << END
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~ A core test failed : $test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+END
+            test "$FAILFAST" = "1" && return 1
+        }
     done
 }
 
 
 # Must be in repos/test before launching
 function grab_modules {
+    local mod_requirements
+    cat << END
+==============================================================
+= Grabbing modules ($(cat $MODULELIST)) ..
+==============================================================
+END
+
+    rm modules/* || true # first clean out everything of modules subdir
     GIT_URL="https://github.com/shinken-monitoring"
-    for module in $(cat $MODULELIST); do
+    for module in $(cat $MODULELIST)
+    do
+        cat << END
+===> Grab $module ..
+END
         git clone $GIT_URL/$module.git tmp/$module
-        $SHINKENCLI install --local tmp/$module > /dev/null
-        cp __import_shinken.py shinken_test.py shinken_modules.py tmp/$module/test
+
+        # $SHINKENCLI install --local tmp/$module > /dev/null
+        # cp __import_shinken.py shinken_test.py shinken_modules.py tmp/$module/test
+
         # Symlink of config files to etc
         if [ -d "tmp/$module/test/etc" ]; then
             for conf_file in tmp/$module/test/etc/*; do
                ln -s ../$conf_file etc/
             done
         fi
-    done
-    # DIRTY HACK TO REMOVE
-    cp tmp/mod-livestatus/test/mock_livestatus.py tmp/mod-logstore-sqlite/test
-    cp tmp/mod-livestatus/test/mock_livestatus.py tmp/mod-logstore-mongodb/test
 
+        # symlink to the test "modules" directory:
+        ( cd modules && ln -s ../tmp/$module/module ${module/mod-/} )
+
+        mod_requirements="tmp/$module/test/requirements.txt"
+        test -f "${mod_requirements}" && pip install -r "${mod_requirements}"
+    done
+    # mod-logstore-mongodb and sqlite
+    # depends on mock_livestatus from mod-livestatus, so we need to copy it (here in shinken/test)
+    # so it's available to them
+    cp tmp/mod-livestatus/test/mock_livestatus.py ./
+
+    cat << END
+==============================================================
+== ALL GRAB DONE
+==============================================================
+END
 }
 
 
 function test_modules {
-    for line in $(grep -vE "#|^ *$" $MODULELIST);do
-        if [ -d "tmp/$line/test/" ]; then
-            for ptest in $(eval "ls tmp/$line/test/test_*.py $REGEXPCMD");do
+    for mod in $(grep -vE "#|^ *$" $MODULELIST)
+    do
+        if [ -d "tmp/$mod/test/" ]
+        then
+            cat << END
+~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=
+~= Launching module $mod tests ..
+~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=
+END
+            for ptest in $(eval "ls tmp/$mod/test/test_*.py $REGEXPCMD");do
                 launch_and_assert $ptest
-                test $? -eq 0 || echo "A test failed : $ptest"
+                test $? -eq 0 || {
+                    echo  "A module ($mod) failed : $ptest"
+                    test "$FAILFAST" = "1" && return 1
+                }
             done
-        else :
-            echo "No tests found for $line. Skipping"
+        else
+            echo "No tests found for $mod. Skipping"
         fi
     done
 }
@@ -170,55 +305,83 @@ function test_modules {
 function test_core {
     # REGEXPCMD is ; or grep -v blabla
     # If ;, we are in normal mode
-    for test in $(eval "ls test_*.py $REGEXPCMD") ;do
+    for test in $(eval "ls test_*.py $REGEXPCMD")
+    do
         launch_and_assert $test
-        test $? -eq 0 || echo "A test failed : $line"
+        test $? -eq 0 || {
+            echo "A test failed : $test"
+            test "$FAILFAST" = "1" && return 1
+        }
     done
 }
 
 function main {
 
+    local tests_rc
+
+    export PYTHONPATH=$PYTHONPATH:$SHINKENDIR
+
+    enable_debug
+
     check_req
 
     cd ${DIR}
 
-    prepare_environment
-
-    . env/bin/activate
+    prepare_environment || {
+        echo "prepare_environment failed ; exiting.."
+        exit 2
+    }
     PYTHONBIN="python"
     PYTHONTOOLS=$(dirname $(which $PYTHONBIN))
     echo "PYTHONTOOLS=$PYTHONTOOLS"
-    # We should be into /path/to/shinken/test/
-    cd ..
+
+    cd .. # We should now be into /path/to/shinken/test/
 
     if [[ ! -d "$RESULTSDIR" ]]; then
-        mkdir -p $RESULTSDIR
         echo "Creation dir $RESULTSDIR"
+        mkdir -p $RESULTSDIR || return 2
     fi
 
     for dir in "xml" "htmlcov"; do
         if [[ ! -d "$RESULTSDIR/$dir" ]]; then
-            mkdir $RESULTSDIR/$dir
+            mkdir $RESULTSDIR/$dir || return 2
         fi
     done
 
     # Cleanup leftover files from former runs
     rm -f "$RESULTSDIR/xml/nosetests.xml"
-    test $COVERAGE == "COVERAGE" && rm -f "$RESULTSDIR/xml/*"
-    test $COVERAGE == "COVERAGE" && rm -f "$RESULTSDIR/htmlcov/*"
-    test $COVERAGE == "COVERAGE" && rm -f ".coverage*"
+    test $COVERAGE == "COVERAGE" && {
+        rm -f "$RESULTSDIR/xml/*"
+        rm -f "$RESULTSDIR/htmlcov/*"
+        rm -f ".coverage*"
+    }
     rm -rf tmp/*
     # Clean previous symlinks
     find etc/ -maxdepth 1 -type l -exec rm {} \;
-    ln -s /var/lib/shinken/modules tmp/modules
-
-    generate_all_tests
 
     # Init Count for coverage
     COUNT=1
-    test_core
-    grab_modules
-    test_modules
+
+    do_tests() {
+        local is_branch_1=$IS_BRANCH_1
+        test_core || return 2
+        test "$is_branch_1" || {
+            is_branch_1=$(git describe --long)
+            if test "1" = "${is_branch_1/\.*/}"
+            then
+                is_branch_1=1
+            else
+                is_branch_1=0
+            fi
+        }
+        # on old branch 1.* modules are included in shinken,
+        # so no need to bother with them in such case:
+        test "$is_branch_1" = "1" && return 0
+        grab_modules || return 2
+        test_modules
+    }
+    do_tests
+    tests_rc=$?
 
     # Create the coverage file
     if [[ $COVERAGE == "COVERAGE" ]]; then
@@ -245,12 +408,13 @@ function main {
     if [[ $COVERAGE == "COVERAGE" && $PYLINT == "PYLINT" ]]; then
         # this run's purpose was to collect metrics, so let jenkins think, it's ok
         # Compile coverage info.
-        #coverage combine
-        #coverage xml
+        coverage combine
+        coverage xml
         return 0
     fi
+
+    return $tests_rc
 }
 
 
 main
-exit $?

--- a/test/jenkins/requirements.txt
+++ b/test/jenkins/requirements.txt
@@ -1,0 +1,2 @@
+# this is the requirements dedicated to Jenkins (or nose+coverage) tests !
+-r ../requirements.txt

--- a/test/modules
+++ b/test/modules
@@ -1,1 +1,0 @@
-/var/lib/shinken/modules

--- a/test/requirements.py26.txt
+++ b/test/requirements.py26.txt
@@ -1,0 +1,13 @@
+# some packages need to be kept as specific version for
+
+# actually don't link with "normal" one as pip otherwise report conflicting package versions.
+# -r ./requirements.txt
+
+# for pylint to succeed with Python2.6 , we actually need all these specific versions:
+pylint==1.3.1
+astroid==1.2.1
+six==1.4.0
+unittest2==0.5.1
+
+# endfor pytlint
+

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,10 @@
 # this is the requirements dedicated to tests.
-
+-r ../requirements.txt
 unittest2
 mock
-coveralls
-nose-cov
+coveralls==0.5
+nose-cov==1.6
+coverage==3.7.1
+nose==1.3.4
+pylint==1.4.1
 pep8==1.5.7

--- a/test/setup_test.sh
+++ b/test/setup_test.sh
@@ -8,5 +8,4 @@ BASE_PATH=$(dirname "$THIS_PATH")
 cd $BASE_PATH
 
 # install prog AND tests requirements :
-pip install -r shinken/dependencies
 pip install -r test/requirements.txt

--- a/test/shinken_test.py
+++ b/test/shinken_test.py
@@ -58,12 +58,8 @@ from logging import ERROR
 # Modules are by default on the ../modules
 myself = os.path.abspath(__file__)
 
-global modules_dir
-modules_dir = "modules"
+modules_dir = os.environ.get('SHINKEN_MODULES_DIR', "modules")
 
-def define_modules_dir(val):
-    global modules_dir
-    modules_dir = val
 
 class __DUMMY:
     def add(self, obj):

--- a/test/test_modulemanager.py
+++ b/test/test_modulemanager.py
@@ -22,10 +22,18 @@
 # This file is used to test reading and processing of config files
 #
 
-from shinken_test import *
+import os
+import time
 
-time_hacker.set_real_time()
+from shinken.modulesmanager import ModulesManager
+from shinken.objects.module import Module
 
+from shinken_test import (
+    ShinkenTest, time_hacker, unittest
+)
+
+
+modules_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'modules')
 
 class TestModuleManager(ShinkenTest):
     def setUp(self):

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -23,10 +23,13 @@ Test shinken.property
 """
 
 
-import shinken
+import __import_shinken
 
+import shinken
 from shinken.property import none_object
+
 from shinken_test import ShinkenTest, unittest
+
 
 
 class PropertyTests:


### PR DESCRIPTION
Mainly : made jenkins dedicated new_runtest.sh script now successfully pass the tests on python2.6 as well as on 2.7 and with "short" as well as "long" tests.

NB: there are still room for this script to be cleaned further but at least now it's (more) stable.

the other most important change is probably:
+ use "requirements.txt" files on shinken level, shinken/test, and shinken/test/jenkins.  ( instead of not common/usual "dependencies" or so ).
+ same for eventual python version specific requirements (requirements.py26.txt or requirements.py27.txt).

otherwise it's fix of some of the tests.
