### PR TITLE
Fix#1839; missing methods in Contact class

### DIFF
--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -116,6 +116,23 @@ class Contact(Item):
         except AttributeError:
             return 'UnnamedContact'
 
+    def get_groupname(self):
+        groupname = ''
+        for cg in self.contactgroups:
+            groupname = "%s" % (cg.alias)
+        return groupname
+
+
+    def get_groupnames(self):
+        groupnames = ''
+        for cg in self.contactgroups:
+            if groupnames == '':
+                groupnames = cg.get_name()
+            else:
+                groupnames = "%s, %s" % (groupnames, cg.get_name())
+        return groupnames
+
+
     # Search for notification_options with state and if t is
     # in service_notification_period
     def want_service_notification(self, t, state, type, business_impact, cmd=None):

--- a/shinken/objects/contactgroup.py
+++ b/shinken/objects/contactgroup.py
@@ -142,6 +142,12 @@ class Contactgroups(Itemgroups):
             # We find the id, we replace the names
             cg.replace_members(new_mbrs)
 
+            # Now register us in our members
+            for c in cg.members:
+                c.contactgroups.append(cg)
+                # and be sure we are uniq in it
+                c.contactgroups = list(set(c.contactgroups))
+
     # Add a contact string to a contact member
     # if the contact group do not exist, create it
     def add_member(self, cname, cgname):


### PR DESCRIPTION
This PR simply add two missing methods in the Contact object. Those methods are used by the most recent WebUI and associated to the macros `CONTACTGROUPNAME` and `CONTACTGROUPNAMES`.

This PR also links the contact groups objects with their member contacts.