### PR TITLE
Enh/Fix: restore Service.display_name previous behavior

### DIFF
--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -556,6 +556,17 @@ class Service(SchedulingItem):
     def unique_key(self):  # actually only used for (un)indexitem() via name_property..
         return (self.host_name, self.service_description)
 
+    @property
+    def display_name(self):
+        display_name = getattr(self, '_display_name', None)
+        if not display_name:
+            return self.service_description
+        return display_name
+
+    @display_name.setter
+    def display_name(self, display_name):
+        self._display_name = display_name
+
     # Give a nice name output
     def get_name(self):
         if hasattr(self, 'service_description'):

--- a/test/test_services.py
+++ b/test/test_services.py
@@ -110,7 +110,7 @@ class TestService(ShinkenTest):
         svc = self.get_svc()
         print 'Display name', svc.display_name, 'toto'
         print 'Full name', svc.get_full_name()
-        self.assertEqual((u'test_host_0', u'test_ok_0'), svc.display_name)
+        self.assertEqual(u'test_ok_0', svc.display_name)
 
     def test_states_from_exit_status(self):
         svc = self.get_svc()


### PR DESCRIPTION
That is: if a Service.display_name is not explicitly set/configured,
then return service_description.

display_name is obviously better to always be a str instance, nothing else.

This had side-effect (on livestatus already) since https://github.com/naparuba/shinken/pull/1480,
see for instance: https://travis-ci.org/shinken-monitoring/mod-livestatus/jobs/50215670

I'm assuming the tests will pass.. :o