### PR TITLE
Handle log_rotation_method none, hourly and weekly

### DIFF
--- a/doc/source/03_configuration/configmain-advanced.rst
+++ b/doc/source/03_configuration/configmain-advanced.rst
@@ -785,7 +785,7 @@ This is the rotation method that you would like Shinken to use for your log file
   * w = Weekly (rotate the log at midnight on Saturday)
   * m = Monthly (rotate the log at midnight on the last day of the month)
 
-.. tip::  From now, only the d (Daily) parameter is managed.
+.. tip::  Currently, the m (Monthly) parameter is **not** managed.
 
 
 .. _configuration/configmain-advanced#check_external_commands:

--- a/doc/source/03_configuration/configmain-advanced.rst
+++ b/doc/source/03_configuration/configmain-advanced.rst
@@ -779,9 +779,9 @@ Example:
 
 This is the rotation method that you would like Shinken to use for your log file on the **broker server**. Values are as follows:
 
-  * n = None (don't rotate the log - this is the default)
+  * n = None (don't rotate the log)
   * h = Hourly (rotate the log at the top of each hour)
-  * d = Daily (rotate the log at midnight each day)
+  * d = Daily (rotate the log at midnight each day - this is the default)
   * w = Weekly (rotate the log at midnight on Saturday)
   * m = Monthly (rotate the log at midnight on the last day of the month)
 

--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -400,7 +400,8 @@ class Daemon(object):
         if hasattr(self, 'use_local_log') and self.use_local_log:
             try:
                 #self.local_log_fd = self.log.register_local_log(self.local_log)
-                self.local_log_fd = logger.register_local_log(self.local_log)
+                self.local_log_fd = logger.register_local_log(self.local_log,
+                        log_rotation_method=self.conf.log_rotation_method)
             except IOError, exp:
                 logger.error("Opening the log file '%s' failed with '%s'", self.local_log, exp)
                 sys.exit(2)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -257,6 +257,35 @@ class TestDefaultLoggingMethods(NoSetup, ShinkenTest, LogCollectMixin):
         # test whether the normal format is used again
         self.test_basic_logging_info()
 
+class TestLogRotationMethods(NoSetup, ShinkenTest):
+    def _prepare_logging(self):
+        from logging.handlers import TimedRotatingFileHandler
+        logfile = NamedTemporaryFile("w", delete=False)
+        logfile.close()
+        self.logfile_name = logfile.name
+
+    def test_daily_logrotation(self):
+        self._prepare_logging()
+        shinken_logger.register_local_log(self.logfile_name, purge_buffer=False, log_rotation_method='d')
+        self.assertIsInstance(shinken_logger.handlers[-1], logging.handlers.TimedRotatingFileHandler)
+        self.assertEqual(shinken_logger.handlers[-1].when, 'MIDNIGHT')
+
+    def test_weekly_logrotation(self):
+        self._prepare_logging()
+        shinken_logger.register_local_log(self.logfile_name, purge_buffer=False, log_rotation_method='w')
+        self.assertIsInstance(shinken_logger.handlers[-1], logging.handlers.TimedRotatingFileHandler)
+        self.assertEqual(shinken_logger.handlers[-1].when, 'W5')
+
+    # TODO : This one is NOT handled yet
+    #def test_monthly_logrotation(self):
+    #    shinken_logger.register_local_log(logfile.name, purge_buffer=False, log_rotation_method='d')
+    #    self.assertIsInstance(shinken_logger.handlers[-1], logging.handlers.TimedRotatingFileHandler)
+    #    self.assertEqual(shinken_logger.handlers[-1].when, '')
+
+    def test_none_logrotation(self):
+        self._prepare_logging()
+        shinken_logger.register_local_log(self.logfile_name, purge_buffer=False, log_rotation_method='n')
+        self.assertIsInstance(shinken_logger.handlers[-1], logging.FileHandler)
 
 class TestColorConsoleLogger(NoSetup, ShinkenTest, LogCollectMixin):
 


### PR DESCRIPTION
Hi,

Here is a small patch I would like to submit in order to workaround bug #1113 
Basically I'd like to use log_rotation_method=n in order to let logrotate do the job using either a *postrotate script* or a *copytruncate* 

By the way, I wonder why the log_rotation_method should only be considered for *broker server* (as written in the documentation) rather than for all daemons ? (To me it currently applies to all daemons, but I might have missed something ?)

Please, let me know if anything needs to be improved before merging.

Regards,