### PR TITLE
Typo: Update some doc files.

### DIFF
--- a/doc/source/03_configuration/configmain-advanced.rst
+++ b/doc/source/03_configuration/configmain-advanced.rst
@@ -807,10 +807,8 @@ Example:
 
 This option determines whether or not Shinken will check the :ref:`External Command File <configuration/configmain-advanced#command_file>` for commands that should be executed with the **arbiter daemon**. More information on external commands can be found :ref:`here <advanced/extcommands>`.
 
-  * 0 = Don't check external commands (default)
+  * 0 = Don't check external commands
   * 1 = Check external commands (default)
-
-.. note::  FIX ME : Find the real default value
 
 
 .. _configuration/configmain-advanced#command_file:

--- a/doc/source/05_thebasics/passivechecks.rst
+++ b/doc/source/05_thebasics/passivechecks.rst
@@ -40,7 +40,7 @@ How Passive Checks Work
    :scale: 90 %
 
 
-DEPRECATED IMAGE - TODO REPLACE WITH MOE ACCURATE DEPTICTION
+DEPRECATED IMAGE - TODO REPLACE WITH MORE ACCURATE DEPICTION
 
 Here's how passive checks work in more detail...
 

--- a/doc/source/08_configobjects/broker.rst
+++ b/doc/source/08_configobjects/broker.rst
@@ -62,7 +62,7 @@ broker_name
   This variable is used to identify the *short name* of the broker which the data is associated with.
 
 address
-  This directive is used to define the address from where the main arbier can reach this broker. This can be a DNS name or a IP address.
+  This directive is used to define the address from where the main arbiter can reach this broker. This can be a DNS name or a IP address.
 
 port
   This directive is used to define the TCP port used bu the daemon. The default value is *7772*.

--- a/doc/source/08_configobjects/poller.rst
+++ b/doc/source/08_configobjects/poller.rst
@@ -62,7 +62,7 @@ poller_name
   This variable is used to identify the *short name* of the poller which the data is associated with.
 
 address
-  This directive is used to define the address from where the main arbier can reach this poller. This can be a DNS name or a IP address.
+  This directive is used to define the address from where the main arbiter can reach this poller. This can be a DNS name or a IP address.
 
 port
   This directive is used to define the TCP port used bu the daemon. The default value is *7771*.

--- a/doc/source/08_configobjects/reactionner.rst
+++ b/doc/source/08_configobjects/reactionner.rst
@@ -62,7 +62,7 @@ reactionner_name
   This variable is used to identify the *short name* of the reactionner which the data is associated with.
 
 address
-  This directive is used to define the address from where the main arbier can reach this reactionner. This can be a DNS name or a IP address.
+  This directive is used to define the address from where the main arbiter can reach this reactionner. This can be a DNS name or a IP address.
 
 port
   This directive is used to define the TCP port used bu the daemon. The default value is *7772*.

--- a/doc/source/08_configobjects/scheduler.rst
+++ b/doc/source/08_configobjects/scheduler.rst
@@ -70,7 +70,7 @@ scheduler_name
   This variable is used to identify the *short name* of the scheduler which the data is associated with.
 
 address
-  This directive is used to define the address from where the main arbier can reach this scheduler. This can be a DNS name or a IP address.
+  This directive is used to define the address from where the main arbiter can reach this scheduler. This can be a DNS name or a IP address.
 
 port
   This directive is used to define the TCP port used bu the daemon. The default value is *7768*.

--- a/manpages/manpages/shinken-arbiter.8
+++ b/manpages/manpages/shinken-arbiter.8
@@ -81,7 +81,7 @@ Dump a profile file. Need the python cProfile librairy
 Dump an analyse statistics file, for support
 .TP
 .BI \-m \ MIGRATE\fP,\fB \ \-\-migrate\fB= MIGRATE
-Migrate the raw configuration read from the arbier to another module. \-\-> VERY EXPERIMENTAL!
+Migrate the raw configuration read from the arbiter to another module. \-\-> VERY EXPERIMENTAL!
 .TP
 .BI \-n \ ARB_NAME\fP,\fB \ \-\-name\fB= ARB_NAME
 Give the arbiter name to use. Optionnal, will use the hostaddress if not provide to find it.

--- a/manpages/sources/shinken-arbiter.rst
+++ b/manpages/sources/shinken-arbiter.rst
@@ -48,6 +48,6 @@ OPTIONS
   --debugfile=DEBUGFILE                     Enable debug logging to *DEBUGFILE*
   -p PROFILE, --profile=PROFILE             Dump a profile file. Need the python cProfile librairy
   -a ANALYSE, --analyse=ANALYSE             Dump an analyse statistics file, for support
-  -m MIGRATE, --migrate=MIGRATE             Migrate the raw configuration read from the arbier to another module. --> VERY EXPERIMENTAL!
+  -m MIGRATE, --migrate=MIGRATE             Migrate the raw configuration read from the arbiter to another module. --> VERY EXPERIMENTAL!
   -n ARB_NAME, --name=ARB_NAME              Give the arbiter name to use. Optionnal, will use the hostaddress if not provide to find it.
 


### PR DESCRIPTION
Correct arbier to arbiter, which was copied/pasted in some files.
One "No newline at end of file".