### PR TITLE
Enh: Also give check_command in broks.

### DIFF
--- a/shinken/commandcall.py
+++ b/shinken/commandcall.py
@@ -103,10 +103,6 @@ class CommandCall(DummyCommandCall):
         self.args = [s.replace('___PROTECT_EXCLAMATION___', '!')
                      for s in tab[1:]]
 
-    # If we didn't already lately relink us, do it
-    def late_linkify_with_command(self, commands):
-        pass
-
     def is_valid(self):
         return self.valid
 

--- a/shinken/commandcall.py
+++ b/shinken/commandcall.py
@@ -105,11 +105,7 @@ class CommandCall(DummyCommandCall):
 
     # If we didn't already lately relink us, do it
     def late_linkify_with_command(self, commands):
-        if self.late_relink_done:
-            return
-        self.late_relink_done = True
-        c = commands.find_by_name(self.command)
-        self.command = c
+        pass
 
     def is_valid(self):
         return self.valid
@@ -131,17 +127,6 @@ class CommandCall(DummyCommandCall):
         for prop in cls.properties:
             if hasattr(self, prop):
                 res[prop] = getattr(self, prop)
-
-        # The command is a bit special, we just put it's name
-        # or a '' if need
-        if self.command and not isinstance(self.command, basestring):
-            res['command'] = self.command.get_name()
-        # Maybe it's a repickle of a unpickle thing... (like with deepcopy). If so
-        # only take the value
-        elif self.command and isinstance(self.command, basestring):
-            res['command'] = self.command
-        else:
-            res['command'] = ''
 
         return res
 

--- a/shinken/objects/checkmodulation.py
+++ b/shinken/objects/checkmodulation.py
@@ -101,13 +101,6 @@ class CheckModulation(Item):
         return state
 
 
-    # In the scheduler we need to relink the commandCall with
-    # the real commands
-    def late_linkify_cw_by_commands(self, commands):
-        if self.check_command:
-            self.check_command.late_linkify_with_command(commands)
-
-
 class CheckModulations(Items):
     name_property = "checkmodulation_name"
     inner_class = CheckModulation

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -2221,8 +2221,11 @@ class Config(Item):
             # Now in packs we have the number of packs [h1, h2, etc]
             # equal to the number of schedulers.
             r.packs = packs
-        logger.info("Total number of hosts : %d",
-                    nb_elements_all_realms)
+        
+        for what in (self.contacts, self.hosts, self.services, self.commands):
+            logger.info("Number of %s : %d", type(what).__name__, len(what))
+
+        logger.info("Total number of hosts in all realms: %d", nb_elements_all_realms)
         if len(self.hosts) != nb_elements_all_realms:
             logger.warning("There are %d hosts defined, and %d hosts dispatched in the realms. "
                            "Some hosts have been ignored", len(self.hosts), nb_elements_all_realms)

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -1258,23 +1258,6 @@ class Config(Item):
     def clean(self):
         self.services.clean()
 
-    # In the scheduler we need to relink the commandCall with
-    # the real commands
-    def late_linkify(self):
-        props = ['ocsp_command', 'ochp_command',
-                 'service_perfdata_command', 'host_perfdata_command',
-                 'global_host_event_handler', 'global_service_event_handler']
-        for prop in props:
-            cc = getattr(self, prop, None)
-            if cc:
-                cc.late_linkify_with_command(self.commands)
-
-        # But also other objects like hosts and services
-        self.hosts.late_linkify_h_by_commands(self.commands)
-        self.services.late_linkify_s_by_commands(self.commands)
-        self.contacts.late_linkify_c_by_commands(self.commands)
-
-
     # Some properties are dangerous to be send like that
     # like realms linked in hosts. Realms are too big to send (too linked)
     # We are also pre-serializing the confs so the sending phase will

--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -251,12 +251,6 @@ class Contacts(Items):
             # Get the list, but first make elements uniq
             i.notificationways = list(set(new_notificationways))
 
