### PR TITLE
Fixing port numbers in documentation

### DIFF
--- a/doc/source/08_configobjects/reactionner.rst
+++ b/doc/source/08_configobjects/reactionner.rst
@@ -65,7 +65,7 @@ address
   This directive is used to define the address from where the main arbier can reach this reactionner. This can be a DNS name or a IP address.
 
 port
-  This directive is used to define the TCP port used bu the daemon. The default value is *7772*.
+  This directive is used to define the TCP port used bu the daemon. The default value is *7769*.
 
 spare
   This variable is used to define if the reactionner must be managed as a spare one (will take the conf only if a master failed). The default value is *0* (master).

--- a/doc/source/08_configobjects/scheduler.rst
+++ b/doc/source/08_configobjects/scheduler.rst
@@ -39,7 +39,7 @@ Example Definition:
   define scheduler{
       scheduler_name         Europe-scheduler
       address                node1.mydomain
-      port                   7770
+      port                   7768
       spare                  0
       realm                  Europe
       


### PR DESCRIPTION
In setting up my Shinken instance, I found that some of the port numbers in the documentation were incorrect.  I have fixed the docs to show the correct port numbers.

I believe I have followed your contribution guidelines, and isolated each change in its own commit.

Please let me know if you have any questions.

Thanks!