### PR TITLE
Fix memory leak in default shinken file generation

### DIFF
--- a/setuppackage.py
+++ b/setuppackage.py
@@ -228,7 +228,7 @@ class build_config(Command):
             # Read the template file
             f = open(templatefile)
             buf = f.read()
-            f.close
+            f.close()
             # substitute
             buf = buf.replace("$ETC$", self.etc_path)
             buf = buf.replace("$VAR$", self.var_path)


### PR DESCRIPTION
The first file is never closed, which means that the memory is never freed (until the gc runs).