### PR TITLE
Further fixes to min/max handling and quotes in names

### DIFF
--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -71,10 +71,9 @@ class Metric:
                 self.max = 100
 
     def __str__(self):
-        components = [ "%s=%s%s" % (self.name, self.value, self.uom),
-                       self.warning, self.critical, self.min, self.max ]
+        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, self.min, self.max]
         while components[-1] is None:
-	    components.pop()
+            components.pop()
         return ";".join(map(lambda v: "" if v is None else str(v), components))
 
 

--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -71,12 +71,11 @@ class Metric:
                 self.max = 100
 
     def __str__(self):
-        s = "%s=%s%s" % (self.name, self.value, self.uom)
-        if self.warning:
-            s = s + ";%s" % (self.warning)
-        if self.critical:
-            s = s + ";%s" % (self.critical)
-        return s
+        components = [ "%s=%s%s" % (self.name, self.value, self.uom),
+                       self.warning, self.critical, self.min, self.max ]
+        while components[-1] is None:
+	    components.pop()
+        return ";".join(map(lambda v: "" if v is None else str(v), components))
 
 
 class PerfDatas:

--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -34,6 +34,8 @@ metric_pattern = \
         '^([^=]+)=([\d\.\-\+eE]+)([\w\/%]*)'
         ';?([\d\.\-\+eE:~@]+)?;?([\d\.\-\+eE:~@]+)?;?([\d\.\-\+eE]+)?;?([\d\.\-\+eE]+)?;?\s*'
     )
+quote_pattern = re.compile("^'(.+)'$")
+replace1_pattern = re.compile('\1')
 
 
 # If we can return an int or a float, or None
@@ -54,32 +56,31 @@ class Metric:
         # print "Analysis string", s
         r = metric_pattern.match(s)
         if r:
-            # Get the name but remove all ' in it
-            self.name = r.group(1).replace("'", "")
+            # Strip outer quotes, and replace double quotes with single
+            self.name = re.sub(r"^'(.+)'$", r'\1', r.group(1)).replace("''", "'")
             self.value = guess_int_or_float(r.group(2))
             self.uom = r.group(3)
             self.warning = guess_int_or_float(r.group(4))
             self.critical = guess_int_or_float(r.group(5))
-            self.min = guess_int_or_float(r.group(6))
-            self.max = guess_int_or_float(r.group(7))
-            self.min_specified = self.min is not None
-            self.max_specified = self.max is not None
+            self.min = self.min_supplied = guess_int_or_float(r.group(6))
+            self.max = self.max_supplied = guess_int_or_float(r.group(7))
             # print 'Name', self.name
             # print "Value", self.value
             # print "Res", r
             # print r.groups()
             if self.uom == '%':
-                self.min = self.min if self.min_specified is not None else 0
-                self.max = self.max if self.max_specified is not None else 100
+                self.min = 0 if self.min is None else self.min
+                self.max = 100 if self.max is None else self.max
 
     def __str__(self):
-        min = self.min if self.min_specified else None
-        max = self.max if self.max_specified else None
-        prefix =  "min=%s, max=%s" % (min, max)
-        if self.uom == '%':
-            min = None if (self.min == 0) and not self.min_specified else min
-            max = None if (self.max == 100) and not self.max_specified else max
-        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, min, max]
+        # Restore double quotes in nae
+        name = self.name.replace("'", "''")
+        # Quote whole name if it contains a space
+        if " " in name:
+            name = "'" + name + "'"
+        min = self.min_supplied
+        max = self.max_supplied
+        components = ["%s=%s%s" % (name, self.value, self.uom), self.warning, self.critical, min, max]
         while components[-1] is None:
             components.pop()
         return ";".join(map(lambda v: "" if v is None else str(v), components))

--- a/shinken/misc/perfdata.py
+++ b/shinken/misc/perfdata.py
@@ -62,16 +62,24 @@ class Metric:
             self.critical = guess_int_or_float(r.group(5))
             self.min = guess_int_or_float(r.group(6))
             self.max = guess_int_or_float(r.group(7))
+            self.min_specified = self.min is not None
+            self.max_specified = self.max is not None
             # print 'Name', self.name
             # print "Value", self.value
             # print "Res", r
             # print r.groups()
             if self.uom == '%':
-                self.min = 0
-                self.max = 100
+                self.min = self.min if self.min_specified is not None else 0
+                self.max = self.max if self.max_specified is not None else 100
 
     def __str__(self):
-        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, self.min, self.max]
+        min = self.min if self.min_specified else None
+        max = self.max if self.max_specified else None
+        prefix =  "min=%s, max=%s" % (min, max)
+        if self.uom == '%':
+            min = None if (self.min == 0) and not self.min_specified else min
+            max = None if (self.max == 100) and not self.max_specified else max
+        components = ["%s=%s%s" % (self.name, self.value, self.uom), self.warning, self.critical, min, max]
         while components[-1] is None:
             components.pop()
         return ";".join(map(lambda v: "" if v is None else str(v), components))
@@ -99,3 +107,4 @@ class PerfDatas:
 
     def __contains__(self, key):
         return key in self.metrics
+

--- a/test/test_string_perfdata.py
+++ b/test/test_string_perfdata.py
@@ -77,6 +77,18 @@ class TestStringPerfdata(ShinkenTest):
         self.assertEqual('utilization=80%;50;75;85', str(Metric('utilization=80%;50;75;85')))
         self.assertEqual('utilization=80%;50;75;;95', str(Metric('utilization=80%;50;75;;95')))
 
