### PR TITLE
Push some more internal metrics into statsd

### DIFF
--- a/doc/source/03_configuration/configmain-advanced.rst
+++ b/doc/source/03_configuration/configmain-advanced.rst
@@ -1381,6 +1381,7 @@ Example:
 
 This is the api_key/scret to exchange with shinken.io and especially the kernel.shinken.io service that will print your shinken metrics. To enable it you must fill the api_key and secret parameters. You must register to http://shinken.io and look at your profile http://shinken.io/~ for your api_key and your secret.
 
+.. _configuration/configmain-advanced#statsd:
 
 Statsd host
 -----------------------------
@@ -1455,27 +1456,60 @@ Example:
 Enable or not the statsd communication. By default it's disabled.
 
 
-
-Statsd polling interval
------------------------------
+Statsd metrics polling interval
+-------------------------------
 
 Format:
 
 ::
 
-  statsd_interval=10
+  statsd_interval=<int>
 
 Example:
 
 ::
 
-  statsd_interval=10
+  statsd_interval=5
 
 Metrics such as internal queues length (checks, broks), number of elements in
 the configuration, latency and so on...may also be exposed via statsd at the
 interval specified in this parameter.
 
 
+Statsd metric name pattern
+-----------------------------
+
+Format:
+
+::
+
+  statsd_pattern=<string>
+
+Example:
+
+::
+
+  statsd_interval=shinken.{name}.{metric}
+
+Allows to customize metric names using a pattern string. Each metric has a base name which may be enriched using placeholders under the python `format` python string notation. The available placeholders are `service` (the service type), `metric` (the metric name) and `name` (the service name). Note that this parameter is mutually exclusive with `statsd_prefix` and has precedence if both are defined.
+
+
+Statsd metrics filter
+-----------------------------
+
+Format:
+
+::
+
+  statsd_types=<string>
+
+Example:
+
+::
+
+  statsd_types=system,queue,object,perf
+
+Allows to filter the metrics to send to statsd. Each metric is attached a type, and only the metrics holding the specifed types will be sent. See the metrics complete descriptions to see the available types.
 
 
 .. _Related topic: http://www.shinken-monitoring.org/forum/index.php/topic,21.0.html

--- a/doc/source/03_configuration/configmain-advanced.rst
+++ b/doc/source/03_configuration/configmain-advanced.rst
@@ -12,30 +12,30 @@ Tuning and advanced parameters
    (and ask for help on the mailing list).
 
 
-Performance data parameters 	
+Performance data parameters
 ============================
 
-Performance Data Processor Command Timeout 
+Performance Data Processor Command Timeout
 -------------------------------------------
 
-Format:  
+Format:
 
 ::
 
   perfdata_timeout=<seconds>
 
-Example:  
+Example:
 
 ::
 
   perfdata_timeout=5
-  
+
 This is the maximum number of seconds that Shinken will allow a :ref:`host performance data processor command <configuration/configmain-advanced#host_perfdata_file_processing_command>` or :ref:`service performance data processor command <configuration/configmain-advanced#service_perfdata_file_processing_command>` to be run. If a command exceeds this time limit it will be killed and a warning will be logged.
 
 
 .. _configuration/configmain-advanced#process_performance_data:
 
-Performance Data Processing Option 
+Performance Data Processing Option
 -----------------------------------
 
 Format:
@@ -52,7 +52,7 @@ Example:
 
 This value determines whether or not Shinken will process host and service check :ref:`performance data <advanced/perfdata>`.
 
-  * 0 = Don't process performance data 
+  * 0 = Don't process performance data
   * 1 = Process performance data (default)
 
 If you want to use tools like PNP, NagiosGrapher or Graphite set it to 1.
@@ -61,7 +61,7 @@ If you want to use tools like PNP, NagiosGrapher or Graphite set it to 1.
 .. _configuration/configmain-advanced#host_perfdata_command:
 .. _configuration/configmain-advanced#service_perfdata_command:
 
-Host/Service Performance Data Processing Command 
+Host/Service Performance Data Processing Command
 -------------------------------------------------
 
 Format:
@@ -77,14 +77,14 @@ Example:
 
   host_perfdata_command=process-host-perfdata
   service_perfdata_command=process-service-perfdata
-  
+
 This option allows you to specify a command to be run after every host/service check to process host/service :ref:`performance data <advanced/perfdata>` that may be returned from the check. The command argument is the short name of a :ref:`command definition <configobjects/command>` that you define in your object configuration file. This command is only executed if the :ref:`Performance Data Processing Option <configuration/configmain-advanced#process_performance_data>` option is enabled globally and if the "process_perf_data" directive in the :ref:`host definition <configobjects/host>` is enabled.
 
 
 .. _configuration/configmain-advanced#host_perfdata_file:
 .. _configuration/configmain-advanced#service_perfdata_file:
 
-Host/Service Performance Data File 
+Host/Service Performance Data File
 -----------------------------------
 
 Format:
@@ -100,13 +100,13 @@ Example:
 
   host_perfdata_file=/var/lib/shinken/host-perfdata.dat
   service_perfdata_file=/var/lib/shinken/service-perfdata.dat
-  
+
 This option allows you to specify a file to which host/service :ref:`performance data <advanced/perfdata>` will be written after every host check. Data will be written to the performance file as specified by the :ref:`Host Performance Data File Template <configuration/configmain-advanced#host_perfdata_file_template>` option or the service one. Performance data is only written to this file if the :ref:`Performance Data Processing Option <configuration/configmain-advanced#process_performance_data>` option is enabled globally and if the "process_perf_data" directive in the :ref:`host definition <configobjects/host>` is enabled.
 
 
 .. _configuration/configmain-advanced#host_perfdata_file_template:
 
-Host Performance Data File Template 
+Host Performance Data File Template
 ------------------------------------
 
 Format:
