### PR TITLE
Enh http daemon overall throughput

### DIFF
--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -696,7 +696,7 @@ class Daemon(object):
         self.http_daemon = HTTPDaemon(self.host, self.port, http_backend,
                                       use_ssl, ca_cert, ssl_key,
                                       ssl_cert, ssl_conf.hard_ssl_name_check,
-                                      self.daemon_thread_pool_size)
+                                      self.daemon_thread_pool_size, self)
         # TODO: fix this "hack" :
         shinken.http_daemon.daemon_inst = self.http_daemon
 


### PR DESCRIPTION
Enh: (WSGI)http_daemon: don't create a fresh new thread for each http request
    
Actually use an hard-coded value as max number of connections/requests to process per client thread.
Higher value (eventually infinite) could also be used.
    
this doesn't change anything but prevent from having to spawn a new thread on each new http connection.
    
As there are quite a lot of http connections/requests between the shinken daemons this could eventually lower the overall system load.