+    def test_string_quoted_names(self):
+        self.assertEqual("ram''used''=10", str(Metric("ram''used''=10")))
+        self.assertEqual("ram''used=10", str(Metric("ram''used=10")))
+        # Outer quotes present but not necessary should be stripped on format
+        self.assertEqual("ram''used=10", str(Metric("'ram''used'=10")))
+        # But not so if there is also a space
+        self.assertEqual("'ram was ''used'=10", str(Metric("'ram was ''used'=10")))
+
+        # String missing required outer quotes, should come back quoted
+        # This is debatable as it basically is an invalid metric/perfdata
+        self.assertEqual("'ram  ''used'''=10", str(Metric("ram  ''used''=10")))
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test/test_string_perfdata.py
+++ b/test/test_string_perfdata.py
@@ -61,6 +61,22 @@ class TestStringPerfdata(ShinkenTest):
         self.assertEqual('ramused=1009MB;;;0', str(Metric('ramused=1009MB;;;0')))
         self.assertEqual('ramused=1009MB;;;;0', str(Metric('ramused=1009MB;;;;0')))
 
+    def test_string_percent_minmaxdefault_0_100(self):
+        # If not specified, defaults of 0 and 100 for min/max should not come back
+        self.assertEqual('utilization=80%;90;95', str(Metric('utilization=80%;90;95')))
+        self.assertEqual('utilization=80%;90;95;;', str(Metric('utilization=80%;90;95')) + ";;")
+
+    def test_string_percent_minmax_echo(self):
+        # Defined values of min max should come back always, even if defaults
+        self.assertEqual('utilization=80%;50;75;0;100', str(Metric('utilization=80%;50;75;0;100')))
+        self.assertEqual('utilization=80%;50;75;0', str(Metric('utilization=80%;50;75;0')))
+        self.assertEqual('utilization=80%;50;75;;100', str(Metric('utilization=80%;50;75;;100')))
+
+        # Same tests with non-default values
+        self.assertEqual('utilization=80%;50;75;85;95', str(Metric('utilization=80%;50;75;85;95')))
+        self.assertEqual('utilization=80%;50;75;85', str(Metric('utilization=80%;50;75;85')))
+        self.assertEqual('utilization=80%;50;75;;95', str(Metric('utilization=80%;50;75;;95')))
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test/test_string_perfdata.py
+++ b/test/test_string_perfdata.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2009-2014:
+#    Gabes Jean, naparuba@gmail.com
+#    Gerhard Lausser, Gerhard.Lausser@consol.de
+#
+# This file is part of Shinken.
+#
+# Shinken is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Shinken is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Shinken.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# This file is used to test reading and processing of config files
+#
+
+from shinken_test import *
+from shinken.misc.perfdata import Metric, PerfDatas
+
+
+class TestStringPerfdata(ShinkenTest):
+    # Uncomment this is you want to use a specific configuration
+    # for your test
+    #def setUp(self):
+    #    self.setup_with_file('etc/shinken_parse_perfdata.cfg')
+
+    def test_string_all_four(self):
+        self.assertEqual('ramused=1009MB;1;2;3;4', str(Metric('ramused=1009MB;1;2;3;4')))
+
+    def test_string_drop_empty_from_end(self):
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB')))
+        self.assertEqual('ramused=1009MB;1', str(Metric('ramused=1009MB;1')))
+        self.assertEqual('ramused=1009MB;1;2', str(Metric('ramused=1009MB;1;2')))
+        self.assertEqual('ramused=1009MB;1;2;3', str(Metric('ramused=1009MB;1;2;3')))
+        self.assertEqual('ramused=1009MB;1;2;3;4', str(Metric('ramused=1009MB;1;2;3;4')))
+
+    def test_string_empty_for_None(self):
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;;')))
+        self.assertEqual('ramused=1009MB', str(Metric('ramused=1009MB;;;;')))
+
+        self.assertEqual('ramused=1009MB;;2', str(Metric('ramused=1009MB;;2')))
+        self.assertEqual('ramused=1009MB;;;3', str(Metric('ramused=1009MB;;;3')))
+        self.assertEqual('ramused=1009MB;;;;4', str(Metric('ramused=1009MB;;;;4')))
+
+        self.assertEqual('ramused=1009MB;;2;;4', str(Metric('ramused=1009MB;;2;;4')))
+
+    def test_string_zero_preserved(self):
+        self.assertEqual('ramused=1009MB;0', str(Metric('ramused=1009MB;0')))
+        self.assertEqual('ramused=1009MB;;0', str(Metric('ramused=1009MB;;0')))
+        self.assertEqual('ramused=1009MB;;;0', str(Metric('ramused=1009MB;;;0')))
+        self.assertEqual('ramused=1009MB;;;;0', str(Metric('ramused=1009MB;;;;0')))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Various fixes in perfdata handling
    
    Previous change for handling defaults for min/max in perfdata without % was incorrect. We should distinguish between several use cases. The first is that when reading min/max for this case, the values should reflect defaults even if no values where specified. The second is that when these values were not specified, they should also not be reflected in the string representation. This was accomplished through two shadow variables.
    
    The handling of quotes in metric names was incorrect. As written "outer quotes" which would be necessitated if the metric name contains at least one space, are not stripped resulting in the "name" property incorrectly still containing these quotes. They should be stripped and re-attached in the string representation only. Secondly all single quotes are stripped. This is wrong, as the specification states that single quotes in the name are to be represented by two successive single quotes in perfdata. Stripping would remove all trace of the quotes. The fix is to replace double-single-quotes with single quotes, after first stripping just the outer quotes, if presen. A related problem is that none of the input transformations on the name are "undone" in the string representation. This makes a re-parse of the string representation result in a non-identical result. The fix was to re-attach the reverse transformations.
    
    Several test cases were added to catch the above scenarios.