### PR TITLE
Fix #1825 : BP rules: take into account acknowledgements

### DIFF
--- a/doc/source/06_medium/business-rules.rst
+++ b/doc/source/06_medium/business-rules.rst
@@ -482,5 +482,12 @@ Imagine you want to build a consolidated service which notifications contain lin
 
 The resulting output would look like ``Down web services: link1 link2 link3 ...`` where ``linkN`` are urls leading to the problem in the WebUI.
 
+Acknowledge management
+======================
+
+By default, if we acknowledge an element, it conserves its state to determine the status of our aggregated service.
+In some cases, we want that an acknowledge element is considered as if it was in Ok/Up state for a business rule.
+
+To enable this feature, simply set `business_rule_ack_as_ok`` to ``1``..
 
 .. _ticket: https://github.com/naparuba/shinken/issues/509

--- a/doc/source/08_configobjects/host.rst
+++ b/doc/source/08_configobjects/host.rst
@@ -79,6 +79,7 @@ labels                                     *labels*
 business_rule_output_template              *template*
 business_rule_smart_notifications          [0/1]
 business_rule_downtime_as_ack              [0/1]
+business_rule_ack_as_ok                    [0/1]
 business_rule_host_notification_options    [d,u,r,f,s]
 business_rule_service_notification_options [w,u,c,r,f,s]
 snapshot_enabled                           [0/1]
@@ -321,8 +322,11 @@ business_rule_output_template
 business_rule_smart_notifications
   This variable may be used to activate smart notifications on :ref:`business rules <medium/business-rules>`. This allows to stop sending notification if all underlying problems have been acknowledged.
 
-business_rule_smart_notifications
+business_rule_downtime_as_ack
   By default, downtimes are not taken into account by :ref:`business rules <medium/business-rules>` smart notifications processing. This variable allows to extend smart notifications to underlying hosts or service checks under downtime (they are treated as if they were acknowledged).
+
+business_rule_ack_as_ok
+  By default, acknowledging an underlying problem doesn't change its state for the :ref:`business rules <medium/business-rules>` evaluation. This variable allows to treat acknowledged services or hosts as if their are in an Ok/Up state.
 
 business_rule_host_notification_options
   This option allows to enforce :ref:`business rules <medium/business-rules>` underlying hosts notification options to easily compose a consolidated meta check. This is especially useful for business rules relying on grouping expansion.

--- a/doc/source/08_configobjects/service.rst
+++ b/doc/source/08_configobjects/service.rst
@@ -70,6 +70,7 @@ labels                                     *labels*
 business_rule_output_template              *template*
 business_rule_smart_notifications          [0/1]
 business_rule_downtime_as_ack              [0/1]
+business_rule_ack_as_ok                    [0/1]
 business_rule_host_notification_options    [d,u,r,f,s]
 business_rule_service_notification_options [w,u,c,r,f,s]
 snapshot_enabled                           [0/1]
@@ -399,8 +400,11 @@ business_rule_output_template
 business_rule_smart_notifications
   This variable may be used to activate smart notifications on :ref:`business rules <medium/business-rules>`. This allows to stop sending notification if all underlying problems have been acknowledged.
 
-business_rule_smart_notifications
+business_rule_downtime_as_ack
   By default, downtimes are not taken into account by :ref:`business rules <medium/business-rules>` smart notifications processing. This variable allows to extend smart notifications to underlying hosts or service checks under downtime (they are treated as if they were acknowledged).
+
+business_rule_ack_as_ok
+  By default, acknowledging an underlying problem doesn't change its state for the :ref:`business rules <medium/business-rules>` evaluation. This variable allows to treat acknowledged services or hosts as if their are in an Ok/Up state.
 
 business_rule_host_notification_options
   This option allows to enforce :ref:`business rules <medium/business-rules>` underlying hosts notification options to easily compose a consolidated meta check. This is especially useful for business rules relying on grouping expansion.

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -211,6 +211,9 @@ class Host(SchedulingItem):
         # Treat downtimes as acknowledgements in smart notifications
         'business_rule_downtime_as_ack':
             BoolProp(default=False, fill_brok=['full_status']),
+        # Treat acknowledged host/service like an Ok/Up state in a business rule
+        'business_rule_ack_as_ok':
+            BoolProp(default=False, fill_brok=['full_status']),
         # Enforces child nodes notification options
         'business_rule_host_notification_options':
             ListProp(default=[], fill_brok=['full_status']),

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -198,6 +198,9 @@ class Service(SchedulingItem):
         # Treat downtimes as acknowledgements in smart notifications
         'business_rule_downtime_as_ack':
             BoolProp(default=False, fill_brok=['full_status']),
+        # Treat acknowledged host/service like an Ok/Up state in a business rule
+        'business_rule_ack_as_ok':
+            BoolProp(default=False, fill_brok=['full_status']),
         # Enforces child nodes notification options
         'business_rule_host_notification_options':
             ListProp(default=[], fill_brok=['full_status'], split_on_coma=True),

--- a/test/etc/business_correlator/hosts.cfg
+++ b/test/etc/business_correlator/hosts.cfg
@@ -16,6 +16,7 @@ define host{
   retain_nonstatus_information   1
   retain_status_information      1
   retry_interval                 1
+  business_rule_ack_as_ok        1
 }
 
 define host{

--- a/test/etc/business_correlator/services.cfg
+++ b/test/etc/business_correlator/services.cfg
@@ -22,6 +22,7 @@ define service{
   retain_nonstatus_information   1
   retain_status_information      1
   retry_interval                 1
+  business_rule_ack_as_ok        1
 }
 
 

--- a/test/test_business_correlator.py
+++ b/test/test_business_correlator.py
@@ -56,6 +56,7 @@ class TestBusinesscorrel(ShinkenTest):
         self.assertEqual(False, svc_bd2.got_business_rule)
         self.assertIs(None, svc_bd2.business_rule)
         svc_cor = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "Simple_Or")
+        self.assertIs(True, svc_cor.business_rule_ack_as_ok)
         self.assertEqual(True, svc_cor.got_business_rule)
         self.assertIsNot(svc_cor.business_rule, None)
         bp_rule = svc_cor.business_rule
@@ -128,7 +129,19 @@ class TestBusinesscorrel(ShinkenTest):
         state = bp_rule.get_state()
         self.assertEqual(1, state)
 
+        # With business_rule_ack_as_ok in a rule, an service/host acknowledged
+        # have an Ok/Up state for the evaluation of the rule
 
+        # We acknowledge bd1
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db1;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd1.problem_has_been_acknowledged)
+        self.assertEqual('CRITICAL', svc_bd1.state)
+        self.assertEqual('HARD', svc_bd1.state_type)
+        self.assertEqual(2, svc_bd1.last_hard_state_id)
+        # Must be OK (bd 1 is OK from the rule point of view)
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
 
 
     # We will try a simple bd1 AND db2
@@ -218,6 +231,22 @@ class TestBusinesscorrel(ShinkenTest):
         self.assertEqual(1, svc_bd1.last_hard_state_id)
 
         # Must be WARNING (worse no 0 value for both)
+        state = bp_rule.get_state()
+        self.assertEqual(1, state)
+
+        # With business_rule_ack_as_ok in a rule, an service/host acknowledged
+        # have an Ok/Up state for the evaluation of the rule
+
+        # BD1 Critical, BD2 Warning, we acknowledge bd1
+        self.scheduler_loop(2, [[svc_bd1, 2, 'CRITICAL | value1=1 value2=2']])
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db1;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd1.problem_has_been_acknowledged)
+        self.assertEqual('CRITICAL', svc_bd1.state)
+        self.assertEqual('HARD', svc_bd1.state_type)
+        self.assertEqual(2, svc_bd1.last_hard_state_id)
+
+        # Must be Warning (bd 1 is OK from the rule point of view)
         state = bp_rule.get_state()
         self.assertEqual(1, state)
 
@@ -350,6 +379,21 @@ class TestBusinesscorrel(ShinkenTest):
         # Must be WARNING (worse no 0 value for both, like for AND rule)
         state = bp_rule.get_state()
         self.assertEqual(1, state)
+
+        # With business_rule_ack_as_ok in a rule, an service/host acknowledged
+        # have an Ok/Up state for the evaluation of the rule
+
+        # BD1 Warning, BD2 Critical, we acknowledge bd2
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db2;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd2.problem_has_been_acknowledged)
+        self.assertEqual('CRITICAL', svc_bd2.state)
+        self.assertEqual('HARD', svc_bd2.state_type)
+        self.assertEqual(2, svc_bd2.last_hard_state_id)
+
+        # Must be OK (bd2 is OK from the rule point of view)
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
 
     # We will try a simple 1of: test_router_0 OR/AND test_host_0
     def test_simple_1of_business_correlator_with_hosts(self):
@@ -643,6 +687,43 @@ class TestBusinesscorrel(ShinkenTest):
         # and bd1 too
         self.assertIn(svc_cor, svc_bd1.impacts)
 
+        # With business_rule_ack_as_ok in a rule, an service/host acknowledged
+        # have an Ok/Up state for the evaluation of the rule
+
+        # BD2 Warning, BD1 Critical, we acknowledge bd2
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db2;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd2.problem_has_been_acknowledged)
+
+        self.assertEqual('WARNING', svc_bd2.state)
+        self.assertEqual('HARD', svc_bd2.state_type)
+        self.assertEqual(1, svc_bd2.last_hard_state_id)
+
+        # Must be Ok
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
+
+        # And in a HARD
+        print "Launch internal check"
+        svc_cor.launch_check(now-1)
+        c = svc_cor.actions[0]
+        self.assertEqual(True, c.internal)
+        self.assertTrue(c.is_launchable(now))
+
+        # ask the scheduler to launch this check
+        # and ask 2 loops: one for launch the check
+        # and another to integer the result
+        self.scheduler_loop(2, [])
+
+        # We should have no more the check
+        self.assertEqual(0, len(svc_cor.actions))
+
+        print "Look at svc_cor state", svc_cor.state
+        # What is the svc_cor state now?
+        self.assertEqual('OK', svc_cor.state)
+        self.assertEqual('HARD', svc_cor.state_type)
+        self.assertEqual(0, svc_cor.last_hard_state_id)
+
     def test_dep_node_list_elements(self):
         svc_bd1 = self.sched.services.find_srv_by_name_and_hostname("test_host_0", "db1")
         self.assertEqual(False, svc_bd1.got_business_rule)
@@ -888,6 +969,39 @@ class TestBusinesscorrel(ShinkenTest):
         self.assertEqual('WARNING', svc_cor.state)
         self.assertEqual('HARD', svc_cor.state_type)
         self.assertEqual(1, svc_cor.last_hard_state_id)
+
+        #Now we acknowledge the warning in bd2 with business_rule_ack_as_ok
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db2;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd2.problem_has_been_acknowledged)
+        self.assertEqual('WARNING', svc_bd2.state)
+        self.assertEqual('HARD', svc_bd2.state_type)
+        self.assertEqual(1, svc_bd2.last_hard_state_id)
+
+        # Must be OK
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
+
+        # And in a HARD
+        print "ERP: Launch internal check"
+        svc_cor.launch_check(now-1)
+        c = svc_cor.actions[0]
+        self.assertEqual(True, c.internal)
+        self.assertTrue(c.is_launchable(now))
+
+        # ask the scheduler to launch this check
+        # and ask 2 loops: one for launch the check
+        # and another to integer the result
+        self.scheduler_loop(2, [])
+
+        # We should have no more the check
+        self.assertEqual(0, len(svc_cor.actions))
+
+        print "ERP: Look at svc_cor state", svc_cor.state
+        # What is the svc_cor state now?
+        self.assertEqual('OK', svc_cor.state)
+        self.assertEqual('HARD', svc_cor.state_type)
+        self.assertEqual(0, svc_cor.last_hard_state_id)
 
         print "All elements", bp_rule.list_all_elements()
 
@@ -1157,6 +1271,34 @@ class TestBusinesscorrel(ShinkenTest):
         bp_rule.is_of_mul = True
         self.assertEqual(1, bp_rule.get_state())
 
+        ##* W ack(C) C O O with business_rule_ack_as_ok
+        # * 3 of: OK
+        # * 4,1,1 -> Critical (same as before)
+        # * 4,1,2 -> Warning
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;B;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+
+        if with_pct == False:
+            bp_rule.of_values = ('3', '5', '5')
+        else:
+            bp_rule.of_values = ('60%', '100%', '100%')
+        bp_rule.is_of_mul = False
+        self.assertEqual(0, bp_rule.get_state())
+        # * 4,1,1
+        if with_pct == False:
+            bp_rule.of_values = ('4', '1', '1')
+        else:
+            bp_rule.of_values = ('80%', '20%', '20%')
+        bp_rule.is_of_mul = True
+        self.assertEqual(2, bp_rule.get_state())
+        # * 4,1,3
+        if with_pct == False:
+            bp_rule.of_values = ('4', '1', '2')
+        else:
+            bp_rule.of_values = ('80%', '20%', '40%')
+        bp_rule.is_of_mul = True
+        self.assertEqual(1, bp_rule.get_state())
+
     # We will try a simple bd1 AND NOT db2
     def test_simple_and_not_business_correlator(self):
         #
@@ -1247,6 +1389,17 @@ class TestBusinesscorrel(ShinkenTest):
         # Must be WARNING (worse no 0 value for both)
         state = bp_rule.get_state()
         self.assertEqual(1, state)
+
+        # Acknowledge bd2 with business_rule_ack_as_ok
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db2;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertEqual('WARNING', svc_bd2.state)
+        self.assertEqual('HARD', svc_bd2.state_type)
+        self.assertEqual(1, svc_bd2.last_hard_state_id)
+
+        # Must be CRITICAL
+        state = bp_rule.get_state()
+        self.assertEqual(2, state)
 
         # Now try to get ok in both place, should be bad :)
         self.scheduler_loop(2, [[svc_bd1, 0, 'OK | value1=1 value2=2'], [svc_bd2, 0, 'OK | value1=1 value2=2']])
@@ -1404,6 +1557,18 @@ class TestBusinesscorrel(ShinkenTest):
         state = bp_rule.get_state()
         self.assertEqual(1, state)
 
+        # Acknowledge bd2 with business_rule_ack_as_ok
+        cmd = "[%lu] ACKNOWLEDGE_SVC_PROBLEM;test_host_0;db2;2;1;1;lausser;blablub" % (now)
+        self.sched.run_external_command(cmd)
+        self.assertIs(True, svc_bd2.problem_has_been_acknowledged)
+        self.assertEqual('WARNING', svc_bd2.state)
+        self.assertEqual('HARD', svc_bd2.state_type)
+        self.assertEqual(1, svc_bd2.last_hard_state_id)
+
+        # Must be OK
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
+
         # We should got now svc_bd2 and svc_bd1 as root problems
         print "Root problems"
         for p in svc_cor.source_problems:
@@ -1501,7 +1666,18 @@ class TestBusinesscorrel(ShinkenTest):
         state = bp_rule.get_state()
         self.assertEqual(0, state)
 
-
+         # We acknowledge A with business_rule_ack_as_ok
+        self.scheduler_loop(3, [[B, 0, 'UP']])
+        self.assertEqual('UP', B.state)
+        self.assertEqual('HARD', B.state_type)
+        self.assertEqual(0, B.last_hard_state_id)
+        cmd = "[%lu] ACKNOWLEDGE_HOST_PROBLEM;test_darthelmet_A;1;1;0;lausser;blablub" % now
+        self.sched.run_external_command(cmd)
+        self.assertEqual('DOWN', A.state)
+        self.assertEqual('HARD', A.state_type)
+        self.assertEqual(1, A.last_hard_state_id)
+        state = bp_rule.get_state()
+        self.assertEqual(0, state)
 
 
 

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -597,6 +597,7 @@ class TestHost(PropertiesTester, ShinkenTest):
         ('snapshot_criteria', ['d','u']),
         ('business_rule_host_notification_options', []),
         ('business_rule_service_notification_options', []),
+        ('business_rule_ack_as_ok', False)
         ])
 
     def setUp(self):
@@ -902,6 +903,7 @@ class TestService(PropertiesTester, ShinkenTest):
         ('business_rule_host_notification_options', []),
         ('business_rule_service_notification_options', []),
         ('host_dependency_enabled', True),
+        ('business_rule_ack_as_ok', False),
         ])
 
     def setUp(self):


### PR DESCRIPTION
Add a parameter for a BP rule deactivate by default : business_rule_ack_as_ok
If activate, we treat host/service acknowledged as if they are Up/Ok for the evaluation of the bp rule 