### PR TITLE
Fixed omission of warn, grit, min or max from graphs if set to 0

### DIFF
--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -71,12 +71,11 @@ class Metric:
                 self.max = 100
 
     def __str__(self):
-        s = "%s=%s%s" % (self.name, self.value, self.uom)
-        if self.warning:
-            s = s + ";%s" % (self.warning)
-        if self.critical:
-            s = s + ";%s" % (self.critical)
-        return s
+        components = [ "%s=%s%s" % (self.name, self.value, self.uom),
+                       self.warning, self.critical, self.min, self.max ]
+        while components[-1] is None:
+	    components.pop()
+        return ";".join(map(lambda v: "" if v is None else str(v), components))
 
 
 class PerfDatas:

--- a/test/test_string_perfdata.py
+++ b/test/test_string_perfdata.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2009-2014:
+#    Gabes Jean, naparuba@gmail.com
+#    Gerhard Lausser, Gerhard.Lausser@consol.de
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# This file is used to test reading and processing of config files
+#
+
+from shinken_test import *
+from shinken.misc.perfdata import Metric, PerfDatas
+
+
+class TestStringPerfdata(ShinkenTest):
+    # Uncomment this is you want to use a specific configuration
+    # for your test
+    #def setUp(self):
+    #    self.setup_with_file('etc/shinken_parse_perfdata.cfg')
+
+    def test_string_all_four(self):
+        self.assertEqual('ramused=1009MB;1;2;3;4', str(Metric('ramused=1009MB;1;2;3;4')))
+
+    def test_string_drop_empty_from_end(self):
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB')))
+        self.assertEqual('ramused=1009MB;1', str(Metric('ramused=1009MB;1')))
+        self.assertEqual('ramused=1009MB;1;2', str(Metric('ramused=1009MB;1;2')))
+        self.assertEqual('ramused=1009MB;1;2;3', str(Metric('ramused=1009MB;1;2;3')))
+        self.assertEqual('ramused=1009MB;1;2;3;4', str(Metric('ramused=1009MB;1;2;3;4')))
+
+    def test_string_empty_for_None(self):
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;;;')))
+
+        self.assertEqual('ramused=1009MB;;2', str(Metric('ramused=1009MB;;2')))
+        self.assertEqual('ramused=1009MB;;;3', str(Metric('ramused=1009MB;;;3')))
+        self.assertEqual('ramused=1009MB;;;;4', str(Metric('ramused=1009MB;;;;4')))
+
+        self.assertEqual('ramused=1009MB;;2;;4', str(Metric('ramused=1009MB;;2;;4')))
+
+    def test_string_zero_preserved(self):
+        self.assertEqual('ramused=1009MB;0', str(Metric('ramused=1009MB;0')))
+        self.assertEqual('ramused=1009MB;;0', str(Metric('ramused=1009MB;;0')))
+        self.assertEqual('ramused=1009MB;;;0', str(Metric('ramused=1009MB;;;0')))
+        self.assertEqual('ramused=1009MB;;;;0', str(Metric('ramused=1009MB;;;;0')))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
String version of `Metric` does not include min or max values, even if they were present in the string passed to the constructor.

String version of `Metric` does not include values for warn, crit, min, or max if they were specified with value `0`. This happens because their inclusion in the string representation of `Metric` was conditional on their boolean-ish value (which is `false` for `0`). Changed to check for `None` instead.

String version of Metric did not collapse None values into empty semi-colon delimited sections, causing input of `;;1` to result in `;1` on conversion to string. Combined with above to remove collapsed `None` values from the end as well.