@@ -120,13 +120,13 @@ Example:
 ::
 
   host_perfdata_file_template=[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$
-  
+
 This option determines what (and how) data is written to the :ref:`host performance data file <configuration/configmain-advanced#host_perfdata_file>`. The template may contain :ref:`macros <thebasics/macros>`, special characters (\t for tab, \r for carriage return, \n for newline) and plain text. A newline is automatically added after each write to the performance data file.
 
 
 .. _configuration/configmain-advanced#service_perfdata_file_template:
 
-Service Performance Data File Template 
+Service Performance Data File Template
 ---------------------------------------
 
 Format:
@@ -140,14 +140,14 @@ Example:
 ::
 
   service_perfdata_file_template=[SERVICEPERFDATA]\t$TIMET$\t$HOSTNAME$\t$SERVICEDESC$\t$SERVICEEXECUTIONTIME$\t$SERVICELATENCY$\t$SERVICEOUTPUT$\t$SERVICEPERFDATA$
-  
+
 This option determines what (and how) data is written to the :ref:`service performance data file <configuration/configmain-advanced#service_perfdata_file>`. The template may contain :ref:`macros <thebasics/macros>`, special characters (\t for tab, \r for carriage return, \n for newline) and plain text. A newline is automatically added after each write to the performance data file.
 
 
 .. _configuration/configmain-advanced#host_perfdata_file_mode:
 .. _configuration/configmain-advanced#service_perfdata_file_mode:
 
-Host/Service Performance Data File Mode 
+Host/Service Performance Data File Mode
 ----------------------------------------
 
 Format:
@@ -163,7 +163,7 @@ Example:
 
   host_perfdata_file_mode=a
   service_perfdata_file_mode=a
-  
+
 This option determines how the :ref:`host performance data file <configuration/configmain-advanced#host_perfdata_file>` (or the service one) is opened. Unless the file is a named pipe you'll probably want to use the default mode of append.
 
   * a = Open file in append mode (default)
@@ -174,7 +174,7 @@ This option determines how the :ref:`host performance data file <configuration/c
 .. _configuration/configmain-advanced#host_perfdata_file_processing_interval:
 .. _configuration/configmain-advanced#service_perfdata_file_processing_interval:
 
-Host/Service Performance Data File Processing Interval (Unused) 
+Host/Service Performance Data File Processing Interval (Unused)
 ----------------------------------------------------------------
 
 Format:
@@ -190,14 +190,14 @@ Example:
 
   host_perfdata_file_processing_interval=0
   service_perfdata_file_processing_interval=0
-  
+
 This option allows you to specify the interval (in seconds) at which the :ref:`host performance data file <configuration/configmain-advanced#host_perfdata_file>` (or the service one) is processed using the :ref:`host performance data file processing command <configuration/configmain-advanced#host_perfdata_command>`. A value of 0 indicates that the performance data file should not be processed at regular intervals.
 
 
 .. _configuration/configmain-advanced#host_perfdata_file_processing_command:
 .. _configuration/configmain-advanced#service_perfdata_file_processing_command:
 
-Host/Service Performance Data File Processing Command (Unused) 
+Host/Service Performance Data File Processing Command (Unused)
 ---------------------------------------------------------------
 
 Format:
@@ -213,17 +213,17 @@ Example:
 
   host_perfdata_file_processing_command=process-host-perfdata-file
   service_perfdata_file_processing_command=process-service-perfdata-file
-  
+
 This option allows you to specify the command that should be executed to process the :ref:`host performance data file <configuration/configmain-advanced#host_perfdata_file>` (or the service one). The command argument is the short name of a :ref:`command definition <configobjects/command>` that you define in your object configuration file. The interval at which this command is executed is determined by the :ref:`host_perfdata_file_processing_interval <configuration/configmain-advanced#host_perfdata_file_processing_interval>` directive.
 
 
-Advanced scheduling parameters 
+Advanced scheduling parameters
 ===============================
 
 
 .. _configuration/configmain-advanced#passive_host_checks_are_soft:
 
-Passive Host Checks Are SOFT Option (Not implemented) 
+Passive Host Checks Are SOFT Option (Not implemented)
 ------------------------------------------------------
 
 Format:
@@ -237,7 +237,7 @@ Example:
 ::
 
   passive_host_checks_are_soft=1
-  
+
 This option determines whether or not Shinken will treat :ref:`passive host checks <thebasics/passivechecks>` as HARD states or SOFT states. By default, a passive host check result will put a host into a :ref:`HARD state type <thebasics/statetypes>`. You can change this behavior by enabling this option.
 
   * 0 = Passive host checks are HARD (default)
@@ -248,7 +248,7 @@ This option determines whether or not Shinken will treat :ref:`passive host chec
 .. _configuration/configmain-advanced#enable_predictive_host_dependency_checks:
 .. _configuration/configmain-advanced#enable_predictive_service_dependency_checks:
 
-Predictive Host/Service Dependency Checks Option (Unused) 
+Predictive Host/Service Dependency Checks Option (Unused)
 ----------------------------------------------------------
 
 Format:
@@ -264,7 +264,7 @@ Example:
 
   enable_predictive_host_dependency_checks=1
   enable_predictive_service_dependency_checks=1
-  
+
 This option determines whether or not Shinken will execute predictive checks of hosts/services that are being depended upon (as defined in :ref:`host/services dependencies <advanced/dependencies>`) for a particular host/service when it changes state. Predictive checks help ensure that the dependency logic is as accurate as possible. More information on how predictive checks work can be found :ref:`here <advanced/dependencychecks>`.
 
   * 0 = Disable predictive checks
@@ -274,7 +274,7 @@ This option determines whether or not Shinken will execute predictive checks of 
 .. _configuration/configmain-advanced#check_for_orphaned_services:
 .. _configuration/configmain-advanced#check_for_orphaned_hosts:
 
-Orphaned Host/Service Check Option 
+Orphaned Host/Service Check Option
 -----------------------------------
 
 Format:
@@ -290,7 +290,7 @@ Example:
 
   check_for_orphaned_services=1
   check_for_orphaned_hosts=1
-  
+
 This option allows you to enable or disable checks for orphaned service/host checks. Orphaned checks are checks which have been launched to pollers but have not had any results reported in a long time.
 
 Since no results have come back in for it, it is not rescheduled in the event queue. This can cause checks to stop being executed. Normally it is very rare for this to happen - it might happen if an external user or process killed off the process that was being used to execute a check.
@@ -305,7 +305,7 @@ If this option is enabled and Shinken finds that results for a particular check 
 
 .. _configuration/configmain-advanced#soft_state_dependencies:
 
-Soft State Dependencies Option (Not implemented) 
+Soft State Dependencies Option (Not implemented)
 -------------------------------------------------
 
 Format:  soft_state_dependencies=<0/1>
@@ -317,13 +317,13 @@ This option determines whether or not Shinken will use soft state information wh
   * 1 = Use soft state dependencies
 
 
-Performance tuning 
+Performance tuning
 ===================
 
 .. _configuration/configmain-advanced#cached_host_check_horizon:
 .. _configuration/configmain-advanced#cached_service_check_horizon:
 
-Cached Host/Service Check Horizon 
+Cached Host/Service Check Horizon
 ----------------------------------
 
 Format:
@@ -339,7 +339,7 @@ Example:
 
    cached_host_check_horizon=15
    cached_service_check_horizon=15
-  
+
 This option determines the maximum amount of time (in seconds) that the state of a previous host check is considered current. Cached host states (from host/service checks that were performed more recently than the time specified by this value) can improve host check performance immensely. Too high of a value for this option may result in (temporarily) inaccurate host/service states, while a low value may result in a performance hit for host/service checks. Use a value of 0 if you want to disable host/service check caching. More information on cached checks can be found :ref:`here <advanced/cachedchecks>`.
 
 .. tip::  Nagios default is 15s, but it's a tweak that make checks less accurate. So Shinken use 0s as a default. If you have performances problems and you can't add a new scheduler or poller, increase this value and start to buy a new server because this won't be magical.
@@ -347,7 +347,7 @@ This option determines the maximum amount of time (in seconds) that the state of
 
 .. _configuration/configmain-advanced#use_large_installation_tweaks:
 
-Large Installation Tweaks Option 
+Large Installation Tweaks Option
 ---------------------------------
 
 Format:
@@ -361,7 +361,7 @@ Example:
 ::
 
   use_large_installation_tweaks=0
-  
+
 This option determines whether or not the Shinken daemon will take shortcuts to improve performance. These shortcuts result in the loss of a few features, but larger installations will likely see a lot of benefit from doing so. If you can't add new satellites to manage the load (like new pollers), you can activate it. More information on what optimizations are taken when you enable this option can be found :ref:`here <tuning/largeinstalltweaks>`.
 
   * 0 = Don't use tweaks (default)
@@ -369,12 +369,12 @@ This option determines whether or not the Shinken daemon will take shortcuts to 
 
 
 
-Flapping parameters 
+Flapping parameters
 ====================
 
 .. _configuration/configmain-advanced#enable_flap_detection:
 
-Flap Detection Option 
+Flap Detection Option
 ----------------------
 
 Format:
@@ -388,7 +388,7 @@ Example:
 ::
 
   enable_flap_detection=1
-  
+
 This option determines whether or not Shinken will try and detect hosts and services that are “flapping". Flapping occurs when a host or service changes between states too frequently, resulting in a barrage of notifications being sent out. When Shinken detects that a host or service is flapping, it will temporarily suppress notifications for that host/service until it stops flapping.
 
 More information on how flap detection and handling works can be found :ref:`here <advanced/flapping>`.
@@ -400,7 +400,7 @@ More information on how flap detection and handling works can be found :ref:`her
 .. _configuration/configmain-advanced#low_host_flap_threshold:
 .. _configuration/configmain-advanced#low_service_flap_threshold:
 
-Low Service/Host Flap Threshold 
+Low Service/Host Flap Threshold
 --------------------------------
 
 Format:
@@ -416,14 +416,14 @@ Example:
 
   low_service_flap_threshold=25.0
   low_host_flap_threshold=25.0
-  
+
 This option is used to set the low threshold for detection of host/service flapping. For more information on how flap detection and handling works (and how this option affects things) read :ref:`this <advanced/flapping>`.
 
 
 .. _configuration/configmain-advanced#high_host_flap_threshold:
 .. _configuration/configmain-advanced#high_service_flap_threshold:
 
-High Service/Host Flap Threshold 
+High Service/Host Flap Threshold
 ---------------------------------
 
 Format:
@@ -439,7 +439,7 @@ Example:
 
   high_service_flap_threshold=50.0
   high_host_flap_threshold=50.0
-  
+
 This option is used to set the high threshold for detection of host/service flapping. For more information on how flap detection and handling works (and how this option affects things) read :ref:`this <advanced/flapping>`.
 
 
@@ -448,7 +448,7 @@ This option is used to set the high threshold for detection of host/service flap
 .. _configuration/configmain-advanced#event_handler_timeout:
 .. _configuration/configmain-advanced#notification_timeout:
 
-Various commands Timeouts 
+Various commands Timeouts
 --------------------------
 
 Format:
@@ -468,18 +468,18 @@ Example:
   notification_timeout=60
   ocsp_timeout=5
   ochp_timeout=5
-  
+
 This is the maximum number of seconds that Shinken will allow :ref:`event handlers <advanced/eventhandlers>`, notification, :ref:`obsessive compulsive service processor command <configuration/configmain-advanced#ocsp_command>` or a :ref:`Obsessive Compulsive Host Processor Command <configuration/configmain-advanced#ochp_command>` to be run. If an command exceeds this time limit it will be killed and a warning will be logged.
 
 There is often widespread confusion as to what this option really does. It is meant to be used as a last ditch mechanism to kill off commands which are misbehaving and not exiting in a timely manner. It should be set to something high (like 60 seconds or more for notification, less for oc*p commands), so that each event handler command normally finishes executing within this time limit. If an event handler runs longer than this limit, Shinken will kill it off thinking it is a runaway processes.
 
 
-Old Obsess Over commands 
+Old Obsess Over commands
 =========================
 
 .. _configuration/configmain-advanced#obsess_over_services:
 
-Obsess Over Services Option 
+Obsess Over Services Option
 ----------------------------
 
 Format:
@@ -493,7 +493,7 @@ Example:
 ::
 
   obsess_over_services=1
-  
+
 This value determines whether or not Shinken will “obsess" over service checks results and run the :ref:`obsessive compulsive service processor command <configuration/configmain-advanced#ocsp_command>` you define. I know _ funny name, but it was all I could think of. This option is useful for performing :ref:`distributed monitoring <advanced/distributed>`. If you're not doing distributed monitoring, don't enable this option.
 
   * 0 = Don't obsess over services (default)
@@ -502,7 +502,7 @@ This value determines whether or not Shinken will “obsess" over service checks
 
 .. _configuration/configmain-advanced#ocsp_command:
 
-Obsessive Compulsive Service Processor Command 
+Obsessive Compulsive Service Processor Command
 -----------------------------------------------
 
 Format:
@@ -524,7 +524,7 @@ It's used nearly only for the old school distributed architecture. If you use it
 
 .. _configuration/configmain-advanced#obsess_over_hosts:
 
-Obsess Over Hosts Option 
+Obsess Over Hosts Option
 -------------------------
 
 Format:
@@ -538,7 +538,7 @@ Example:
 ::
 
   obsess_over_hosts=1
-  
+
 This value determines whether or not Shinken will “obsess" over host checks results and run the :ref:`obsessive compulsive host processor command <configuration/configmain-advanced#ochp_command>` you define. Same like the service one but for hosts :)
 
   * 0 = Don't obsess over hosts (default)
@@ -547,7 +547,7 @@ This value determines whether or not Shinken will “obsess" over host checks re
 
 .. _configuration/configmain-advanced#ochp_command:
 
-Obsessive Compulsive Host Processor Command 
+Obsessive Compulsive Host Processor Command
 --------------------------------------------
 
 Format:
@@ -561,19 +561,19 @@ Example:
 ::
 
   ochp_command=obsessive_host_handler
-  
-This option allows you to specify a command to be run after every host check, which can be useful in :ref:`distributed monitoring <advanced/distributed>`. This command is executed after any :ref:`event handler <advanced/eventhandlers>` or :ref:`notification <thebasics/notifications>` commands. The command argument is the short name of a :ref:`command definition <configobjects/command>` that you define in your object configuration file. 
+
+This option allows you to specify a command to be run after every host check, which can be useful in :ref:`distributed monitoring <advanced/distributed>`. This command is executed after any :ref:`event handler <advanced/eventhandlers>` or :ref:`notification <thebasics/notifications>` commands. The command argument is the short name of a :ref:`command definition <configobjects/command>` that you define in your object configuration file.
 
 This command is only executed if the :ref:`Obsess Over Hosts Option <configuration/configmain-advanced#obsess_over_hosts>` option is enabled globally and if the "obsess_over_host" directive in the :ref:`host definition <configobjects/host>` is enabled.
 
 
-Freshness check 
+Freshness check
 ================
 
 .. _configuration/configmain-advanced#check_service_freshness:
 .. _configuration/configmain-advanced#check_host_freshness:
 
-Host/Service Freshness Checking Option 
+Host/Service Freshness Checking Option
 ---------------------------------------
 
 Format:
@@ -589,7 +589,7 @@ Example:
 
   check_service_freshness=0
   check_host_freshness=0
-  
+
 This option determines whether or not Shinken will periodically check the “freshness" of host/service checks. Enabling this option is useful for helping to ensure that :ref:`passive service checks <thebasics/passivechecks>` are received in a timely manner. More information on freshness checking can be found :ref:`here <advanced/freshness>`.
 
   * 0 = Don't check host/service freshness
@@ -599,7 +599,7 @@ This option determines whether or not Shinken will periodically check the “fre
 .. _configuration/configmain-advanced#service_freshness_check_interval:
 .. _configuration/configmain-advanced#host_freshness_check_interval:
 
-Host/Service Freshness Check Interval 
+Host/Service Freshness Check Interval
 --------------------------------------
 
 Format:
@@ -615,13 +615,13 @@ Example:
 
   service_freshness_check_interval=60
   host_freshness_check_interval=60
-  
+
 This setting determines how often (in seconds) Shinken will periodically check the “freshness" of host/service check results. If you have disabled host/service freshness checking (with the :ref:`check_service_freshness <configuration/configmain-advanced#check_service_freshness>` option), this option has no effect. More information on freshness checking can be found :ref:`here <advanced/freshness>`.
 
 
 .. _configuration/configmain-advanced#additional_freshness_latency:
 
-Additional Freshness Threshold Latency Option (Not implemented) 
+Additional Freshness Threshold Latency Option (Not implemented)
 ----------------------------------------------------------------
 
 Format:
@@ -635,7 +635,7 @@ Example:
 ::
 
   additional_freshness_latency=15
-  
+
 This option determines the number of seconds Shinken will add to any host or services freshness threshold it automatically calculates (e.g. those not specified explicitly by the user). More information on freshness checking can be found :ref:`here <advanced/freshness>`.
 
 
@@ -1177,13 +1177,13 @@ They are listed on another page :ref:`unused Nagios parameters <advanced/unused-
 
 
 
-All the others :) 
+All the others :)
 ==================
 
 
 .. _configuration/configmain-advanced#date_format:
 
-Date Format (Not implemented) 
+Date Format (Not implemented)
 ------------------------------
 
 Format:
@@ -1197,11 +1197,11 @@ Example:
 ::
 
   date_format=us
-  
+
 This option allows you to specify what kind of date/time format Shinken should use in date/time :ref:`macros <thebasics/macros>`. Possible options (along with example output) include:
 
 ============== =================== ===================
-Option         Output Format       Sample Output      
+Option         Output Format       Sample Output
 us             MM/DD/YYYY HH:MM:SS 06/30/2002 03:15:00
 euro           DD/MM/YYYY HH:MM:SS 30/06/2002 03:15:00
 iso8601        YYYY-MM-DD HH:MM:SS 2002-06-30 03:15:00
@@ -1213,7 +1213,7 @@ strict-iso8601 YYYY-MM-DDTHH:MM:SS 2002-06-30T03:15:00
 
 .. _configuration/configmain-advanced#illegal_object_name_chars:
 
-Illegal Object Name Characters 
+Illegal Object Name Characters
 -------------------------------
 
 Format:
@@ -1227,13 +1227,13 @@ Example:
 ::
 
   illegal_object_name_chars=`-!$%^&*"|'<>?,()=
-  
+
 This option allows you to specify illegal characters that cannot be used in host names, service descriptions, or names of other object types. Shinken will allow you to use most characters in object definitions, but I recommend not using the characters shown in the example above. Doing may give you problems in the web interface, notification commands, etc.
 
 
 .. _configuration/configmain-advanced#illegal_macro_output_chars:
 
-Illegal Macro Output Characters 
+Illegal Macro Output Characters
 --------------------------------
 
 Format:
@@ -1247,7 +1247,7 @@ Example:
 ::
 
   illegal_macro_output_chars=`-$^&"|'<>
-  
+
 This option allows you to specify illegal characters that should be stripped from :ref:`macros <thebasics/macros>` before being used in notifications, event handlers, and other commands. This DOES NOT affect macros used in service or host check commands. You can choose to not strip out the characters shown in the example above, but I recommend you do not do this. Some of these characters are interpreted by the shell (i.e. the backtick) and can lead to security problems. The following macros are stripped of the characters you specify:
 
   * "$HOSTOUTPUT$"
@@ -1259,10 +1259,10 @@ This option allows you to specify illegal characters that should be stripped fro
   * "$SERVICEACKAUTHOR$"
   * "$SERVICEACKCOMMENT$"
 
-  
+
 .. _configuration/configmain-advanced#use_regexp_matching:
 
-Regular Expression Matching Option (Not implemented) 
+Regular Expression Matching Option (Not implemented)
 -----------------------------------------------------
 
 Format:
@@ -1276,7 +1276,7 @@ Example:
 ::
 
   use_regexp_matching=0
-  
+
 This option determines whether or not various directives in your :ref:`Object Configuration Overview <configuration/configobject>` will be processed as regular expressions. More information on how this works can be found :ref:`here <advanced/objecttricks>`.
 
   * 0 = Don't use regular expression matching (default)
@@ -1285,7 +1285,7 @@ This option determines whether or not various directives in your :ref:`Object Co
 
 .. _configuration/configmain-advanced#use_true_regexp_matching:
 
-True Regular Expression Matching Option (Not implemented) 
+True Regular Expression Matching Option (Not implemented)
 ----------------------------------------------------------
 
 Format:
@@ -1299,7 +1299,7 @@ Example:
 ::
 
   use_true_regexp_matching=0
-  
+
 If you've enabled regular expression matching of various object directives using the :ref:`Regular Expression Matching Option <configuration/configmain-advanced#use_regexp_matching>` option, this option will determine when object directives are treated as regular expressions. If this option is disabled (the default), directives will only be treated as regular expressions if they contain \*, ?, +, or \.. If this option is enabled, all appropriate directives will be treated as regular expression _ be careful when enabling this! More information on how this works can be found :ref:`here <advanced/objecttricks>`.
 
   * 0 = Don't use true regular expression matching (default)
@@ -1308,7 +1308,7 @@ If you've enabled regular expression matching of various object directives using
 
 .. _configuration/configmain-advanced#admin_email:
 
-Administrator Email Address (unused) 
+Administrator Email Address (unused)
 -------------------------------------
 
 Format:
@@ -1322,13 +1322,13 @@ Example:
 ::
 
   admin_email=root@localhost.localdomain
-  
+
 This is the email address for the administrator of the local machine (i.e. the one that Shinken is running on). This value can be used in notification commands by using the "$ADMINEMAIL$" :ref:`macro <thebasics/macros>`.
 
 
 .. _configuration/configmain-advanced#admin_pager:
 
-Administrator Pager (unused) 
+Administrator Pager (unused)
 -----------------------------
 
 Format:
@@ -1342,7 +1342,7 @@ Example:
 ::
 
   admin_pager=pageroot@localhost.localdomain
-  
+
 This is the pager number (or pager email gateway) for the administrator of the local machine (i.e. the one that Shinken is running on). The pager number/address can be used in notification commands by using the $ADMINPAGER$ :ref:`macro <thebasics/macros>`.
 
 
@@ -1360,7 +1360,7 @@ Example:
 ::
 
   api_key=AZERTYUIOP
-  
+
 This is the api_key/scret to exchange with shinken.io and especially the kernel.shinken.io service that will print your shinken metrics. To enable it you must fill the api_key and secret parameters. You must register to http://shinken.io and look at your profile http://shinken.io/~ for your api_key and your secret.
 
 
@@ -1378,7 +1378,7 @@ Example:
 ::
 
   secret=QSDFGHJ
-  
+
 This is the api_key/scret to exchange with shinken.io and especially the kernel.shinken.io service that will print your shinken metrics. To enable it you must fill the api_key and secret parameters. You must register to http://shinken.io and look at your profile http://shinken.io/~ for your api_key and your secret.
 
 
@@ -1396,7 +1396,7 @@ Example:
 ::
 
   statsd_host=localhost
-  
+
 Configure your local statsd daemon address.
 
 
@@ -1415,7 +1415,7 @@ Example:
 ::
 
   statsd_port=8125
-  
+
 Configure your local statsd daemon port. Notice that the port is in UDP
 
 
@@ -1433,7 +1433,7 @@ Example:
 ::
 
   statsd_prefix=shinken
-  
+
 The prefix to add before all your stats so you will find them easily in graphite
 
 
@@ -1451,11 +1451,29 @@ Example:
 ::
 
   statsd_enabled=0
-  
+
 Enable or not the statsd communication. By default it's disabled.
 
 
 
+Statsd polling interval
+-----------------------------
+
+Format:
+
+::
+
+  statsd_interval=10
+
+Example:
+
+::
+
+  statsd_interval=10
+
+Metrics such as internal queues length (checks, broks), number of elements in
+the configuration, latency and so on...may also be exposed via statsd at the
+interval specified in this parameter.
 
 
 

--- a/doc/source/07_advanced/index.rst
+++ b/doc/source/07_advanced/index.rst
@@ -53,3 +53,4 @@ Advanced Topics
    unused-nagios-parameters
    discovery-with-shinken-advanced
    discovery-with-shinken
+   internals-monitoring

--- a/doc/source/07_advanced/internals-monitoring.rst
+++ b/doc/source/07_advanced/internals-monitoring.rst
@@ -1,0 +1,400 @@
+.. _advanced/internals-monitoring:
+
+================================
+ Shinken internals monitoring
+================================
+
+
+Introduction
+=============
+
+Shinken is able to expose many internal metrics to a statsd server, allowing to monitor its performances and its operation. It may also be useful to troubleshoot issues.
+
+The metrics export to statsd may be controlled through parameters explained in :ref:`advanced configuration <configuration/configmain-advanced#statsd>`.
+
+The various metrics available in statsd are described in the sections below (the metric names do not mention the configurable prefix nor hostname).
+
+Each metric is specified
+- Its name
+- Its metric type
+- A description telling which information it represents
+- The type it is linked to, which may be used to filter the metrics to send to statsd through the `statsd_types` global attribute.
+
+Initial connection timings
+==========================
+
+Some services establish connections to continuously exchange data. The metrics below measure the time spent to establish them.
+
+==================== ===== ============================================================ ====
+con-init.poller      timer Connection time from broker to poller                        perf
+con-init.reactionner timer Connection time from broker to reactionner                   perf
+con-init.receiver    timer Connection time from broker to receiver                      perf
+con-init.scheduler   timer Connection time from broker/poller/reactcionner to schedule  perf
+==================== ===== ============================================================ ====
+
+con-init.poller
+  Time spent to establish initial session from the broker to the poller services.
+
+con-init.reactionner
+  Time spent to establish initial session from the broker to the reactionner services.
+
+con-init.receiver
+  Time spent to establish initial session from the broker to the receiver services.
+
+con-init.scheduler
+  Time spent to establish initial session from the broker (to get objects state), the poller and the reactionner (to get actions to execute) to the scheduler services.
+
+Hook timings
+============
+
+The shinken services executes code in hooks on different conditions (on a particular point in the workflow, on a timer, on a particular event, ...). The hook events are forwarded to modules for them to execute actions on them. The metrics below expose the time spent to execute those hooks.
+
+======================== ===== ============================================ ====
+hook.early_configuration timer Time spent in the `early_configuration` hook perf
+hook.get_new_actions     timer Time spent in the `get_new_actions` hook     perf
+hook.late_configuration  timer Time spent in the `late_configuration` hook  perf
+hook.load_retention      timer Time spent in the `load_retention` hook      perf
+hook.read_configuration  timer Time spent in the `read_configuration` hook  perf
+hook.save_retention      timer Time spent in the `save_retention` hook      perf
+hook.tick                timer Time spent in the `tick` hook                perf
+======================== ===== ============================================ ====
+
+hook.early_configuration
+  The `early_configuration` hook is executed in the Arbiter daemon after having read the raw configuration, and before starting the deeper parsing operation. This metric exposes the time spent by Arbiter modules to react to this hook.
+
+hook.get_new_actions
+  The `get_new_actions` hook is executed in the Scheduler daemon to get actions to execute from modules (actions may be checks, notifications or event handlers). This metric exposes the time spent by Scheduler modules to react to this hook.
+
+hook.late_configuration
+  The `late_configuration` hook is executed in the Arbiter daemon after the deeper configuration parsing, and before validating it's correct. This metric exposes the time spent by Arbiter modules to react to this hook.
+
+hook.load_retention
+  The `load_retention` hook is executed in the Scheduler and Broker daemons to load retention data using the registered retention module. This metric exposes the time spent by the Schedulers and Brokers to load their retention data.
+
+hook.save_retention
+  The `save_retention` hook is executed in the Scheduler and Broker daemons to save retention data using the registered retention module. This metric exposes the time spent by the Schedulers and Brokers to save their retention data.
+
+hook.tick
+  All daemons send `tick` event each time they finish to execute a cycle in their main loop. This metric exposes the time spent by modules to react to the `tick` event.
+
+Http communication timings
+==========================
+
+Daemons exchange data using remote execution calls based on HTTP/REST APIs. Each of the communications between the daemons are measured (server side). Depending on the request type, various metrics are calculated.
+
+============== ===== ============================================================ ====
+http.*.aqulock timer Time spent waiting for a lock (if the operation requires it) perf
+http.*.args    timer Time spent parsing the request and its parameters            perf
+http.*.calling timer Time spent executing the required procedure                  perf
+http.*.global  timer Total time spent to execute the remote procedure             perf
+http.*.json    timer Time spent encoding the result                               perf
+============== ===== ============================================================ ====
+
+Scheduling metrics
+==================
+
+The scheduler operations are measured carefully. Each operation registered in the `recurrent_works` dictionary in the Scheduler daemon is measured its execution time, and the memory increase it generated. Those values are exposed using the metrics below.
+
+====================================== ======= ================================================ =====
+loop.*                                 timer   Time spent in the operation                      perf
+loop.*.mem                             counter Memory usage evolution involved by the operation perf
+core.scheduler.actions.queue           gauge   The actions queue size in the Scheduler          queue
+core.scheduler.checks.havetoresolvedep gauge   The check queue size in state havetoresolvedep   queue
+core.scheduler.checks.inpoller         gauge   The check queue size in state inpoller           queue
+core.scheduler.checks.queue            gauge   The total check queue size in the scheduler      queue
+core.scheduler.checks.scheduled        gauge   The check queue size in state scheduled          queue
+core.scheduler.checks.timeout          gauge   The check queue size in state timeout            queue
+core.scheduler.checks.waitconsume      gauge   The check queue size in state waitconsume        queue
+core.scheduler.checks.waitdep          gauge   The check queue size in state waitdep            queue
+core.scheduler.checks.zombie           gauge   The check queue size in state zombie             queue
+====================================== ======= ================================================ =====
+
+loop.*
+  Time spent in a particular step in the scheduler workflow.
+
+loop.*.mem
+  The memory variation involved in a particular step in the scheduler workflow.
+
+core.scheduler.actions.queue
+  The notifications and eventhandlers queue to be consumed by the reactionners
+
+core.scheduler.checks.havetoresolvedep
+  The checks count having havetoresolvedep state in the scheduler. Those checks have dependent checks that have to be checked before taking any decision.
+
+core.scheduler.checks.inpoller
+  The checks count having inpoller state in the scheduler. Those checks have been got from by a poller, and the scheduler is waiting for its result.
+
+core.scheduler.checks.queue
+  The total queue size on the Scheduler (all states).
+
+core.scheduler.checks.scheduled
+  The checks count having scheduled state in the scheduler. Those checks have to be taken by a poller.
+
+core.scheduler.checks.timeout
+  The checks count having inpoller state in the scheduler. Those checks have been got from by a poller, and the result did not came in time.
+
+core.scheduler.checks.waitconsume
+  The checks count having waitconsume state in the scheduler. Those checks have been got from by a poller, the result came in time and has to be processed by the Scheduler.
+
+core.scheduler.checks.waitconsume
+  The checks count having waitdep state in the scheduler. Those checks have dependent checks which result is required.
+
+core.scheduler.checks.zombie
+  The checks count having zombie state in the scheduler. Those checks have been totally processed and may be deleted.
+
+Broker specific metrics
+=======================
+
+The broker receives broks emitted by the other services to manage its internal representation of the infrastructure, and forwards broks to its modules for them to do the same. The time to manage its state. Those various operation are measured and exposed through the metrics below.
+
+================================= ===== ================================ ====
+core.broker.manage-brok           timer Time to manage a single brok     perf
+core.broker.put-to-external-queue timer Time to forward broks to modules perf
+core.broker.get-new-broks         timer Time to forward broks to modules perf
+================================= ===== ================================ ====
+
+core.broker.manage-brok
+  When broks are received, they have to be decoded and integrated in the broker configuration to update its representation of the infrastructure. This metric measures the time spent to handle a single brok.
+
+core.broker.put-to-external-queue
+  External broker modules do not benefit from broker internal state representation, and have to decode broks to do the work on their own. This metric measures the time spent to forward all the received broks to all the external modules.
+
+core.broker.get-new-broks
+  Time to get new broks from other services.
+
+Poller/Reactionner specific metrics
+===================================
+
+============================= ======= =========================================================== =====
+core.*.manage-returns         timer   Time spent by a satellite to send results to scheduler      perf
+core.*.wait-ratio             gauge   **To be documented**                                        perf
+core.*.timeout                gauge   **To be documented**                                        perf
+core.*.worker-fork.queue-size gauge   The checks/notifications/eventhandlers execution queue size queue
+core.*.actions.in             counter The number of new actions got from scheduler                queue
+core.*.actions.queue          gauge   The number actions currently queued                         queue
+core.*.results.out            counter The number of results returned to scheduler                 queue
+core.*.results.queue          gauge   The number results currently queued                         queue
+============================= ======= =========================================================== =====
+
+core.*.manage-returns
+  Time spent by the poller or reactionners to return the execution results to the scheduler.
+
+core.*.wait-ratio
+  **To be documented**
+
+core.*.timeout
+  **To be documented**
+
+core.*.worker-fork.queue-size
+  The execution queue in the poller/reactionner.
+
+core.*.worker-fork.queue-size
+  The execution queue in the poller/reactionner.
+
+core.*.actions.in
+  The number of new actions got from scheduler.
+
+core.*.actions.queue
+ The number actions currently queued
+
+core.*.results.out
+  The number of results returned to scheduler.
+
+core.*.results.queued
+  The number results currently queued
+
+Broks related metrics
+=====================
+
+Broks transit from the satellites to broker using a pull strategy. So broks are made available on the satellites, and the active Broker fetches them. The exception is the Arbiter that sends its broks directly to the broker. The broks queue on the satellites are monitored through the metrics below.
+
+==================================== ======= ================================================== =====
+core.broker.get-new-broks.poller     timer   Time spent to fetch broks from poller              perf
+core.broker.get-new-broks.reactionnertimer   Time spent to fetch broks from reactionner         perf
+core.broker.get-new-broks.receiver   timer   Time spent to fetch broks from receiver            perf
+core.broker.get-new-broks.scheduler  timer   Time spent to fetch broks from scheduler           perf
+core.arbiter.broks.in.broker         counter Broks received by the Arbiter from the broker      queue
+core.arbiter.broks.in.poller         counter Broks received by the Arbiter from the poller      queue
+core.arbiter.broks.in.reactionner    counter Broks received by the Arbiter from the reactionner queue
+core.arbiter.broks.in.receiver       counter Broks received by the Arbiter from the receiver    queue
+core.arbiter.broks.in.scheduler      counter Broks received by the Arbiter from the scheduler   queue
+core.arbiter.broks.queue             counter The broks queue size on the Arbiter                queue
+core.broker.broks.queue              counter The broks queue size on the Broker                 queue
+core.poller.broks.queue              counter The broks queue size on the Poller                 queue
+core.reactionner.broks.queue         counter The broks queue size on the Poller                 queue
+core.receiver.broks.queue            counter The broks queue size on the Receiver               queue
+core.scheduler.broks.queue           counter The broks queue size on the Receiver               queue
+==================================== ======= ================================================== ======
+
+core.broker.get-new-broks.poller
+  Time spent by the Broker to download, decode and integrate broks downloaded from the Poller.
+
+core.broker.get-new-broks.reactionner
+  Time spent by the Broker to download, decode and integrate broks downloaded from the Reactionner.
+
+core.broker.get-new-broks.receiver
+  Time spent by the Broker to download, decode and integrate broks downloaded from the Receiver.
+
+core.broker.get-new-broks.scheduler
+  Time spent by the Broker to download, decode and integrate broks downloaded from the Scheduler.
+
+core.broker.arbiter.broks.in.broker
+  The broks downloaded by the Arbiter from the Scheduler.
+
+core.arbiter.broks.in.poller
+  The broks downloaded by the Arbiter from the Poller
+
+core.arbiter.broks.in.reactionner
+  The broks downloaded by the Arbiter from the Reactionner
+
+core.arbiter.broks.in.receiver
+  The broks downloaded by the Arbiter from the Receiver
+
+core.arbiter.broks.in.scheduler
+  The broks downloaded by the Arbiter from the Scheduler
+
+core.arbiter.broks.queue
+  The total broks queue size in the Arbiter
+
+core.broker.broks.queue
+  The total broks queue size in the Broker
+
+core.poller.broks.queue
+  The total broks queue size in the Poller
+
+core.reactionner.broks.queue
+  The total broks queue size in the Reactionner
+
+core.receiver.broks.queue
+  The total broks queue size in the Receiver
+
+core.scheduler.broks.queue
+  The total broks queue size in the Scheduler
+
+External commands related metrics
+=================================
+
+The external commands may emitted by any service or module. They may also be externally received and transferred by the Arbiter or the Receiver. When an external command is emitted, it goes up to the Arbiter which is able to decide to which service it should be routed. Each service is monitorred its external command queue which are exosed by the metrics below.
+
+======================================== ===== ===================================================== ======
+core.arbiter.external-commands.queue     gauge The external commands queue length on the Arbiter     queue
+core.broker.external-commands.queue      gauge The external commands queue length on the Broker      queue
+core.poller.external-commands.queue      gauge The external commands queue length on the Poller      queue
+core.reactionner.external-commands.queue gauge The external commands queue length on the Reactionner queue
+core.receiver.external-commands.queue    gauge The external commands queue length on the Receiver    queue
+core.scheduler.external-commands.queue   gauge The external commands queue length on the Scheduler   queue
+======================================== ===== ===================================================== =====
+
+core.arbiter.external-commands.queue
+  The external commands queue length on the Arbiter
+
+core.broker.external-commands.queue
+  The external commands queue length on the Broker
+
+core.poller.external-commands.queue
+  The external commands queue length on the Poller
+
+core.reactionner.external-commands.queue
+  The external commands queue length on the Reactionner
+
+core.receiver.external-commands.queue
+  The external commands queue length on the Receiver
+
+core.scheduler.external-commands.queue
+  The external commands queue length on the Scheduler
+
+Memory related metrics
+======================
+
+All services are monitored their memory usage through the metrics below.
+
+==================== ===== ================================================ ======
+core.arbiter.mem     gauge The total memory used by the Arbiter service     system
+core.broker.mem      gauge The total memory used by the Broker service      system
+core.poller.mem      gauge The total memory used by the Poller service      system
+core.reactionner.mem gauge The total memory used by the Reactionner service system
+core.receiver.mem    gauge The total memory used by the Receiver service    system
+core.scheduler.mem   gauge The total memory used by the Scheduler service   system
+==================== ===== ================================================ ======
+
+core.arbiter.mem
+  The total memory used by the Arbiter service
+
+core.broker.mem
+  The total memory used by the Broker service
+
+core.poller.mem
+  The total memory used by the Poller service
+
+core.reactionner.mem
+  The total memory used by the Reactionner service
+
+core.receiver.mem
+  The total memory used by the Receiver service
+
+core.scheduler.mem
+  The total memory used by the Scheduler service
+
+Managed objects
+===============
+
+Service that hold configuration objects are monitored the objects they manage through the metrics below. Note the the Arbiter holds the whole confugiration, but the schedulers may havo only a portion of it if multible active schedulers are used.
+
+============================ ===== =========================================================== =====
+core.arbiter.commands        gauge The number of Command objects managed by the Arbiter        queue
+core.arbiter.contactgroups   gauge The number of Contactgroup objects managed by the Arbiter   queue
+core.arbiter.contacts        gauge The number of Contact objects managed by the Arbiter        queue
+core.arbiter.hostgroups      gauge The number of Hostgroup objects managed by the Arbiter      queue
+core.arbiter.hosts           gauge The number of Host objects managed by the Arbiter           queue
+core.arbiter.servicegroups   gauge The number of Servicegroup objects managed by the Arbiter   queue
+core.arbiter.services        gauge The number of Service objects managed by the Arbiter        queue
+core.scheduler.commands      gauge The number of Command objects managed by the Scheduler      queue
+core.scheduler.contactgroups gauge The number of Contactgroup objects managed by the Scheduler queue
+core.scheduler.contacts      gauge The number of Contact objects managed by the Scheduler      queue
+core.scheduler.hostgroups    gauge The number of Hostgroup objects managed by the Scheduler    queue
+core.scheduler.hosts         gauge The number of Host objects managed by the Scheduler         queue
+core.scheduler.servicegroups gauge The number of Servicegroup objects managed by the Scheduler queue
+core.scheduler.services      gauge The number of Service objects managed by the Scheduler      queue
+============================= ===== ========================================================== =====
+
+core.arbiter.commands
+  The number of Command objects managed by the Arbiter
+
+core.arbiter.contactgroups
+  The number of Contactgroup objects managed by the Arbiter
+
+core.arbiter.contacts
+  The number of Contact objects managed by the Arbiter
+
+core.arbiter.hostgroups
+  The number of Hostgroup objects managed by the Arbiter
+
+core.arbiter.hosts
+  The number of Host objects managed by the Arbiter
+
+core.arbiter.servicegroups
+  The number of Servicegroup objects managed by the Arbiter
+
+core.arbiter.services
+  The number of Service objects managed by the Arbiter
+
+core.scheduler.commands
+  The number of Command objects managed by the Scheduler
+
+core.scheduler.contactgroups
+  The number of Contactgroup objects managed by the Scheduler
+
+core.scheduler.contacts
+  The number of Contact objects managed by the Scheduler
+
+core.scheduler.hostgroups
+  The number of Hostgroup objects managed by the Scheduler
+
+core.scheduler.hosts
+  The number of Host objects managed by the Scheduler
+
+core.scheduler.servicegroups
+  The number of Servicegroup objects managed by the Scheduler
+
+core.scheduler.services
+  The number of Service objects managed by the Scheduler

--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -1044,7 +1044,7 @@ class Daemon(object):
                     logger.warning('The instance %s raised an exception %s. I disabled it,'
                                    'and set it to restart later', inst.get_name(), str(exp))
                     self.modules_manager.set_to_restart(inst)
-        statsmgr.incr('core.hook.%s' % hook_name, time.time() - _t)
+        statsmgr.timing('core.hook.%s' % hook_name, time.time() - _t)
 
 
     # Dummy function for daemons. Get all retention data

--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -1044,7 +1044,8 @@ class Daemon(object):
                     logger.warning('The instance %s raised an exception %s. I disabled it,'
                                    'and set it to restart later', inst.get_name(), str(exp))
                     self.modules_manager.set_to_restart(inst)
-        statsmgr.timing('core.hook.%s' % hook_name, time.time() - _t)
+
+        statsmgr.timing('hook.%s' % hook_name, time.time() - _t, 'perf')
 
 
     # Dummy function for daemons. Get all retention data

--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -638,7 +638,7 @@ class Daemon(object):
     # use_pyro= open the TCP port for communication
     # fake= use for test to do not launch runonly feature, like the stats reaper thread
     def do_daemon_init_and_start(self, use_pyro=True, fake=False):
-        self.change_to_workdir()        
+        self.change_to_workdir()
         self.change_to_user_group()
         self.check_parallel_run()
         if use_pyro:
@@ -671,6 +671,7 @@ class Daemon(object):
         # a test launch (time.time() is hooked and will do BIG problems there)
         if not fake:
             statsmgr.launch_reaper_thread()
+            statsmgr.launch_harvester_thread()
 
         # Now start the http_daemon thread
         self.http_thread = None

--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -302,12 +302,15 @@ class Arbiter(Daemon):
                 http_proxy = getattr(self.conf, 'http_proxy', '')
                 statsd_host = getattr(self.conf, 'statsd_host', 'localhost')
                 statsd_port = getattr(self.conf, 'statsd_port', 8125)
+                statsd_interval = getattr(self.conf, 'statsd_interval', 5)
                 statsd_prefix = getattr(self.conf, 'statsd_prefix', 'shinken')
                 statsd_enabled = getattr(self.conf, 'statsd_enabled', False)
                 statsmgr.register(self, arb.get_name(), 'arbiter',
                                   api_key=api_key, secret=secret, http_proxy=http_proxy,
                                   statsd_host=statsd_host, statsd_port=statsd_port,
-                                  statsd_prefix=statsd_prefix, statsd_enabled=statsd_enabled)
+                                  statsd_prefix=statsd_prefix,
+                                  statsd_enabled=statsd_enabled,
+                                  statsd_interval=statsd_interval)
 
                 # Set myself as alive ;)
                 self.me.alive = True

