### PR TITLE
fix tests so one can execute them from a clean repo

### DIFF
--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -732,7 +732,7 @@ class Daemon(object):
         logger.info("Modules directory: %s", modules_dir)
         if not os.path.exists(modules_dir):
             raise RuntimeError("The modules directory '%s' is missing! Bailing out."
-                               "Please fix your configuration", modules_dir)
+                               "Please fix your configuration" % (modules_dir,))
         return modules_dir
 
 

--- a/test/etc/test_sslv3_disabled/schedulerd.ini
+++ b/test/etc/test_sslv3_disabled/schedulerd.ini
@@ -13,7 +13,7 @@ port=9998
 idontcareaboutsecurity=0
 
 # To be changed, to match your real modules directory installation
-#modulesdir=modules
+modules_dir=modules
 
 # Set to 0 if you want to make this daemon NOT run
 daemon_enabled=1

--- a/test/etc/test_sslv3_disabled/shinken.cfg
+++ b/test/etc/test_sslv3_disabled/shinken.cfg
@@ -38,7 +38,7 @@ cfg_dir=../core/realms
 #resource_file=resource.cfg
 
 # The path to the modules directory
-modules_dir=/var/lib/shinken/modules
+modules_dir=modules
 
 # Number of minutes between 2 retention save, here 1hour
 retention_update_interval=60
@@ -114,7 +114,6 @@ local_log=/dev/null
 # By default don't launch even handlers during downtime. Put 0 to
 # get back the default N4G105 behavior
 no_event_handlers_during_downtimes=1
-modules_dir=modules
 
 # [Optionnal], a pack distribution file is a local file near the arbiter
 # that will keep host pack id association, and so push same host on the same

--- a/test/etc/test_sslv3_disabled/shinken.cfg
+++ b/test/etc/test_sslv3_disabled/shinken.cfg
@@ -114,7 +114,7 @@ local_log=/dev/null
 # By default don't launch even handlers during downtime. Put 0 to
 # get back the default N4G105 behavior
 no_event_handlers_during_downtimes=1
-
+modules_dir=modules
 
 # [Optionnal], a pack distribution file is a local file near the arbiter
 # that will keep host pack id association, and so push same host on the same

--- a/test/test_modulemanager.py
+++ b/test/test_modulemanager.py
@@ -25,13 +25,12 @@
 import os
 import time
 
-from shinken.modulesmanager import ModulesManager
-from shinken.objects.module import Module
-
 from shinken_test import (
     ShinkenTest, time_hacker, unittest
 )
 
+from shinken.modulesmanager import ModulesManager
+from shinken.objects.module import Module
 
 modules_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'modules')
 

--- a/test/test_poller_addition.py
+++ b/test/test_poller_addition.py
@@ -22,13 +22,13 @@
 # This file is used to test reading and processing of config files
 #
 import time
+from shinken_test import ShinkenTest, unittest
 from shinken.external_command import ExternalCommand
 from shinken.objects.brokerlink import BrokerLink
 from shinken.objects.arbiterlink import ArbiterLink
 from shinken.objects.pollerlink import PollerLink
 from shinken.objects.reactionnerlink import ReactionnerLink
 from shinken.objects.schedulerlink import SchedulerLink
-from shinken_test import ShinkenTest, unittest
 
 
 class GoodArbiter(ArbiterLink):

--- a/test/test_reversed_list.py
+++ b/test/test_reversed_list.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
-
+from shinken_test import ShinkenTest, unittest
 from shinken.misc.regenerator import Regenerator
 from shinken.brok import Brok
-
-from shinken_test import ShinkenTest, unittest
 
 
 class TestReversedList(ShinkenTest):


### PR DESCRIPTION
Hey, 

i couldn't get the tests running locally when i just cloned the repo, installed dependencies (`pip install -r requirements.txt`) and run tests `./quick_test.sh` and `test.sh`. 

i wanted to contribute a PR for #1534 but i need this to get the tests running from the beginning