### PR TITLE
travis-ci.org - Allow Shinken to run on new infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: python
+
+# Allow shinken to run on new travis infra
+sudo: False
+
+# Allow cache of downloads
+cache: pip
+
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
Also cache python packages, to speed up the builds.