### PR TITLE
Reverse dependency admin <-> admins.

### DIFF
--- a/etc/contactgroups/admins.cfg
+++ b/etc/contactgroups/admins.cfg
@@ -1,6 +1,5 @@
 define contactgroup{
     contactgroup_name   admins
     alias               admins
-    members             admin
 }
 

--- a/etc/contactgroups/users.cfg
+++ b/etc/contactgroups/users.cfg
@@ -1,5 +1,4 @@
 define contactgroup{
     contactgroup_name   users
     alias               users
-    members             admin
 }

--- a/etc/contacts/admin.cfg
+++ b/etc/contacts/admin.cfg
@@ -4,6 +4,7 @@
 define contact{
     use             generic-contact
     contact_name    admin
+    contactgroups   admin,users
     email           shinken@localhost
     pager           0600000000   ; contact phone number
     password        admin


### PR DESCRIPTION
When admins declared admin as a member, any standardised packaging (e.g. Docker) would have to include a user admin as declared by contacts/admin.cfg. With users declaring their groups, admin.cfg can simply be excluded in packaging.