### PR TITLE
Enh: allow white space between foreach elements

### DIFF
--- a/shinken/util.py
+++ b/shinken/util.py
@@ -563,15 +563,15 @@ def get_key_value_sequence(entry, default_value=None):
 
     # match a key$(value1..n)$
     keyval_pattern_txt = r"""
-\s*(?P<key>[^,]+?)(?P<values>(\$\(.*?\)\$)*)(?:[,]|$)
+\s*(?P<key>[^,]+?)(?P<values>(\s*\$\(.*?\)\$\s*)*)(?:[,]|$)
 """
     keyval_pattern = re.compile('(?x)' + keyval_pattern_txt)
     # match a whole sequence of key$(value1..n)$
     all_keyval_pattern = re.compile('(?x)^(' + keyval_pattern_txt + ')+$')
     # match a single value
-    value_pattern = re.compile('(?:\$\((?P<val>.*?)\)\$)')
+    value_pattern = re.compile('(?:\s*\$\((?P<val>.*?)\)\$\s*)')
     # match a sequence of values
-    all_value_pattern = re.compile('^(?:\$\(.*?\)\$)+$')
+    all_value_pattern = re.compile('^(?:\s*\$\(.*?\)\$\s*)+$')
 
     if all_keyval_pattern.match(conf_entry):
         for mat in re.finditer(keyval_pattern, conf_entry):

--- a/test/etc/service_generators/hosts.cfg
+++ b/test/etc/service_generators/hosts.cfg
@@ -45,7 +45,7 @@ define host{
   use                            generic-host
 
   #Now the generated part
-  _disks			 C$(80%!90%)$,D$(95%!70%)$,E,F$(95%!70%)$,G
+  _disks			 C $(80%!90%)$, D $(95%!70%)$, E, F $(95%!70%)$,G
 
   # Same but here we say we do not want in fact E and F to be generated
   _disksbis			 C$(80%!90%)$,D$(95%!70%)$,E,F$(95%!70%)$,G


### PR DESCRIPTION
This patch allows to separate the elements from a `duplicate_foreach` statement entry with white spaces for better readability.

Example:

The statement:

    C$(80%)$$(90%)$,D$(95%)$$(70%)$,E,F$(95%)$$(70%)$,G

May also be written:

    C $(80%)$ $(90%)$, D $(95%)$ $(70%)$, E, F $(95%)$ $(70%)$, G