--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -401,13 +401,19 @@ class Broker(BaseSatellite):
         self.statsd_port = g_conf['statsd_port']
         self.statsd_prefix = g_conf['statsd_prefix']
         self.statsd_enabled = g_conf['statsd_enabled']
+        self.statsd_interval = g_conf['statsd_interval']
 
         # We got a name so we can update the logger and the stats global objects
         logger.load_obj(self, name)
         statsmgr.register(self, name, 'broker',
-                          api_key=self.api_key, secret=self.secret, http_proxy=self.http_proxy,
-                          statsd_host=self.statsd_host, statsd_port=self.statsd_port,
-                          statsd_prefix=self.statsd_prefix, statsd_enabled=self.statsd_enabled)
+                          api_key=self.api_key,
+                          secret=self.secret,
+                          http_proxy=self.http_proxy,
+                          statsd_host=self.statsd_host,
+                          statsd_port=self.statsd_port,
+                          statsd_prefix=self.statsd_prefix,
+                          statsd_enabled=self.statsd_enabled,
+                          statsd_interval=self.statsd_interval)
 
         logger.debug("[%s] Sending us configuration %s", self.name, conf)
         # If we've got something in the schedulers, we do not

--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -34,7 +34,7 @@ from multiprocessing import active_children
 
 from shinken.satellite import BaseSatellite
 from shinken.property import PathProp, IntegerProp
