### PR TITLE
tests: clean: Don't reset uselessly Scheduler.sched instance.

### DIFF
--- a/test/shinken_test.py
+++ b/test/shinken_test.py
@@ -234,9 +234,8 @@ class ShinkenTest(unittest.TestCase):
         self.dispatcher = Dispatcher(self.conf, self.me)
 
         scheddaemon = Shinken(None, False, False, False, None, None)
-        self.sched = Scheduler(scheddaemon)
-
-        scheddaemon.sched = self.sched
+        self.scheddaemon = scheddaemon
+        self.sched = scheddaemon.sched
         scheddaemon.modules_dir = modules_dir
         scheddaemon.load_modules_manager()
         # Remember to clean the logs we just created before launching tests


### PR DESCRIPTION
```
Scheduler(..)
```

is already instantiated within Shinken.\_\_init__() and linked to that Shinken' self instance: https://github.com/naparuba/shinken/blob/master/shinken/daemons/schedulerdaemon.py#L230

so I don't know why this was originally done but what I can say is that it looks awful :p 
( I'm quite astonished that this has not break some test, ouf ^^ )