### PR TITLE
Feature/1534 fix item inheritance

### DIFF
--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -732,7 +732,7 @@ class Daemon(object):
         logger.info("Modules directory: %s", modules_dir)
         if not os.path.exists(modules_dir):
             raise RuntimeError("The modules directory '%s' is missing! Bailing out."
-                               "Please fix your configuration", modules_dir)
+                               "Please fix your configuration" % (modules_dir,))
         return modules_dir
 
 

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -1495,9 +1495,9 @@ class Config(Item):
         # print "Contacts"
         self.contacts.apply_inheritance()
         # print "Services"
-        self.services.apply_inheritance(self.hosts)
+        self.services.apply_inheritance()
         # print "Servicedependencies"
-        self.servicedependencies.apply_inheritance(self.hosts)
+        self.servicedependencies.apply_inheritance()
         # print "Hostdependencies"
         self.hostdependencies.apply_inheritance()
         # Also timeperiods

--- a/shinken/objects/hostdependency.py
+++ b/shinken/objects/hostdependency.py
@@ -184,18 +184,6 @@ class Hostdependencies(Items):
                 hd.host_name, hd.execution_failure_criteria, dp, hd.inherits_parent
             )
 
-    # Apply inheritance for all properties
-    def apply_inheritance(self):
-        # We check for all Host properties if the host has it
-        # if not, it check all host templates for a value
-        for prop in Hostdependency.properties:
-            self.apply_partial_inheritance(prop)
-
-        # Then implicit inheritance
-        # self.apply_implicit_inheritance(hosts)
-        for h in self:
-            h.get_customs_properties_by_inheritance()
-
     def is_correct(self):
         r = super(Hostdependencies, self).is_correct()
         return r and self.no_loop_in_parents("host_name", "dependent_host_name")

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -1096,14 +1096,17 @@ class Items(object):
                 pass
 
     def apply_inheritance(self):
+        """ For all items and templates inherite properties and custom
+            variables.
+        """
         # We check for all Class properties if the host has it
         # if not, it check all host templates for a value
         cls = self.inner_class
         for prop in cls.properties:
             self.apply_partial_inheritance(prop)
-        for i in self:
+        for i in itertools.chain(self.items.itervalues(),
+                                 self.templates.itervalues()):
             i.get_customs_properties_by_inheritance()
-
 
     # We've got a contacts property with , separated contacts names
     # and we want have a list of Contacts

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -1467,18 +1467,6 @@ class Services(Items):
                     if h is not None and hasattr(h, prop):
                         setattr(s, prop, getattr(h, prop))
 
-    # Apply inheritance for all properties
-    def apply_inheritance(self, hosts):
-        # We check for all Host properties if the host has it
-        # if not, it check all host templates for a value
-        for prop in Service.properties:
-            self.apply_partial_inheritance(prop)
-
-        # Then implicit inheritance
-        # self.apply_implicit_inheritance(hosts)
-        for s in self:
-            s.get_customs_properties_by_inheritance()
-
     # Create dependencies for services (daddy ones)
     def apply_dependencies(self):
         for s in self:

--- a/shinken/objects/servicedependency.py
+++ b/shinken/objects/servicedependency.py
@@ -283,18 +283,6 @@ class Servicedependencies(Items):
                 dsc.add_service_chk_dependency(sdval, sd.execution_failure_criteria,
                                                dp, sd.inherits_parent)
 
-    # Apply inheritance for all properties
-    def apply_inheritance(self, hosts):
-        # We check for all Host properties if the host has it
-        # if not, it check all host templates for a value
-        for prop in Servicedependency.properties:
-            self.apply_partial_inheritance(prop)
-
-        # Then implicit inheritance
-        # self.apply_implicit_inheritance(hosts)
-        for s in self:
-            s.get_customs_properties_by_inheritance()
-
     def is_correct(self):
         r = super(Servicedependencies, self).is_correct()
         return r and self.no_loop_in_parents("service_description", "dependent_service_description")

--- a/test/etc/inheritance_and_plus/pack_like_inheritance.cfg
+++ b/test/etc/inheritance_and_plus/pack_like_inheritance.cfg
@@ -1,0 +1,26 @@
+define host {
+  use                            my-pack,generic-host ; using the pack my-host
+  host_name                      pack-host
+  address                        127.0.0.1
+}
+
+# ~~ pack definition
+
+define host {
+  name                            my-pack
+  register                        0
+}
+
+define service {
+  use                            my-service,generic-service
+  service_description            CHECK-123
+  host_name                      my-pack
+  check_command                  check_service!$_SERVICEcustom_123$
+  register                       0
+}
+
+define service {
+  name                            my-service
+  _custom_123                     sth_useful ; this should be inheritated into the CHECK-123
+  register                        0
+}