-from shinken.util import sort_by_ids
+from shinken.util import sort_by_ids, get_memory
 from shinken.log import logger
 from shinken.stats import statsmgr
 from shinken.external_command import ExternalCommand
@@ -182,7 +182,7 @@ class Broker(BaseSatellite):
     def pynag_con_init(self, id, type='scheduler'):
         _t = time.time()
         r = self.do_pynag_con_init(id, type)
-        statsmgr.timing('con-init.%s' % type, time.time() - _t)
+        statsmgr.timing('con-init.%s' % type, time.time() - _t, 'perf')
         return r
 
 
@@ -402,6 +402,8 @@ class Broker(BaseSatellite):
         self.statsd_prefix = g_conf['statsd_prefix']
         self.statsd_enabled = g_conf['statsd_enabled']
         self.statsd_interval = g_conf['statsd_interval']
+        self.statsd_types = g_conf['statsd_types']
+        self.statsd_pattern = g_conf['statsd_pattern']
 
         # We got a name so we can update the logger and the stats global objects
         logger.load_obj(self, name)
@@ -413,7 +415,9 @@ class Broker(BaseSatellite):
                           statsd_port=self.statsd_port,
                           statsd_prefix=self.statsd_prefix,
                           statsd_enabled=self.statsd_enabled,
