### PR TITLE
Web UI : some modifications in Shinken core are necessary to help WebUI features

### DIFF
--- a/shinken/objects/hostgroup.py
+++ b/shinken/objects/hostgroup.py
@@ -36,13 +36,14 @@ class Hostgroup(Itemgroup):
 
     properties = Itemgroup.properties.copy()
     properties.update({
-        'id':             IntegerProp(default=0, fill_brok=['full_status']),
-        'hostgroup_name': StringProp(fill_brok=['full_status']),
-        'alias':          StringProp(fill_brok=['full_status']),
-        'notes':          StringProp(default='', fill_brok=['full_status']),
-        'notes_url':      StringProp(default='', fill_brok=['full_status']),
-        'action_url':     StringProp(default='', fill_brok=['full_status']),
-        'realm':          StringProp(default='', fill_brok=['full_status'],
+        'id':                   IntegerProp(default=0, fill_brok=['full_status']),
+        'hostgroup_name':       StringProp(fill_brok=['full_status']),
+        'alias':                StringProp(fill_brok=['full_status']),
+        'hostgroup_members':    StringProp(fill_brok=['full_status']),
+        'notes':                StringProp(default='', fill_brok=['full_status']),
+        'notes_url':            StringProp(default='', fill_brok=['full_status']),
+        'action_url':           StringProp(default='', fill_brok=['full_status']),
+        'realm':                StringProp(default='', fill_brok=['full_status'],
                                      conf_send_preparation=get_obj_name),
     })
 

--- a/shinken/objects/servicegroup.py
+++ b/shinken/objects/servicegroup.py
@@ -36,12 +36,13 @@ class Servicegroup(Itemgroup):
 
     properties = Itemgroup.properties.copy()
     properties.update({
-        'id':                IntegerProp(default=0, fill_brok=['full_status']),
-        'servicegroup_name': StringProp(fill_brok=['full_status']),
-        'alias':             StringProp(fill_brok=['full_status']),
-        'notes':             StringProp(default='', fill_brok=['full_status']),
-        'notes_url':         StringProp(default='', fill_brok=['full_status']),
-        'action_url':        StringProp(default='', fill_brok=['full_status']),
+        'id':                   IntegerProp(default=0, fill_brok=['full_status']),
+        'servicegroup_name':    StringProp(fill_brok=['full_status']),
+        'alias':                StringProp(fill_brok=['full_status']),
+        'servicegroup_members': StringProp(fill_brok=['full_status']),
+        'notes':                StringProp(default='', fill_brok=['full_status']),
+        'notes_url':            StringProp(default='', fill_brok=['full_status']),
+        'action_url':           StringProp(default='', fill_brok=['full_status']),
     })
 
     macros = {


### PR DESCRIPTION
- hostgroup_members property found in configuration is not stored in hostgroup object
- same for servicegroup_members propery ...

With those properties, the WebUI is able to build links between groups ...

