### PR TITLE
add hint to webui module name

### DIFF
--- a/doc/source/11_integration/webui.rst
+++ b/doc/source/11_integration/webui.rst
@@ -68,7 +68,7 @@ Enable the **webui** module in ''modules/webui.cfg'' configuration file that is 
 
 .. important::  Have you changed the **auth_secret** parameter already? No? Do it now!
 
-.. important:: Also add the webui to the modules in the broker config in brokers/broker-master.cfg.
+.. important:: Also add the webui to the modules in the broker config in brokers/broker-master.cfg. Use the module name you used in your webui.cfg (e.g. use WebUI if you used the example webui.cfg above, not just simply webui)
 
 .. note::  The web-server handling HTTP Request to the WebUI is a Python process. You *do not need* any web-server (like Apache) to run the WebUI.
 


### PR DESCRIPTION
Otherwise the user might simply add 'webui' to the broker-master.cfg and encounter an error on the next shinken restart.

```
[item::broker-master] Error: the module webui is unknown for broker-master
```