-                          statsd_interval=self.statsd_interval)
+                          statsd_interval=self.statsd_interval,
+                          statsd_types=self.statsd_types,
+                          statsd_pattern=self.statsd_pattern)
 
         logger.debug("[%s] Sending us configuration %s", self.name, conf)
         # If we've got something in the schedulers, we do not
@@ -642,14 +646,29 @@ class Broker(BaseSatellite):
         self.modules_manager.clear_instances()
 
 
+    # Gets internal metrics for both statsd and
+    def get_internal_metrics(self):
+        # Queues
+        metrics = [
+            ('core.broker.mem', get_memory(), 'system'),
+            ('core.broker.external-commands.queue',
+             len(self.external_commands), 'queue'),
+            ('core.broker.broks.queue', len(self.broks), 'queue'),
+        ]
+        return metrics
+
 
     # stats threads is asking us a main structure for stats
     def get_stats_struct(self):
+        now = int(time.time())
         # call the daemon one
         res = super(Broker, self).get_stats_struct()
-        res.update({'name': self.name, 'type': 'broker'})
-        res['hosts'] = len(self.conf.hosts)
-        res['services'] = len(self.conf.services)
+        res.update({'name': self.name, 'type': "broker"})
+        # metrics specific
+        metrics = res["metrics"]
+        for metric in self.get_internal_metrics():
+            name, value, mtype = metric
+            metrics.append(name, value, now, mtype)
         return res
 
 
