### PR TITLE
Use first SOFT result timestamp as timestamp of first notification

### DIFF
--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -301,6 +301,8 @@ class Host(SchedulingItem):
             StringProp(default='PENDING', fill_brok=['full_status'], retention=True),
         'last_hard_state_id':
             IntegerProp(default=0, fill_brok=['full_status'], retention=True),
+        'time_first_soft_result':
+            IntegerProp(default=0, fill_brok=['full_status'], retention=True),
         'last_time_up':
             IntegerProp(default=0, fill_brok=['full_status', 'check_result'], retention=True),
         'last_time_down':
@@ -587,6 +589,7 @@ class Host(SchedulingItem):
         'HOSTGROUPNAMES':    'get_groupnames',
         'LASTHOSTCHECK':     'last_chk',
         'LASTHOSTSTATECHANGE': 'last_state_change',
+        'TIMEFIRSTSOFTRESULT': 'time_first_soft_result',
         'LASTHOSTUP':        'last_time_up',
         'LASTHOSTDOWN':      'last_time_down',
         'LASTHOSTUNREACHABLE': 'last_time_unreachable',

--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1018,6 +1018,7 @@ class SchedulingItem(Item):
             else:
                 # This is the first NON-OK result. Initiate the SOFT-sequence
                 # Also launch the event handler, he might fix it.
+                self.time_first_soft_result = int(time.time())
                 self.attempt = 1
                 self.state_type = 'SOFT'
                 self.raise_alert_log_entry()
@@ -1271,7 +1272,10 @@ class SchedulingItem(Item):
             t_wished = now
             # if first notification, we must add first_notification_delay
             if self.current_notification_number == 0 and type == 'PROBLEM':
-                last_time_non_ok_or_up = self.last_time_non_ok_or_up()
+                if self.time_first_soft_result != 0:
+                    last_time_non_ok_or_up = self.time_first_soft_result
+                else:
+                    last_time_non_ok_or_up = self.last_time_non_ok_or_up()
                 if last_time_non_ok_or_up == 0:
                     # this happens at initial
                     t_wished = now + self.first_notification_delay * cls.interval_length


### PR DESCRIPTION
In the company I work for, we opted using the datetime of the first SOFT check result obtained for the PROBLEM notification datetime, as this might be the real datetime for the start of the problem detected. 

As a matter of fact, Nagios and Centreon already take the first SOFT result obtained as the PROBLEM notification datetime.

In order to do that, I've added an attribute called "time_first_soft_result" so I can store the timestamp of the first SOFT result of a host. On shinken/objects/schedulingitem.py, Shinken updates the attr at the first NON-OK result, which initiates the SOFT-sequence. The attribute is then used to create the first notification with the timestamp of first SOFT result.