### PR TITLE
Send notification to related hosts contact for a service

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -1352,6 +1352,11 @@ class SchedulingItem(Item):
             else:
                 contacts = self.contacts
 
+        if hasattr(self, "host"):
+            contacts = contacts + self.host.contacts
+            # Make contact uniq
+            contacts = [x for i,x in enumerate(contacts) if x not in contacts[i+1:]]
+
         for contact in contacts:
             # We do not want to notify again a contact with
             # notification interval == 0 that has been already


### PR DESCRIPTION
Hi,

With the following configuration when an alert is trigger on a service the non-admin contact linked to parent host for my service is not notified.

```
Host : 
  ...
  contact_groups: +my_contact_group

Contact group
  define contactgroup {
    contactgroup_name my_contact_group
    alias                       my_contact_group
    members                my_contact
  }

Contact
  define contact{
    use			generic-contact
    contact_name	my_contact
    email	                me@word.tld	

    service_notifications_enabled 1 
    notificationways   detailled-email
}


define notificationway{
   notificationway_name            detailled-email
   service_notification_period     24x7
   host_notification_period        24x7
   service_notification_options    c,w,r
   host_notification_options       d,u,r,f,s
   service_notification_commands   detailled-service-by-email ; send service notifications via email
   host_notification_commands      detailled-host-by-email    ; send host notifications via email
}
```

As I see in schedulingitem the contacts field of host is not handle. I've write few lines in order to catch this case.

Not sure this is the right way or if I've made a configuration mistake. What do you think about this ?

Regards
