### PR TITLE
Service excludes/includes/overrides extension

### DIFF
--- a/doc/source/07_advanced/objectinheritance.rst
+++ b/doc/source/07_advanced/objectinheritance.rst
@@ -518,6 +518,18 @@ Its syntax is:
 
 It could be summarized as "*For the service bound to me, named ``xxx``, I want the directive ``yyy`` set to ``zzz`` rather tran the inherited value*"
 
+The service description selector (represented by ``xxx`` in the previous example) may be:
+
+A service name (default)
+  The ``service_description`` of one of the services attached to the host.
+
+``*`` (wildcard)
+  Means *all the services attached to the host*
+
+A regular expression
+  A regular expression against the ``service_description`` of the services attached to the host (it has to be prefixed by ``r:``).
+
+
 Example:
 
 ::
@@ -543,8 +555,22 @@ Example:
          ...
   }
   ...
+  define host {
+         host_name               web-back-02
+         hostgroups              web
+         service_overrides       *,notification_options c
+         ...
+  }
+  ...
+  define host {
+         host_name               web-back-03
+         hostgroups              web
+         service_overrides       r:^HTTP,notification_options r
+         ...
+  }
+  ...
 
-In the previous example, we defined only one instance of the HTTP service, and we enforced the service ``notification_options`` for the web servers composing the backend. The final result is the same, but the second example is shorter, and does not require the second service definition.
+In the previous example, we defined only one instance of the HTTP service, and we enforced the service ``notification_options`` for some web servers composing the backend. The final result is the same, but the second example is shorter, and does not require the second service definition.
 
 Using packs allows an even shorter configuration.
 
@@ -563,6 +589,20 @@ Example:
          use                     http
          host_name               web-back-01
          service_overrides       HTTP,notification_options c,r
+         ...
+  }
+  ...
+  define host {
+         use                     http
+         host_name               web-back-02
+         service_overrides       HTTP,notification_options c
+         ...
+  }
+  ...
+  define host {
+         use                     http
+         host_name               web-back-03
+         service_overrides       HTTP,notification_options r
          ...
   }
   ...
@@ -612,7 +652,24 @@ In this situation, there is several ways to manage the situation:
 
 None of these options are satisfying.
 
-There is a last solution that consists of excluding the corresponding service from the specified host. This may be done using the ``service_excludes directive``.
+There is a last solution that consists of excluding the corresponding service from the specified host. This may be done using the ``service_excludes`` directive.
+
+Its syntax is:
+
+::
+
+  service_excludes xxx
+
+The service description selector (represented by ``xxx`` in the previous example) may be:
+
+A service name (default)
+  The ``service_description`` of one of the services attached to the host.
+
+``*`` (wildcard)
+  Means *all the services attached to the host*
+
+A regular expression
+  A regular expression against the ``service_description`` of the services attached to the host (it has to be prefixed by ``r:``).
 
 Example:
 
@@ -620,18 +677,32 @@ Example:
 ::
 
   define host {
-         use                     web-fromt
+         use                     web-front
          host_name               web-back-01
          ...
   }
 
   define host {
-         use                     web-fromt
+         use                     web-front
          host_name               web-back-02    ; The virtual server
          service_excludes        Management interface
          ...
   }
   ...
+  define host {
+         use                     web-front
+         host_name               web-back-03    ; The virtual server
+         service_excludes        *
+         ...
+  }
+  ...
+  define host {
+         use                     web-front
+         host_name               web-back-04    ; The virtual server
+         service_excludes        r^Management
+         ...
+  }
+  ...
 
 
-In the case you want the opposite (exclude all except) you can use the service_includes directive
+In the case you want the opposite (exclude all except) you can use the ``service_includes`` directive which is its corollary.

