### PR TITLE
Fix setup.py for installation with zip file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = shinken
-version = 2.4-BETA1
 summary = Shinken is a monitoring framework compatible with Nagios configuration and plugins
 author = Gabes Jean
 author_email =naparuba@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 #!/usr/bin/python
+import os
+from shinken.bin import VERSION
+os.environ['PBR_VERSION'] = VERSION
+
 import setuptools
+
 
 setuptools.setup(
     setup_requires=['pbr'],
+    version=VERSION,
     pbr=True,
 )


### PR DESCRIPTION
Hello !
This is a small fix to be able to use ```python setup.py install``` outsite a git repository
To reproduce this problem:
```
git clone https://github.com/naparuba/shinken.git
cd shinken
rm -rf .git
python setup.py install
```

This patch fix it :)
