### PR TITLE
improve script directory finding in init scripts

### DIFF
--- a/bin/init.d/shinken-arbiter
+++ b/bin/init.d/shinken-arbiter
@@ -45,8 +45,8 @@
 
 SHORTNAME=arbiter
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 

--- a/bin/init.d/shinken-broker
+++ b/bin/init.d/shinken-broker
@@ -45,8 +45,8 @@
 
 SHORTNAME=broker
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 

--- a/bin/init.d/shinken-poller
+++ b/bin/init.d/shinken-poller
@@ -46,8 +46,8 @@
 
 SHORTNAME=poller
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 

--- a/bin/init.d/shinken-reactionner
+++ b/bin/init.d/shinken-reactionner
@@ -45,8 +45,8 @@
 
 SHORTNAME=reactionner
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 

--- a/bin/init.d/shinken-receiver
+++ b/bin/init.d/shinken-receiver
@@ -45,8 +45,8 @@
 
 SHORTNAME=receiver
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 

--- a/bin/init.d/shinken-scheduler
+++ b/bin/init.d/shinken-scheduler
@@ -45,8 +45,8 @@
 
 SHORTNAME=scheduler
 NAME="shinken-$SHORTNAME"
-
-curdir=$(dirname "$0")
+SCRIPT=$(readlink -f "$0")
+curdir=$(dirname "$SCRIPT")
 
 export SHINKEN_MODULE_FILE="$NAME"  ## for 'shinken' init script to see that it's called by us
 


### PR DESCRIPTION
the per-daemon init scripts delegate to the main `shinken` init
script. In order to do this, they find the current directory (where all
the init scripts are defined), and then calls `$curdir/shinken`.

The previous method of finding the current directory did not account for
symlinks, so running something like `/etc/rc2.d/S20shinken-poller
start` (where `S20shinken-poller` is a symlink)
would assume the current directory is `/etc/rc2.d/`, and then fail when
it couldn't find the main shinken init script.

This patch uses the method from http://stackoverflow.com/a/1638397 to
find the current directory of the script and resolve symlinks.

refs #1543