--- a/shinken/misc/termcolor.py
+++ b/shinken/misc/termcolor.py
@@ -33,16 +33,17 @@ VERSION = (1, 1, 0)
 
 ATTRIBUTES = dict(
     list(
-        zip([
-            'bold',
-            'dark',
-            '',
-            'underline',
-            'blink',
-            '',
-            'reverse',
-            'concealed'
-        ],
+        zip(
+            [
+                'bold',
+                'dark',
+                '',
+                'underline',
+                'blink',
+                '',
+                'reverse',
+                'concealed'
+            ],
             list(range(1, 9))
         )
     )
@@ -52,16 +53,17 @@ del ATTRIBUTES['']
 
 HIGHLIGHTS = dict(
     list(
-        zip([
-            'on_grey',
-            'on_red',
-            'on_green',
-            'on_yellow',
-            'on_blue',
-            'on_magenta',
-            'on_cyan',
-            'on_white'
-        ],
+        zip(
+            [
+                'on_grey',
+                'on_red',
+                'on_green',
+                'on_yellow',
+                'on_blue',
+                'on_magenta',
+                'on_cyan',
+                'on_white'
+            ],
             list(range(40, 48))
         )
     )
@@ -70,16 +72,17 @@ HIGHLIGHTS = dict(
 
 COLORS = dict(
     list(
-        zip([
-            'grey',
-            'red',
-            'green',
-            'yellow',
-            'blue',
-            'magenta',
-            'cyan',
-            'white',
-        ],
+        zip(
+            [
+                'grey',
+                'red',
+                'green',
+                'yellow',
+                'blue',
+                'magenta',
+                'cyan',
+                'white',
+            ],
             list(range(90, 98))
         )
     )

--- a/shinken/objects/realm.py
+++ b/shinken/objects/realm.py
@@ -231,7 +231,8 @@ class Realm(Itemgroup):
         self.count_receivers()
         self.fill_potential_satellites_by_type('receivers')
 
-        s = "%s: (in/potential) (schedulers:%d) (pollers:%d/%d) (reactionners:%d/%d) (brokers:%d/%d) (receivers:%d/%d)" % \
+        s = "%s: (in/potential) (schedulers:%d) (pollers:%d/%d) "\
+            "(reactionners:%d/%d) (brokers:%d/%d) (receivers:%d/%d)" % \
             (self.get_name(),
              len(self.schedulers),
              self.nb_pollers, len(self.potential_pollers),

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -896,4 +896,3 @@ def get_exclude_match_expr(pattern):
         return reg.match
     else:
         return lambda d: d == pattern
-

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -804,9 +804,9 @@ def filter_service_by_regex_name(regex):
 def filter_service_by_host_name(host_name):
 
     def inner_filter(service):
-        if service is None or service.host is None:
+        if service is None:
             return False
-        return service.host.host_name == host_name
+        return service.host_name == host_name
 
     return inner_filter
 
@@ -815,9 +815,9 @@ def filter_service_by_regex_host_name(regex):
     host_re = re.compile(regex)
 
     def inner_filter(service):
-        if service is None or service.host is None:
+        if service is None:
             return False
-        return host_re.match(service.host.host_name) is not None
+        return host_re.match(service.host_name) is not None
 
     return inner_filter
 
@@ -886,3 +886,14 @@ def is_complex_expr(expr):
         if m in expr:
             return True
     return False
+
+
+def get_exclude_match_expr(pattern):
+    if pattern == "*":
+        return lambda d: True
+    elif pattern.startswith("r:"):
+        reg = re.compile(pattern[2:])
+        return reg.match
+    else:
+        return lambda d: d == pattern
+

--- a/test/etc/exclude_include_services/hosts.cfg
+++ b/test/etc/exclude_include_services/hosts.cfg
@@ -45,7 +45,20 @@ define host{
   service_includes               proc proc2,srv-svc11,srv-svc22
 }
 
+define host{
+  host_name                      test_host_04
+  use                            srv
+  service_excludes               r:proc proc2
+  service_excludes               r:srv-svc2
+}
+
+define host{
+  host_name                      test_host_05
+  use                            srv
+  service_excludes               *
+}
+
 define hostgroup {
   hostgroup_name                testhostgroup
-  members                       test_host_01, test_host_02, test_host_03
+  members                       test_host_01, test_host_02, test_host_03, test_host_04, test_host_05
 }

--- a/test/etc/property_override/hosts.cfg
+++ b/test/etc/property_override/hosts.cfg
@@ -43,13 +43,6 @@ define host{
   service_overrides              proc proc2,notification_options  c,r ; string
   service_overrides              proc proc2,notifications_enabled 0 ; boolean value
 
-  service_overrides              srv-svc,maintenance_period       testperiod ; timeperiod object
-  service_overrides              srv-svc,retry_interval           3 ; integer value
-  service_overrides              srv-svc,check_command            dummy_command ; Command object
-  service_overrides              srv-svc,contact_groups           admins ; contactgroup object
-  service_overrides              srv-svc,notification_options     c,r ; string
-  service_overrides              srv-svc,notifications_enabled    0 ; boolean value
-
   service_overrides              srv-svc2,maintenance_period      testperiod ; timeperiod object
   service_overrides              srv-svc2,retry_interval          3 ; integer value
   service_overrides              srv-svc2,check_command           dummy_command ; Command object
@@ -58,7 +51,31 @@ define host{
   service_overrides              srv-svc2,notifications_enabled   0 ; boolean value
 }
 
+define host{
+  host_name                      test_host_03
+  use                            srv
+
+  service_overrides              *,maintenance_period    testperiod ; timeperiod object
+  service_overrides              *,retry_interval        3 ; integer value
+  service_overrides              *,check_command         dummy_command ; Command object
+  service_overrides              *,contact_groups        admins ; contactgroup object
+  service_overrides              *,notification_options  c,r ; string
+  service_overrides              *,notifications_enabled 0 ; boolean value
+}
+
+define host{
+  host_name                      test_host_04
+  use                            srv
+
+  service_overrides              r:^srv-svc,maintenance_period    testperiod ; timeperiod object
+  service_overrides              r:^srv-svc,retry_interval        3 ; integer value
+  service_overrides              r:^srv-svc,check_command         dummy_command ; Command object
+  service_overrides              r:^srv-svc,contact_groups        admins ; contactgroup object
+  service_overrides              r:^srv-svc,notification_options  c,r ; string
+  service_overrides              r:^srv-svc,notifications_enabled 0 ; boolean value
+}
+
 define hostgroup{
   hostgroup_name                 testhostgroup
-  members                        test_host_01,test_host_02
+  members                        test_host_01,test_host_02, test_host_03, test_host_04
 }

--- a/test/etc/property_override/services.cfg
+++ b/test/etc/property_override/services.cfg
@@ -25,7 +25,7 @@ define service{
 define service{
   check_command                  check_service!ok
   host_name                      srv
-  service_description            srv-svc
+  service_description            srv-svc1
   use                            generic-service
   maintenance_period             24x7
   register                       0

--- a/test/test_exclude_services.py
+++ b/test/test_exclude_services.py
@@ -52,10 +52,24 @@ class TestPropertyOverride(ShinkenTest):
 
         # Half the services only should exist for test_host_02
         find = partial(Find, 'test_host_02')
-        for svc in ('srv-svc12', 'srv-svc22', 'proc proc2', ):
+        for svc in ('srv-svc12', 'srv-svc22', 'proc proc2'):
             self.assertIsNotNone(find(svc))
 
-        for svc in ('srv-svc11', 'srv-svc21', 'proc proc1', ):
+        for svc in ('srv-svc11', 'srv-svc21', 'proc proc1'):
+            self.assertIsNone(find(svc))
+
+        # 2 and 21 should not exist on test-04
+        find = partial(Find, 'test_host_04')
+        for svc in ('srv-svc11', 'srv-svc12', 'proc proc1'):
+            self.assertIsNotNone(find(svc))
+
+        for svc in ('srv-svc21', 'srv-svc22', 'proc proc2'):
+            self.assertIsNone(find(svc))
+
+        # no service should be defined on test_host_05
+        find = partial(Find, 'test_host_05')
+        for svc in ('srv-svc11', 'srv-svc12', 'proc proc1',
+                    'srv-svc21', 'srv-svc22', 'proc proc2'):
             self.assertIsNone(find(svc))
 
 

--- a/test/test_property_override.py
+++ b/test/test_property_override.py
@@ -32,24 +32,36 @@ class TestPropertyOverride(ShinkenTest):
         self.setup_with_file('etc/shinken_property_override.cfg')
 
     def test_service_property_override(self):
-        svc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv-svc")
-        svc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv-svc")
+        svc11 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv-svc1")
+        svc12 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv-svc2")
+        svc21 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv-svc1")
+        svc22 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv-svc2")
+        svc31 = self.sched.services.find_srv_by_name_and_hostname("test_host_03", "srv-svc1")
+        svc32 = self.sched.services.find_srv_by_name_and_hostname("test_host_03", "srv-svc2")
+        svc41 = self.sched.services.find_srv_by_name_and_hostname("test_host_04", "srv-svc1")
+        svc42 = self.sched.services.find_srv_by_name_and_hostname("test_host_04", "srv-svc2")
+
         svc1proc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "proc proc1")
         svc1proc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "proc proc2")
         svc2proc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "proc proc1")
         svc2proc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "proc proc2")
+        svc3proc1 = self.sched.services.find_srv_by_name_and_hostname(
+            "test_host_03", "proc proc1")
+        svc3proc2 = self.sched.services.find_srv_by_name_and_hostname(
+            "test_host_03", "proc proc2")
+        svc4proc1 = self.sched.services.find_srv_by_name_and_hostname("test_host_04", "proc proc1")
+        svc4proc2 = self.sched.services.find_srv_by_name_and_hostname("test_host_04", "proc proc2")
+
         tp24x7 = self.sched.timeperiods.find_by_name("24x7")
         tptest = self.sched.timeperiods.find_by_name("testperiod")
         cgtest = self.sched.contactgroups.find_by_name("test_contact")
         cgadm = self.sched.contactgroups.find_by_name("admins")
         cmdsvc = self.sched.commands.find_by_name("check_service")
         cmdtest = self.sched.commands.find_by_name("dummy_command")
-        svc12 = self.sched.services.find_srv_by_name_and_hostname("test_host_01", "srv-svc2")
-        svc22 = self.sched.services.find_srv_by_name_and_hostname("test_host_02", "srv-svc2")
 
         # Checks we got the objects we need
-        self.assertIsNot(svc1, None)
-        self.assertIsNot(svc2, None)
+        self.assertIsNot(svc11, None)
+        self.assertIsNot(svc21, None)
         self.assertIsNot(svc1proc1, None)
         self.assertIsNot(svc1proc2, None)
         self.assertIsNot(svc2proc1, None)
@@ -64,7 +76,8 @@ class TestPropertyOverride(ShinkenTest):
         self.assertIsNot(svc22, None)
 
         # Check non overriden properies value
-        for svc in (svc1, svc1proc1, svc1proc2, svc2proc1, svc12):
+        for svc in (svc11, svc12, svc1proc1, svc1proc2,
+                    svc21, svc2proc1, svc4proc1, svc4proc2):
             self.assertEqual(["test_contact"], svc.contact_groups)
             self.assertIs(tp24x7, svc.maintenance_period)
             self.assertEqual(1, svc.retry_interval)
@@ -73,7 +86,8 @@ class TestPropertyOverride(ShinkenTest):
             self.assertIs(True, svc.notifications_enabled)
 
         # Check overriden properies value
-        for svc in (svc2, svc2proc2, svc22):
+        for svc in (svc22, svc2proc2, svc31, svc32, svc3proc1, svc3proc2,
+                    svc41, svc42):
             self.assertEqual(["admins"], svc.contact_groups)
             self.assertIs(tptest, svc.maintenance_period)
             self.assertEqual(3, svc.retry_interval)
@@ -93,9 +107,8 @@ class TestConfigBroken(ShinkenTest):
         # Get the arbiter's log broks
         [b.prepare() for b in self.broks.values()]
         logs = [b.data['log'] for b in self.broks.values() if b.type == 'log']
-
         self.assertEqual(1, len([log for log in logs if re.search('Error: invalid service override syntax: fake', log)]) )
-        self.assertEqual(1, len([log for log in logs if re.search("Error: trying to override property 'retry_interval' on service 'fakesrv' but it's unknown for this host", log)]) )
+        self.assertEqual(1, len([log for log in logs if re.search("Error: trying to override property 'retry_interval' on service identified by 'fakesrv' but it's unknown for this host", log)]) )
         self.assertEqual(1, len([log for log in logs if re.search("Error: trying to override 'host_name', a forbidden property for service 'proc proc2'", log)]) )
 
 


### PR DESCRIPTION
This patch extends the service excludes (https://github.com/naparuba/shinken/pull/1167), includes (https://github.com/naparuba/shinken/pull/1480) and overrides (https://github.com/naparuba/shinken/pull/981) features by allowing to select target services in `service_excludes`, `service_excludes` and `service_overrides` host attribute using `*` (meaning all services attached to the host), or using a regular expression (using the `r:` prefix) on the host's services `service_description` attribute.

Examples:

    define host {
        ...
        host_name test
        service_excludes *
        ....
    }

This example would exclude all services from host `test`

    define host {
        ...
        host_name test
        service_excludes r:^proc
        ....
    }

This example would exclude all services from host `test` which `service_description` starts by `proc`

    define host {
        ...
        host_name test
        service_overrides *,notification_period workhours
        ....
    }

This example would enforce `notification_period` to `workhours` on all services from host `test`

    define host {
        ...
        host_name test
        service_overrides r:^proc,notification_period workhours
        ....
    }

This example would enforce `notification_period` to `workhours` on all services from host `test` which `service_description` starts by `proc`

**Caution**: regular expressions are case sensitive, and a regular expression which is matched by none of the services on the host would still raise an error.