### PR TITLE
Enh also set "command_name" in check_result brok

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1688,3 +1688,10 @@ class SchedulingItem(Item):
                     "We got an exception from a trigger on %s for %s",
                     self.get_full_name().decode('utf8', 'ignore'), str(traceback.format_exc())
                 )
+
+    def fill_data_brok_from(self, data, brok_type):
+        super(SchedulingItem, self).fill_data_brok_from(data, brok_type)
+        # workaround/easy trick to have the command_name of this
+        # SchedulingItem in its check_result brok
+        if brok_type == 'check_result':
+            data['command_name'] = self.check_command.command.command_name

--- a/test/test_check_result_brok.py
+++ b/test/test_check_result_brok.py
@@ -1,0 +1,37 @@
+
+
+
+from shinken_test import *
+
+
+class Test_CheckResult_Brok(ShinkenTest):
+
+    cfg_file = 'etc/shinken_1r_1h_1s.cfg'
+
+    expected_host_command_name = 'check-host-alive-parent'
+    expected_svc_command_name = 'check_service'
+
+    def setUp(self):
+        self.setup_with_file(self.cfg_file)
+
+    def test_host_check_result_brok_has_command_name(self):
+        host = self.sched.hosts.find_by_name('test_host_0')
+        res = {}
+        host.fill_data_brok_from(res, 'check_result')
+        self.assertIn('command_name', res)
+        self.assertEqual(self.expected_host_command_name, res['command_name'])
+
+    def test_service_check_result_brok_has_command_name(self):
+        svc = self.sched.services.find_srv_by_name_and_hostname(
+            'test_host_0', 'test_ok_0')
+        res = {}
+        svc.fill_data_brok_from(res, 'check_result')
+        self.assertIn('command_name', res)
+        self.assertEqual(self.expected_svc_command_name, res['command_name'])
+
+
+class Test_CheckResult_Brok_Host_No_command(Test_CheckResult_Brok):
+
+    cfg_file = 'etc/shinken_host_without_cmd.cfg'
+
+    expected_host_command_name = "_internal_host_up"


### PR DESCRIPTION
This happily replace PR https://github.com/naparuba/shinken/pull/1564 which may appear to be overkill for the intended purpose.

With this in effect, the "check_result" broks received at broker level (or anywhere else) will also contain the actual "command_name" of the command which had generated this check (result).