@@ -700,7 +719,8 @@ class Broker(BaseSatellite):
             _t = time.time()
             # And from schedulers
             self.get_new_broks(type=_type)
-            statsmgr.timing('get-new-broks.%s' % _type, time.time() - _t)
+            statsmgr.timing('core.broker.get-new-broks.%s' % _type, time.time() - _t,
+                            'perf')
 
         # Sort the brok list by id
         self.broks.sort(sort_by_ids)
@@ -733,7 +753,8 @@ class Broker(BaseSatellite):
         # No more need to send them
         for b in to_send:
             b.need_send_to_ext = False
-        statsmgr.timing('core.put-to-external-queue', time.time() - t0)
+        statsmgr.timing('core.broker.put-to-external-queue', time.time() - t0,
+                        'perf')
         logger.debug("Time to send %s broks (%d secs)", len(to_send), time.time() - t0)
 
         # We must had new broks at the end of the list, so we reverse the list
@@ -754,7 +775,7 @@ class Broker(BaseSatellite):
             b.prepare()
             _t = time.time()
             self.manage_brok(b)
-            statsmgr.timing('core.manage-brok', time.time() - _t)
+            statsmgr.timing('core.broker.manage-brok', time.time() - _t, 'perf')
 
             nb_broks = len(self.broks)
 

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -185,6 +185,8 @@ class Receiver(Satellite):
         self.statsd_prefix = conf['global']['statsd_prefix']
         self.statsd_enabled = conf['global']['statsd_enabled']
         self.statsd_interval = conf['global']['statsd_interval']
+        self.statsd_types = conf['global']['statsd_types']
+        self.statsd_pattern = conf['global']['statsd_pattern']
 
         statsmgr.register(self, self.name, 'receiver',
                           api_key=self.api_key,
@@ -194,7 +196,9 @@ class Receiver(Satellite):
                           statsd_port=self.statsd_port,
                           statsd_prefix=self.statsd_prefix,
                           statsd_enabled=self.statsd_enabled,
-                          statsd_interval=self.statsd_interval)
+                          statsd_interval=self.statsd_interval,
+                          statsd_types=self.statsd_types,
+                          statsd_pattern=self.statsd_pattern)
         logger.load_obj(self, name)
         self.direct_routing = conf['global']['direct_routing']
         self.accept_passive_unknown_check_results = \

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -415,14 +415,8 @@ class Receiver(Satellite):
 
     # stats threads is asking us a main structure for stats
     def get_stats_struct(self):
-        now = int(time.time())
         # call the daemon one
         res = super(Receiver, self).get_stats_struct()
         res.update({'name': self.name, 'type': 'receiver',
                     'direct_routing': self.direct_routing})
-        metrics = res['metrics']
-        # metrics specific
-        metrics.append('receiver.%s.external-commands.queue %d %d' % (
-            self.name, len(self.external_commands), now))
-
         return res

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -184,11 +184,17 @@ class Receiver(Satellite):
         self.statsd_port = conf['global']['statsd_port']
         self.statsd_prefix = conf['global']['statsd_prefix']
         self.statsd_enabled = conf['global']['statsd_enabled']
+        self.statsd_interval = conf['global']['statsd_interval']
 
         statsmgr.register(self, self.name, 'receiver',
-                          api_key=self.api_key, secret=self.secret, http_proxy=self.http_proxy,
-                          statsd_host=self.statsd_host, statsd_port=self.statsd_port,
-                          statsd_prefix=self.statsd_prefix, statsd_enabled=self.statsd_enabled)
+                          api_key=self.api_key,
+                          secret=self.secret,
+                          http_proxy=self.http_proxy,
+                          statsd_host=self.statsd_host,
+                          statsd_port=self.statsd_port,
+                          statsd_prefix=self.statsd_prefix,
+                          statsd_enabled=self.statsd_enabled,
+                          statsd_interval=self.statsd_interval)
         logger.load_obj(self, name)
         self.direct_routing = conf['global']['direct_routing']
         self.accept_passive_unknown_check_results = \

--- a/shinken/daemons/schedulerdaemon.py
+++ b/shinken/daemons/schedulerdaemon.py
@@ -361,12 +361,18 @@ class Shinken(BaseSatellite):
         statsd_port = pk['statsd_port']
         statsd_prefix = pk['statsd_prefix']
         statsd_enabled = pk['statsd_enabled']
+        statsd_interval = pk['statsd_interval']
 
         # horay, we got a name, we can set it in our stats objects
         statsmgr.register(self.sched, instance_name, 'scheduler',
-                          api_key=api_key, secret=secret, http_proxy=http_proxy,
-                          statsd_host=statsd_host, statsd_port=statsd_port,
-                          statsd_prefix=statsd_prefix, statsd_enabled=statsd_enabled)
+                          api_key=api_key,
+                          secret=secret,
+                          http_proxy=http_proxy,
+                          statsd_host=statsd_host,
+                          statsd_port=statsd_port,
+                          statsd_prefix=statsd_prefix,
+                          statsd_enabled=statsd_enabled,
+                          statsd_interval=statsd_interval)
 
         t0 = time.time()
         conf = cPickle.loads(conf_raw)

--- a/shinken/daemons/schedulerdaemon.py
+++ b/shinken/daemons/schedulerdaemon.py
@@ -362,6 +362,8 @@ class Shinken(BaseSatellite):
         statsd_prefix = pk['statsd_prefix']
         statsd_enabled = pk['statsd_enabled']
         statsd_interval = pk['statsd_interval']
+        statsd_types = pk['statsd_types']
+        statsd_pattern = pk['statsd_pattern']
 
         # horay, we got a name, we can set it in our stats objects
         statsmgr.register(self.sched, instance_name, 'scheduler',
@@ -372,7 +374,9 @@ class Shinken(BaseSatellite):
                           statsd_port=statsd_port,
                           statsd_prefix=statsd_prefix,
                           statsd_enabled=statsd_enabled,
-                          statsd_interval=statsd_interval)
+                          statsd_interval=statsd_interval,
+                          statsd_types=statsd_types,
+                          statsd_pattern=statsd_pattern)
 
         t0 = time.time()
         conf = cPickle.loads(conf_raw)

--- a/shinken/dispatcher.py
+++ b/shinken/dispatcher.py
@@ -421,6 +421,7 @@ class Dispatcher:
                             'statsd_port': self.conf.statsd_port,
                             'statsd_prefix': self.conf.statsd_prefix,
                             'statsd_enabled': self.conf.statsd_enabled,
+                            'statsd_interval': self.conf.statsd_interval,
                         }
 
                         t1 = time.time()

--- a/shinken/dispatcher.py
+++ b/shinken/dispatcher.py
@@ -422,6 +422,8 @@ class Dispatcher:
                             'statsd_prefix': self.conf.statsd_prefix,
                             'statsd_enabled': self.conf.statsd_enabled,
                             'statsd_interval': self.conf.statsd_interval,
+                            'statsd_types': self.conf.statsd_types,
+                            'statsd_pattern': self.conf.statsd_pattern,
                         }
 
                         t1 = time.time()

--- a/shinken/http_daemon.py
+++ b/shinken/http_daemon.py
@@ -416,7 +416,7 @@ class HTTPDaemon(object):
                                ('global', global_time)]
                         # increase the stats timers
                         for (k, _t) in lst:
-                            statsmgr.timing('http.%s.%s' % (fname, k), _t)
+                            statsmgr.timing('http.%s.%s' % (fname, k), _t, 'perf')
 
                         return j
                     # Ok now really put the route in place

--- a/shinken/http_daemon.py
+++ b/shinken/http_daemon.py
@@ -416,7 +416,7 @@ class HTTPDaemon(object):
                                ('global', global_time)]
                         # increase the stats timers
                         for (k, _t) in lst:
-                            statsmgr.incr('http.%s.%s' % (fname, k), _t)
+                            statsmgr.timing('http.%s.%s' % (fname, k), _t)
 
                         return j
                     # Ok now really put the route in place

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -657,6 +657,16 @@ class Config(Item):
                         class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
                                        (BrokerLink, None), (PollerLink, None),
                                        (ReceiverLink, None),  (ArbiterLink, None)]),
+        'statsd_types':
+            StringProp(default=None,
+                       class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
+                                      (BrokerLink, None), (PollerLink, None),
+                                      (ReceiverLink, None),  (ArbiterLink, None)]),
+        'statsd_pattern':
+            StringProp(default=None,
+                       class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
+                                      (BrokerLink, None), (PollerLink, None),
+                                      (ReceiverLink, None),  (ArbiterLink, None)]),
     }
 
     macros = {

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -652,6 +652,10 @@ class Config(Item):
                                    class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
                                                   (BrokerLink, None), (PollerLink, None),
                                                   (ReceiverLink, None),  (ArbiterLink, None)]),
+        'statsd_interval': IntegerProp(default=5,
+                                   class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
+                                                  (BrokerLink, None), (PollerLink, None),
+                                                  (ReceiverLink, None),  (ArbiterLink, None)]),
     }
 
     macros = {

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -652,10 +652,11 @@ class Config(Item):
                                    class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
                                                   (BrokerLink, None), (PollerLink, None),
                                                   (ReceiverLink, None),  (ArbiterLink, None)]),
