### PR TITLE
Fix for issue #1777

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -437,8 +437,11 @@ class SchedulingItem(Item):
         # if a parent is not down, no dep can explain the pb
         if False in parent_is_down:
             return False
-        else:  # every parents are dead, so... It's not my fault :)
-            return True
+        else:  # every parents are dead, so... It's not my fault, unless I want to know about it anyway :)
+            if 'u' in self.notification_options:
+                return False
+            else:
+                return True
 
     # We check if we are no action just because of ours parents (or host for
     # service)

--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -438,8 +438,11 @@ class SchedulingItem(Item):
         if False in parent_is_down:
             return False
         else:  # every parents are dead, so... It's not my fault, unless I want to know about it anyway :)
-            if 'u' in self.notification_options:
-                return False
+            if hasattr(self, 'notification_options'):
+                if 'u' in self.notification_options:
+                    return False
+                else:
+                    return True
             else:
                 return True
 


### PR DESCRIPTION
This is a fix for issue #1777, which describes the scenario of Shinken not sending notifications for hosts on unreachable state, even if you enable this in notification_options.

The "is_no_action_dependent" function uses dep status info to define if actions can be raised or not for a host (no_action boolean variable), and the default behaviour is to disable actions if all parents are dead. I added an "if" condition testing for 'u' (unreachable) in notification options. If 'u' is in notification options, the function returns False when all parents are down, and True if 'u' is not in notification options.

This was tested on Shinken 2.4.2 with Debian 8.