### PR TITLE
Enh: Add id getter for objects

### DIFF
--- a/shinken/comment.py
+++ b/shinken/comment.py
@@ -74,6 +74,14 @@ class Comment:
     def __str__(self):
         return "Comment id=%d %s" % (self.id, self.comment)
 
+    def get_id(self):
+        """Getter for id attribute
+
+        :return: id
+        :rtype: int
+        """
+        return self.id
+
     # Call by pickle for dataify the ackn
     # because we DO NOT WANT REF in this pickleisation!
     def __getstate__(self):

--- a/shinken/downtime.py
+++ b/shinken/downtime.py
@@ -113,6 +113,14 @@ class Downtime:
         return "%s %s Downtime id=%d %s - %s" % (
             active, type, self.id, time.ctime(self.start_time), time.ctime(self.end_time))
 
+    def get_id(self):
+        """Getter for id attribute
+
+        :return: id
+        :rtype: int
+        """
+        return self.id
+
     def trigger_me(self, other_downtime):
         self.activate_me.append(other_downtime)
 

--- a/shinken/objects/item.py
+++ b/shinken/objects/item.py
@@ -211,6 +211,14 @@ Like temporary attributes such as "imported_from", etc.. """
     def __str__(self):
         return str(self.__dict__) + '\n'
 
+    def get_id(self):
+        """Getter for id attribute
+
+        :return: id
+        :rtype: int
+        """
+        return self.id
+
     def is_tpl(self):
         """ Return if the elements is a template """
         return not getattr(self, "register", True)


### PR DESCRIPTION
Like notification, check and event handlers object. 

Id should be private, it's a better way to access those field for external modules for example.