-        'statsd_interval': IntegerProp(default=5,
-                                   class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
-                                                  (BrokerLink, None), (PollerLink, None),
-                                                  (ReceiverLink, None),  (ArbiterLink, None)]),
+        'statsd_interval':
+            IntegerProp(default=5,
+                        class_inherit=[(SchedulerLink, None), (ReactionnerLink, None),
+                                       (BrokerLink, None), (PollerLink, None),
+                                       (ReceiverLink, None),  (ArbiterLink, None)]),
     }
 
     macros = {

--- a/shinken/objects/satellitelink.py
+++ b/shinken/objects/satellitelink.py
@@ -415,6 +415,8 @@ class SatelliteLink(Item):
         self.cfg['global']['statsd_prefix'] = cls.statsd_prefix
         self.cfg['global']['statsd_enabled'] = cls.statsd_enabled
         self.cfg['global']['statsd_interval'] = cls.statsd_interval
+        self.cfg['global']['statsd_types'] = cls.statsd_types
+        self.cfg['global']['statsd_pattern'] = cls.statsd_pattern
 
 
     # Some parameters for satellites are not defined in the satellites conf

--- a/shinken/objects/satellitelink.py
+++ b/shinken/objects/satellitelink.py
@@ -414,6 +414,7 @@ class SatelliteLink(Item):
         self.cfg['global']['statsd_port'] = cls.statsd_port
         self.cfg['global']['statsd_prefix'] = cls.statsd_prefix
         self.cfg['global']['statsd_enabled'] = cls.statsd_enabled
+        self.cfg['global']['statsd_interval'] = cls.statsd_interval
 
 
     # Some parameters for satellites are not defined in the satellites conf

--- a/shinken/satellite.py
+++ b/shinken/satellite.py
@@ -306,7 +306,7 @@ class Satellite(BaseSatellite):
     def pynag_con_init(self, id):
         _t = time.time()
         r = self.do_pynag_con_init(id)
-        statsmgr.timing('con-init.scheduler', time.time() - _t)
+        statsmgr.timing('con-init.scheduler', time.time() - _t, "perf")
         return r
 
 
@@ -401,7 +401,9 @@ class Satellite(BaseSatellite):
     def manage_returns(self):
         _t = time.time()
         r = self.do_manage_returns()
-        statsmgr.timing('core.manage-returns', time.time() - _t)
+        _type = self.__class__.my_type
+        statsmgr.timing('core.%s.manage-returns' % _type, time.time() - _t,
+                        'perf')
         return r
 
 
@@ -410,6 +412,7 @@ class Satellite(BaseSatellite):
     def do_manage_returns(self):
         # For all schedulers, we check for waitforhomerun
         # and we send back results
+        count = 0
         for sched_id in self.schedulers:
             sched = self.schedulers[sched_id]
             # If sched is not active, I do not try return
@@ -436,10 +439,13 @@ class Satellite(BaseSatellite):
 
             # We clean ONLY if the send is OK
             if send_ok:
+                count += len(ret)
                 sched['wait_homerun'].clear()
             else:
                 self.pynag_con_init(sched_id)
                 logger.warning("Sent failed!")
+        _type = self.__class__.my_type
+        statsmgr.incr('core.%s.results.out' % _type, count, 'queue')
 
 
     # Get all returning actions for a call from a
@@ -458,7 +464,6 @@ class Satellite(BaseSatellite):
 
         # and clear our dict
         sched['wait_homerun'].clear()
-
         return ret
 
 
@@ -551,7 +556,7 @@ class Satellite(BaseSatellite):
     # Someone ask us our broks. We send them, and clean the queue
     def get_broks(self):
         _type = self.__class__.my_type
-        statsmgr.incr('%s.broks.out' % (_type), len(self.broks))
+        statsmgr.incr('core.%s.broks.out' % _type, len(self.broks), 'queue')
         res = copy.copy(self.broks)
         self.broks.clear()
         return res
@@ -666,8 +671,6 @@ class Satellite(BaseSatellite):
 
     # Add a list of actions to our queues
     def add_actions(self, lst, sched_id):
-        _type = self.__class__.my_type
-        statsmgr.incr('%s.new-actions' % (_type), len(lst))
         for a in lst:
             # First we look if we do not already have it, if so
             # do nothing, we are already working!
@@ -692,7 +695,9 @@ class Satellite(BaseSatellite):
     def get_new_actions(self):
         _t = time.time()
         self.do_get_new_actions()
-        statsmgr.timing('core.get-new-actions', time.time() - _t)
+        _type = self.__class__.my_type
+        statsmgr.timing('core.%s.get-new-actions' % _type, time.time() - _t,
+                        'perf')
 
 
     # We get new actions from schedulers, we create a Message and we
@@ -707,6 +712,7 @@ class Satellite(BaseSatellite):
         do_actions = self.__class__.do_actions
 
         # We check for new check in each schedulers and put the result in new_checks
+        count = 0
         for sched_id in self.schedulers:
             sched = self.schedulers[sched_id]
             # If sched is not active, I do not try return
@@ -738,6 +744,7 @@ class Satellite(BaseSatellite):
                     # We 'tag' them with sched_id and put into queue for workers
                     # REF: doc/shinken-action-queues.png (2)
                     self.add_actions(tmp, sched_id)
+                    count += len(tmp)
                 else:  # no con? make the connection
                     self.pynag_con_init(sched_id)
             # Ok, con is unknown, so we create it
@@ -754,6 +761,8 @@ class Satellite(BaseSatellite):
             except Exception, exp:
                 logger.error("A satellite raised an unknown exception: %s (%s)", exp, type(exp))
                 raise
+        _type = self.__class__.my_type
+        statsmgr.incr('core.%s.actions.in' % _type, count, 'queue')
 
 
     # In android we got a Queue, and a manager list for others
@@ -825,12 +834,11 @@ class Satellite(BaseSatellite):
                     logger.debug("[%d][%s][%s] Stats: Workers:%d (Queued:%d TotalReturnWait:%d)",
                                  sched_id, sched['name'], mod,
                                  i, q.qsize(), self.get_returns_queue_len())
-                    # also update the stats module
-                    statsmgr.gauge('core.worker-%s.queue-size' % mod, q.qsize())
 
         # Before return or get new actions, see how we manage
         # old ones: are they still in queue (s)? If True, we
         # must wait more or at least have more workers
+        _type = self.__class__.my_type
         wait_ratio = self.wait_ratio.get_load()
         total_q = 0
         for mod in self.q_by_mod:
@@ -847,14 +855,14 @@ class Satellite(BaseSatellite):
             self.wait_ratio.update_load(self.polling_interval)
         wait_ratio = self.wait_ratio.get_load()
         logger.debug("Wait ratio: %f", wait_ratio)
-        statsmgr.timing('core.wait-ratio', wait_ratio)
+        statsmgr.gauge('core.%s.wait-ratio' % _type, wait_ratio, 'queue')
 
         # We can wait more than 1s if needed,
         # no more than 5s, but no less than 1
         timeout = self.timeout * wait_ratio
         timeout = max(self.polling_interval, timeout)
         self.timeout = min(5 * self.polling_interval, timeout)
-        statsmgr.timing('core.timeout', wait_ratio)
+        statsmgr.gauge('core.%s.timeout' % _type, self.timeout, 'queue')
 
         # Maybe we do not have enough workers, we check for it
         # and launch the new ones if needed
@@ -864,7 +872,6 @@ class Satellite(BaseSatellite):
         # for queue in self.return_messages:
         while self.get_returns_queue_len() != 0:
             self.manage_action_return(self.get_returns_queue_item())
-
 
         # If we are passive, we do not initiate the check getting
         # and return
@@ -938,27 +945,25 @@ class Satellite(BaseSatellite):
         self.statsd_prefix = g_conf['statsd_prefix']
         self.statsd_enabled = g_conf['statsd_enabled']
         self.statsd_interval = g_conf['statsd_interval']
+        self.statsd_types = g_conf['statsd_types']
+        self.statsd_pattern = g_conf['statsd_pattern']
 
         # we got a name, we can now say it to our statsmgr
         if 'poller_name' in g_conf:
-            statsmgr.register(self, self.name, 'poller',
-                              api_key=self.api_key,
-                              secret=self.secret,
-                              http_proxy=self.http_proxy,
-                              statsd_host=self.statsd_host,
-                              statsd_port=self.statsd_port,
-                              statsd_prefix=self.statsd_prefix,
-                              statsd_enabled=self.statsd_enabled,
-                              statsd_interval=self.statsd_interval)
+            service = 'poller'
         else:
-            statsmgr.register(self, self.name, 'reactionner',
-                              api_key=self.api_key,
-                              secret=self.secret,
-                              statsd_host=self.statsd_host,
-                              statsd_port=self.statsd_port,
-                              statsd_prefix=self.statsd_prefix,
-                              statsd_enabled=self.statsd_enabled,
-                              statsd_interval=self.statsd_interval)
+            service = 'reactionner'
+        statsmgr.register(self, self.name, service,
+                          api_key=self.api_key,
+                          secret=self.secret,
+                          http_proxy=self.http_proxy,
+                          statsd_host=self.statsd_host,
+                          statsd_port=self.statsd_port,
+                          statsd_prefix=self.statsd_prefix,
+                          statsd_enabled=self.statsd_enabled,
+                          statsd_interval=self.statsd_interval,
+                          statsd_types=self.statsd_types,
+                          statsd_pattern=self.statsd_pattern)
 
         self.passive = g_conf['passive']
         if self.passive:
@@ -1061,6 +1066,29 @@ class Satellite(BaseSatellite):
                 self.q_by_mod[module.module_type] = {}
 
 
+    # Gets internal metrics for both statsd and
+    def get_internal_metrics(self):
+        _type = self.__class__.my_type
+
+        # Queues
+        metrics = [
+            ('core.%s.mem' % _type, get_memory(), 'system'),
+            ('core.%s.workers' % _type, len(self.workers), 'system'),
+            ('core.%s.external-commands.queue' % _type,
+             len(self.external_commands), 'queue'),
+            ('core.%s.broks.queue' % _type, len(self.broks), 'queue'),
+            ('core.%s.results.queue' % _type, self.get_returns_queue_len(),
+             'queue'),
+        ]
+
+        actions = 0
+        for mod in self.q_by_mod:
+            for q in self.q_by_mod[mod].values():
+                actions += q.qsize()
+        metrics.append(('core.%s.actions.queue' % _type, actions, 'queue'))
+        return metrics
+
+
     # stats threads is asking us a main structure for stats
     def get_stats_struct(self):
         now = int(time.time())
@@ -1071,18 +1099,11 @@ class Satellite(BaseSatellite):
         # The receiver do nto have a passie prop
         if hasattr(self, 'passive'):
             res['passive'] = self.passive
-        metrics = res['metrics']
         # metrics specific
-        metrics.append('%s.%s.external-commands.queue %d %d' % (
-            _type, self.name, len(self.external_commands), now))
-        # Arbiter name is not defined under the same attribute as other
-        # services other services. Arbiter metrics are managed in arbiter
-        # itself.
-        if _type != "arbiter":
-            metrics.append('%s.%s.mem %d %d' %
-                           (_type, self.name, get_memory(), now))
-            metrics.append('%s.%s.broks.queue %d %d' %
-                           (_type, self.name, len(self.broks), now))
+        metrics = res['metrics']
+        for metric in self.get_internal_metrics():
+            name, value, mtype = metric
+            metrics.append(name, value, now, mtype)
         return res
 
 

--- a/shinken/satellite.py
+++ b/shinken/satellite.py
@@ -598,7 +598,7 @@ class Satellite(BaseSatellite):
             # So now we can really forgot it
             del self.workers[id]
 
-        
+
 
     # Here we create new workers if the queue load (len of verifs) is too long
     def adjust_worker_number_by_load(self):
@@ -639,7 +639,7 @@ class Satellite(BaseSatellite):
             del self.q_by_mod[mod]
         # TODO: if len(workers) > 2*wish, maybe we can kill a worker?
 
-        
+
     # Get the Queue() from an action by looking at which module
     # it wants with a round robin way to scale the load between
     # workers
@@ -932,18 +932,28 @@ class Satellite(BaseSatellite):
         self.statsd_port = g_conf['statsd_port']
         self.statsd_prefix = g_conf['statsd_prefix']
         self.statsd_enabled = g_conf['statsd_enabled']
+        self.statsd_interval = g_conf['statsd_interval']
 
         # we got a name, we can now say it to our statsmgr
         if 'poller_name' in g_conf:
             statsmgr.register(self, self.name, 'poller',
-                              api_key=self.api_key, secret=self.secret, http_proxy=self.http_proxy,
-                              statsd_host=self.statsd_host, statsd_port=self.statsd_port,
-                              statsd_prefix=self.statsd_prefix, statsd_enabled=self.statsd_enabled)
+                              api_key=self.api_key,
+                              secret=self.secret,
+                              http_proxy=self.http_proxy,
+                              statsd_host=self.statsd_host,
+                              statsd_port=self.statsd_port,
+                              statsd_prefix=self.statsd_prefix,
+                              statsd_enabled=self.statsd_enabled,
+                              statsd_interval=self.statsd_interval)
         else:
             statsmgr.register(self, self.name, 'reactionner',
-                              api_key=self.api_key, secret=self.secret,
-                              statsd_host=self.statsd_host, statsd_port=self.statsd_port,
-                              statsd_prefix=self.statsd_prefix, statsd_enabled=self.statsd_enabled)
+                              api_key=self.api_key,
+                              secret=self.secret,
+                              statsd_host=self.statsd_host,
+                              statsd_port=self.statsd_port,
+                              statsd_prefix=self.statsd_prefix,
+                              statsd_enabled=self.statsd_enabled,
+                              statsd_interval=self.statsd_interval)
 
         self.passive = g_conf['passive']
         if self.passive:

