### PR TITLE
Fix initial_state mapping for hosts

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -643,7 +643,7 @@ class Host(SchedulingItem):
 
     def set_initial_state(self):
         mapping = {
-            "u": {
+            "o": {
                 "state": "UP",
                 "state_id": 0
             },


### PR DESCRIPTION
The initial_state "u" is declared twice, for UP and UNREACHABLE. Documentation
says that UP state is "o".