### PR TITLE
WebUI: Check X-Forwarded-Proto header when determining URL scheme

### DIFF
--- a/shinken/webui/bottlewebui.py
+++ b/shinken/webui/bottlewebui.py
@@ -994,7 +994,7 @@ class BaseRequest(DictMixin):
             but the fragment is always empty because it is not visible to the
             server. '''
         env = self.environ
-        http = env.get('wsgi.url_scheme', 'http')
+        http = env.get('HTTP_X_FORWARDED_PROTO') or env.get('wsgi.url_scheme', 'http')
         host = env.get('HTTP_X_FORWARDED_HOST') or env.get('HTTP_HOST')
         if not host:
             # HTTP 1.1 requires a Host-header. This is for HTTP/1.0 clients.


### PR DESCRIPTION
Otherwise it always redirects to http when behind a proxy properly setting X-Forwarded-Proto

Fixes https://phabricator.wikimedia.org/T85326