--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -1558,7 +1558,7 @@ class Scheduler(object):
         for s in ("scheduled", "inpoller", "zombie", "timeout",
                   "waitconsume", "waitdep", "havetoresolvedep"):
             metrics.append('scheduler.%s.checks.%s %d %d' %
-                        (self.instance_name, s,
+                           (self.instance_name, s,
                             len([c for c in self.checks.values() if c.status == s]),
                             now))
         metrics.append('scheduler.%s.actions.queue %d %d' %

--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -1538,7 +1538,8 @@ class Scheduler(object):
         now = int(time.time())
 
         res = self.sched_daemon.get_stats_struct()
-        res.update({'name': self.instance_name, 'type': 'scheduler'})
+        instance_name = getattr(self, "instance_name", "")
+        res.update({'name': instance_name, 'type': 'scheduler'})
 
         # Get a overview of the latencies with just
         # a 95 percentile view, but lso min/max values
@@ -1552,15 +1553,14 @@ class Scheduler(object):
         res['services'] = len(self.services)
         # metrics specific
         metrics = res['metrics']
-        metrics.append('scheduler.%s.checks.scheduled %d %d' %
-                       (self.instance_name,
-                        len([c for c in self.checks.values() if c.status == 'scheduled']), now))
-        metrics.append('scheduler.%s.checks.inpoller %d %d' %
-                       (self.instance_name,
-                        len([c for c in self.checks.values() if c.status == 'scheduled']), now))
-        metrics.append('scheduler.%s.checks.zombie %d %d' %
-                       (self.instance_name,
-                        len([c for c in self.checks.values() if c.status == 'scheduled']), now))
+        metrics.append('scheduler.%s.checks.queue %d %d' %
+                       (self.instance_name, len(self.checks), now))
+        for s in ("scheduled", "inpoller", "zombie", "timeout",
+                  "waitconsume", "waitdep", "havetoresolvedep"):
+            metrics.append('scheduler.%s.checks.%s %d %d' %
+                        (self.instance_name, s,
+                            len([c for c in self.checks.values() if c.status == s]),
+                            now))
         metrics.append('scheduler.%s.actions.queue %d %d' %
                        (self.instance_name,
                         len(self.actions), now))

--- a/shinken/scheduler.py
+++ b/shinken/scheduler.py
@@ -1549,8 +1549,11 @@ class Scheduler(object):
         if lat_avg:
             res['latency'] = {'avg': lat_avg, 'min': lat_min, 'max': lat_max}
 
-        res['hosts'] = len(self.hosts)
-        res['services'] = len(self.services)
+        # Managed objects
+        for t in ("contacts", "contactgroups", "hosts", "hostgroups",
+                  "services", "servicegroups", "commands"):
+            res[t] = len(getattr(self, t))
+
         # metrics specific
         metrics = res['metrics']
         metrics.append('scheduler.%s.checks.queue %d %d' %

--- a/shinken/stats.py
+++ b/shinken/stats.py
@@ -289,15 +289,14 @@ class Stats(object):
                         packets.append('%s.%s.%s:%d|g' % (
                             self.statsd_prefix, self.name, name, int(val)))
 
-                if "hosts" in struct:
-                    count = struct["hosts"]
-                    packets.append('%s.%s.%s.hosts:%d|g' % (
-                        self.statsd_prefix, self.name, struct["type"], count))
-
-                if "services" in struct:
-                    count = struct["services"]
-                    packets.append('%s.%s.%s.services:%d|g' % (
-                        self.statsd_prefix, self.name, struct["type"], count))
+                for t in ("contacts", "contactgroups", "hosts", "hostgroups",
+                          "services", "servicegroups", "commands"):
+                    if t in struct:
+                        c = struct[t]
+                        p = self.statsd_prefix
+                        n = self.name
+                        s = struct["type"]
+                        packets.append('%s.%s.%s.%s:%d|g' % (p, n, s, t, c))
 
                 for packet in packets:
                     self.send_metric(packet)

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
     NodeSet = None
 
+try:
+    import resource
+except ImportError:
+    resource = None
+
 from shinken.macroresolver import MacroResolver
 from shinken.log import logger
 
@@ -896,3 +901,18 @@ def get_exclude_match_expr(pattern):
         return reg.match
     else:
         return lambda d: d == pattern
+
+
+# ##################### system related utility functions  #####################
+
+def get_memory(who="self"):
+    if resource is None:
+        return 0
+    if who == "self":
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+    elif who == "children":
+        return resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss * 1024
+    elif who == "both":
+        return resource.getrusage(resource.RUSAGE_BOTH).ru_maxrss * 1024
+    else:
+        return 0

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -243,6 +243,7 @@ class TestConfig(PropertiesTester, ShinkenTest):
         ('statsd_port', 8125),
         ('statsd_prefix', 'shinken'),
         ('statsd_enabled', False),
+        ('statsd_interval', 10),
         ])
 
     def setUp(self):

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -243,7 +243,7 @@ class TestConfig(PropertiesTester, ShinkenTest):
         ('statsd_port', 8125),
         ('statsd_prefix', 'shinken'),
         ('statsd_enabled', False),
-        ('statsd_interval', 10),
+        ('statsd_interval', 5),
         ])
 
     def setUp(self):

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -244,6 +244,8 @@ class TestConfig(PropertiesTester, ShinkenTest):
         ('statsd_prefix', 'shinken'),
         ('statsd_enabled', False),
         ('statsd_interval', 5),
+        ('statsd_types', None),
+        ('statsd_pattern', None),
         ])
 
     def setUp(self):


### PR DESCRIPTION
This patch adds (and extends) metrics sent to kernel.shinken.io and to statsd, such as number of elements in the  queues, number of managed objects, and so on... The changes are described below.

**Metrics collection**
Those metrics are collected and sent to statsd by a dedicated thread, with frequency controlled by the new `statsd_interval` parameter in the global configuration file (it defaults to 5s).

**Metrics name normalization**
The metric names have been normalized in order to have something more usable.  Each metric is made of a  base name, which may be decorated using a prefix, or a pattern string.

*Metric base name*
Metrics names follow the pattern below (parts between brackets are facultative):

    {namespace}.{service}.{name}[.{type}][.{direction}]

- The `namespace` is what the metric is related to. For instance `loop` for scheduler recurrent work methods, `tick` for tick timings, `core` for core metrics.
- The `service` is the metric emitter service. May be `arbiter`, `broker`, `poller`, `receiver`, `reactionner`, and `scheduler`. This allows to avoid collisions when metrics are emitted from services running on the same host.
- The `name` is what the metric refers to.
- The `type` is used to have variation around a common metric.
- The `direction` indicates if the metric corresponds to an input or an output stream (for counters, for instance).

Example:

    core.scheduler.hosts
    core.poller.actions.in
    hook.tick

*Metrics name decoration*
The metric names may be decorated either by a static prefix (current behaviour), or using an expansion string.

The prefix is prepended, with the host name, to the base metric.

For instance:

    statd_prefix = shinken

Leads to metrics looking like

    shinken.mon-XX.core.scheduler.hosts

The pattern allows to chose which elements are used to build the metric name.

Example:

    statsd_pattern = shinken.{host}.{metric}

Leads to the same result as below. See the documentation for a list of available macros.

Note that if both prefix and pattern as configured, pattern has precedence.

**Metrics filtering**

Each metric is set a type (`system`, `perf`, `queue`, ...).  The new parameter `statsd_types` allows to filter the metrics to be send to statsd. By default, every metrics are sent, but if this parameter is set, only metrics holding types referenced are pushed. See the documentation for a lis of metrics, and their type.

**New metrics**

See documentation for a list of available metrics, their type and a their description.
