### PR TITLE
Fix raise error arbiterlink

### DIFF
--- a/shinken/objects/arbiterlink.py
+++ b/shinken/objects/arbiterlink.py
@@ -47,20 +47,6 @@ class ArbiterLink(SatelliteLink):
     def get_config(self):
         return self.con.get('get_config')
 
-    # Check is required when prop are set:
-    # contacts OR contactgroups is need
-    def is_correct(self):
-        state = True
-        cls = self.__class__
-
-        for prop, entry in cls.properties.items():
-            if not hasattr(self, prop) and entry.required:
-                # This should raise an error afterwards?
-                # Log the issue
-                logger.warning("%s arbiterlink is missing %s property", self.get_name(), prop)
-                self.debug("%s arbiterlink is missing %s property" % (self.get_name(), prop))
-                state = False  # Bad boy...
-        return state
 
     # Look for ourself as an arbiter. If we search for a specific arbiter name, go forit
     # If not look be our fqdn name, or if not, our hostname
@@ -129,7 +115,7 @@ class ArbiterLink(SatelliteLink):
 
 
 class ArbiterLinks(SatelliteLinks):
-    name_property = "name"
+    name_property = "arbiter_name"
     inner_class = ArbiterLink
 
 

--- a/test/test_arbiterlink_errors.py
+++ b/test/test_arbiterlink_errors.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# Copyright (C) 2009-2014:
+#    Sebastien Coavoux, s.coavoux@free.fr
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# This file is used to test reading and processing of config files
+#
+
+from shinken_test import *
+
+
+class TestArbiterError(ShinkenTest):
+
+    def setUp(self):
+        self.setup_with_file('etc/shinken_1r_1h_1s.cfg')
+
+    def test_arbiter_error(self):
+        self.assertListEqual(self.conf.arbiters[0].configuration_errors, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi there,

Need review on that, @titilambert @naparuba 

Case : The arbiter was not raising error found during parsing. There was an error introduced by the new indexing and it was not raised properly. This could lead to all other error in the arbiter not to be raised. Not easy to find problems. 

I removed the is_correct def because it was overloading the Items one and was doing bad. Items.is_config is working well, we don't need such overloading.