--- a/test/etc/shinken_inheritance_and_plus.cfg
+++ b/test/etc/shinken_inheritance_and_plus.cfg
@@ -12,6 +12,7 @@ cfg_file=inheritance_and_plus/hosts.cfg
 cfg_file=standard/services.cfg
 cfg_file=standard/contacts.cfg
 cfg_file=inheritance_and_plus/commands.cfg
+cfg_file=inheritance_and_plus/pack_like_inheritance.cfg
 cfg_file=standard/timeperiods.cfg
 cfg_file=standard/hostgroups.cfg
 cfg_file=standard/servicegroups.cfg

--- a/test/etc/test_sslv3_disabled/schedulerd.ini
+++ b/test/etc/test_sslv3_disabled/schedulerd.ini
@@ -13,7 +13,7 @@ port=9998
 idontcareaboutsecurity=0
 
 # To be changed, to match your real modules directory installation
-#modulesdir=modules
+modules_dir=modules
 
 # Set to 0 if you want to make this daemon NOT run
 daemon_enabled=1

--- a/test/etc/test_sslv3_disabled/shinken.cfg
+++ b/test/etc/test_sslv3_disabled/shinken.cfg
@@ -114,7 +114,7 @@ local_log=/dev/null
 # By default don't launch even handlers during downtime. Put 0 to
 # get back the default N4G105 behavior
 no_event_handlers_during_downtimes=1
-
+modules_dir=modules
 
 # [Optionnal], a pack distribution file is a local file near the arbiter
 # that will keep host pack id association, and so push same host on the same

--- a/test/test_inheritance_and_plus.py
+++ b/test/test_inheritance_and_plus.py
@@ -18,10 +18,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
 
-#
-# This file is used to test reading and processing of config files
-#
-
 from shinken_test import *
 
 
@@ -59,7 +55,18 @@ class TestInheritanceAndPlus(ShinkenTest):
         self.assertIn(dmz.get_name(), [hg.get_name() for hg in host2.hostgroups])
         self.assertIn(mysql.get_name(), [hg.get_name() for hg in host2.hostgroups])
 
+    def test_pack_like_inheritance(self):
+        # get our pack service
+        host = self.sched.hosts.find_by_name('pack-host')
+        service = host.find_service_by_name('CHECK-123')
 
+        # it should exist
+        self.assertIsNotNone(service)
+
+        # it should contain the custom variable `_CUSTOM_123` because custom
+        # variables are always stored in upper case
+        customs = service.customs
+        self.assertIn('_CUSTOM_123', customs)
 
 
 if __name__ == '__main__':

--- a/test/test_modulemanager.py
+++ b/test/test_modulemanager.py
@@ -25,13 +25,12 @@
 import os
 import time
 
-from shinken.modulesmanager import ModulesManager
-from shinken.objects.module import Module
-
 from shinken_test import (
     ShinkenTest, time_hacker, unittest
 )
 
+from shinken.modulesmanager import ModulesManager
+from shinken.objects.module import Module
 
 modules_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'modules')
 

--- a/test/test_poller_addition.py
+++ b/test/test_poller_addition.py
@@ -22,13 +22,13 @@
 # This file is used to test reading and processing of config files
 #
 import time
+from shinken_test import ShinkenTest, unittest
 from shinken.external_command import ExternalCommand
 from shinken.objects.brokerlink import BrokerLink
 from shinken.objects.arbiterlink import ArbiterLink
 from shinken.objects.pollerlink import PollerLink
 from shinken.objects.reactionnerlink import ReactionnerLink
 from shinken.objects.schedulerlink import SchedulerLink
-from shinken_test import ShinkenTest, unittest
 
 
 class GoodArbiter(ArbiterLink):

--- a/test/test_reversed_list.py
+++ b/test/test_reversed_list.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
-
+from shinken_test import ShinkenTest, unittest
 from shinken.misc.regenerator import Regenerator
 from shinken.brok import Brok
-
-from shinken_test import ShinkenTest, unittest
 
 
 class TestReversedList(ShinkenTest):


### PR DESCRIPTION
This PR fixes the handling of inheriting properties and custom variables. It is based on the issue #1534 and should be merged after #1537 

1. apply inheritance on both items and templates now
2. unify usage of apply_inheritance across the objects

