### PR TITLE
Added some more git ignored patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ INSTALLED_FILES
 .settings
 .gitignore
 modules/*
+.ropeproject
+.coverage
 
 # Logs and databases #
 ######################


### PR DESCRIPTION
Added patterns:
- `.ropeproject`: For Python Rope project directory
- `.coverage`: For python-coverage temporary folder