### PR TITLE
Revert "Enh: converted last old style classes to newstyle"

### DIFF
--- a/shinken/acknowledge.py
+++ b/shinken/acknowledge.py
@@ -24,7 +24,7 @@
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class Acknowledge(object):
+class Acknowledge:
     """
     Allows you to acknowledge the current problem for the specified service.
     By acknowledging the current problem, future notifications (for the same

--- a/shinken/basemodule.py
+++ b/shinken/basemodule.py
@@ -64,7 +64,7 @@ properties = {
 }
 
 
-class ModulePhases(object):
+class ModulePhases:
     """TODO: Add some comment about this class for the doc"""
     # TODO: why not use simply integers instead of string
     # to represent the different phases??

--- a/shinken/brok.py
+++ b/shinken/brok.py
@@ -25,7 +25,7 @@
 import cPickle
 
 
-class Brok(object):
+class Brok:
     """A Brok is a piece of information exported by Shinken to the Broker.
     Broker can do whatever he wants with it.
     """

--- a/shinken/clients/livestatus.py
+++ b/shinken/clients/livestatus.py
@@ -25,10 +25,10 @@
 
 import socket
 import asyncore
-from shinken.log import logger
+from log import logger
 
 
-class LSSyncConnection(object):
+class LSSyncConnection:
     def __init__(self, addr='127.0.0.1', port=50000, path=None, timeout=10):
         self.addr = addr
         self.port = port

--- a/shinken/comment.py
+++ b/shinken/comment.py
@@ -26,7 +26,7 @@
 import time
 
 """ TODO: Add some comment about this class for the doc"""
-class Comment(object):
+class Comment:
     id = 1
 
     properties = {

--- a/shinken/contactdowntime.py
+++ b/shinken/contactdowntime.py
@@ -27,7 +27,7 @@ import time
 from shinken.log import logger
 
 """ TODO: Add some comment about this class for the doc"""
-class ContactDowntime(object):
+class ContactDowntime:
     id = 1
 
     # Just to list the properties we will send as pickle

--- a/shinken/discovery/discoverymanager.py
+++ b/shinken/discovery/discoverymanager.py
@@ -307,7 +307,7 @@ class DiscoveredHost(object):
         self.read_disco_buf(raw_disco_data)
 
 
-class DiscoveryManager(object):
+class DiscoveryManager:
     def __init__(self, path, macros, overwrite, runners, output_dir=None,
                  dbmod='', db_direct_insert=False, only_new_hosts=False,
                  backend=None, modules_path='', merge=False, conf=None, first_level_only=False):

--- a/shinken/dispatcher.py
+++ b/shinken/dispatcher.py
@@ -41,7 +41,7 @@ random.seed()
 
 
 # Dispatcher Class
-class Dispatcher(object):
+class Dispatcher:
 
     # Load all elements, set them as not assigned
     # and add them to elements, so loop will be easier :)

--- a/shinken/downtime.py
+++ b/shinken/downtime.py
@@ -41,7 +41,7 @@ from shinken.log import logger
  specified service should not be triggered by another downtime entry.
 
 """
-class Downtime(object):
+class Downtime:
     id = 1
 
     # Just to list the properties we will send as pickle

--- a/shinken/external_command.py
+++ b/shinken/external_command.py
@@ -40,7 +40,7 @@ from shinken.misc.common import DICT_MODATTR
 
 
 """ TODO: Add some comment about this class for the doc"""
-class ExternalCommand(object):
+class ExternalCommand:
     my_type = 'externalcommand'
 
     def __init__(self, cmd_line):
@@ -48,7 +48,7 @@ class ExternalCommand(object):
 
 
 """ TODO: Add some comment about this class for the doc"""
-class ExternalCommandManager(object):
+class ExternalCommandManager:
 
     commands = {
         'CHANGE_CONTACT_MODSATTR':

--- a/shinken/graph.py
+++ b/shinken/graph.py
@@ -24,7 +24,7 @@
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class Graph(object):
+class Graph:
     """Graph is a class to make graph things like DFS checks or accessibility
     Why use an atomic bomb when a little hammer is enough?
 

--- a/shinken/http_client.py
+++ b/shinken/http_client.py
@@ -43,7 +43,7 @@ class HTTPException(Exception):
 
 HTTPExceptions = (HTTPException,)
 
-class FileReader(object):
+class FileReader:
     def __init__(self, fp):
         self.fp = fp
     def read_callback(self, size):

--- a/shinken/load.py
+++ b/shinken/load.py
@@ -27,7 +27,7 @@ import time
 import math
 
 
-class Load(object):
+class Load:
     """This class is for having a easy Load calculation
     without having to send value at regular interval
     (but it's more efficient if you do this :) ) and without

--- a/shinken/message.py
+++ b/shinken/message.py
@@ -23,7 +23,7 @@
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class Message(object):
+class Message:
     """This is a simple message class for communications between actionners and
     workers
 

--- a/shinken/misc/logevent.py
+++ b/shinken/misc/logevent.py
@@ -98,7 +98,7 @@ event_types = {
 
 # Class for parsing event logs
 # Populates self.data with the log type's properties
-class LogEvent(object):
+class LogEvent:
 
     def __init__(self, log):
         self.data = {}

--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -46,7 +46,7 @@ def guess_int_or_float(val):
 
 
 # Class for one metric of a perf_data
-class Metric(object):
+class Metric:
     def __init__(self, s):
         self.name = self.value = self.uom = \
             self.warning = self.critical = self.min = self.max = None
@@ -79,7 +79,7 @@ class Metric(object):
         return s
 
 
-class PerfDatas(object):
+class PerfDatas:
     def __init__(self, s):
         s = s or ''
         elts = perfdata_split_pattern.findall(s)

--- a/shinken/worker.py
+++ b/shinken/worker.py
@@ -48,7 +48,7 @@ import cStringIO
 from shinken.log import logger
 from shinken.misc.common import setproctitle
 
-class Worker(object):
+class Worker:
     """This class is used for poller and reactionner to work.
     The worker is a process launch by theses process and read Message in a Queue
     (self.s) (slave)


### PR DESCRIPTION
Reverts naparuba/shinken#1522

Upstream is broken . 

```
Traceback (most recent call last):
  File "./bin/shinken-arbiter", line 116, in <module>
    daemon.main()
  File "/usr/lib/python2.7/site-packages/shinken/daemons/arbiterdaemon.py", line 616, in main
    self.do_mainloop()
  File "/usr/lib/python2.7/site-packages/shinken/daemon.py", line 332, in do_mainloop
    self.do_loop_turn()
  File "/usr/lib/python2.7/site-packages/shinken/daemons/arbiterdaemon.py", line 652, in do_loop_turn
    self.run()
  File "/usr/lib/python2.7/site-packages/shinken/daemons/arbiterdaemon.py", line 834, in run
    self.push_broks_to_broker()
  File "/usr/lib/python2.7/site-packages/shinken/daemons/arbiterdaemon.py", line 224, in push_broks_to_broker
    is_send = brk.push_broks(self.broks)
  File "/usr/lib/python2.7/site-packages/shinken/objects/satellitelink.py", line 370, in push_broks
    self.con.post('push_broks', {'broks': broks}, wait='long')
  File "/usr/lib/python2.7/site-packages/shinken/http_client.py", line 141, in post
    args[k] = zlib.compress(cPickle.dumps(v), 2)
  File "/usr/lib64/python2.7/copy_reg.py", line 77, in _reduce_ex
    raise TypeError("a class that defines __slots__ without "
TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled
```