-    def late_linkify_c_by_commands(self, commands):
-        for i in self:
-            for nw in i.notificationways:
-                nw.late_linkify_nw_by_commands(commands)
-
-
     # We look for contacts property in contacts and
     def explode(self, contactgroups, notificationways):
         # Contactgroups property need to be fullfill for got the informations

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -1514,23 +1514,6 @@ class Hosts(Items):
                 for hg in h.hostgroups:
                     hostgroups.add_member(hname, hg.strip())
 
-
-    # In the scheduler we need to relink the commandCall with
-    # the real commands
-    def late_linkify_h_by_commands(self, commands):
-        props = ['check_command', 'event_handler', 'snapshot_command']
-        for h in self:
-            for prop in props:
-                cc = getattr(h, prop, None)
-                if cc:
-                    cc.late_linkify_with_command(commands)
-
-            # Ok also link checkmodulations
-            for cw in h.checkmodulations:
-                cw.late_linkify_cw_by_commands(commands)
-                print cw
-
-
     # Create dependencies:
     # Dependencies at the host level: host parent
     def apply_dependencies(self):

--- a/shinken/objects/notificationway.py
+++ b/shinken/objects/notificationway.py
@@ -232,15 +232,6 @@ class NotificationWay(Item):
         return state
 
 
-    # In the scheduler we need to relink the commandCall with
-    # the real commands
-    def late_linkify_nw_by_commands(self, commands):
-        props = ['service_notification_commands', 'host_notification_commands']
-        for prop in props:
-            for cc in getattr(self, prop, []):
-                cc.late_linkify_with_command(commands)
-
-
 class NotificationWays(Items):
     name_property = "notificationway_name"
     inner_class = NotificationWay

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -1516,16 +1516,6 @@ class Services(Items):
                         s.configuration_errors.append(err)
             s.servicegroups = new_servicegroups
 
-    # In the scheduler we need to relink the commandCall with
-    # the real commands
-    def late_linkify_s_by_commands(self, commands):
-        props = ['check_command', 'event_handler', 'snapshot_command']
-        for s in self:
-            for prop in props:
-                cc = getattr(s, prop, None)
-                if cc:
-                    cc.late_linkify_with_command(commands)
-
     # Delete services by ids
     def delete_services_by_id(self, ids):
         for id in ids:

--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -157,7 +157,7 @@ class Scheduler(object):
     # Load conf for future use
     # we are in_test if the data are from an arbiter object like,
     # so only for tests
-    def load_conf(self, conf, in_test=False):
+    def load_conf(self, conf):
         self.program_start = int(time.time())
         self.conf = conf
         self.hostgroups = conf.hostgroups
@@ -178,14 +178,6 @@ class Scheduler(object):
         self.triggers = conf.triggers
         self.triggers.compile()
         self.triggers.load_objects(self)
-
-
-        if not in_test:
-            # Commands in the host/services/contacts are not real one
-            # we must relink them
-            t0 = time.time()
-            self.conf.late_linkify()
-            logger.debug("Late command relink in %d", time.time() - t0)
 
         # self.status_file = StatusFile(self)
         #  External status file

--- a/test/shinken_test.py
+++ b/test/shinken_test.py
@@ -239,7 +239,7 @@ class ShinkenTest(unittest.TestCase):
         self.clear_logs()
         m = MacroResolver()
         m.init(self.conf)
-        self.sched.load_conf(self.conf, in_test=True)
+        self.sched.load_conf(self.conf)
         e = ExternalCommandManager(self.conf, 'applyer')
         self.sched.external_command = e
         e.load_scheduler(self.sched)


### PR DESCRIPTION
EDIT:
This has been replaced by https://github.com/naparuba/shinken/pull/1592 but kept open for now..
See last comment.

-------
This allow the broker (more specifically one of its modules) to know what command was used for each check
 and eventually use that for its purpose.