### PR TITLE
Improve systemd units reliability

### DIFF
--- a/for_fedora/systemd/shinken-arbiter.service
+++ b/for_fedora/systemd/shinken-arbiter.service
@@ -5,8 +5,11 @@ After=syslog.target
 [Service]
 Type=forking
 ExecStart=/usr/sbin/shinken-arbiter -d -r -c /etc/shinken/shinken.cfg
-KillMode=process
-TimeoutStopSec=3
+KillMode=mixed
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/arbiterd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/for_fedora/systemd/shinken-broker.service
+++ b/for_fedora/systemd/shinken-broker.service
@@ -6,7 +6,10 @@ After=syslog.target
 Type=forking
 ExecStart=/usr/sbin/shinken-broker -d -c /etc/shinken/daemons/brokerd.ini
 KillMode=mixed
-TimeoutStopSec=3
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/brokerd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/for_fedora/systemd/shinken-poller.service
+++ b/for_fedora/systemd/shinken-poller.service
@@ -5,8 +5,11 @@ After=syslog.target
 [Service]
 Type=forking
 ExecStart=/usr/sbin/shinken-poller -d -c /etc/shinken/daemons/pollerd.ini
-KillMode=process
-TimeoutStopSec=3
+KillMode=mixed
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/pollerd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/for_fedora/systemd/shinken-reactionner.service
+++ b/for_fedora/systemd/shinken-reactionner.service
@@ -5,8 +5,11 @@ After=syslog.target
 [Service]
 Type=forking
 ExecStart=/usr/sbin/shinken-reactionner -d -c /etc/shinken/daemons/reactionnerd.ini
-KillMode=process
-TimeoutStopSec=3
+KillMode=mixed
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/reactionnerd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/for_fedora/systemd/shinken-receiver.service
+++ b/for_fedora/systemd/shinken-receiver.service
@@ -5,8 +5,11 @@ After=syslog.target
 [Service]
 Type=forking
 ExecStart=/usr/sbin/shinken-receiver -d -c /etc/shinken/daemons/receiverd.ini
-KillMode=process
-TimeoutStopSec=3
+KillMode=mixed
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/receiverd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/for_fedora/systemd/shinken-scheduler.service
+++ b/for_fedora/systemd/shinken-scheduler.service
@@ -5,8 +5,11 @@ After=syslog.target
 [Service]
 Type=forking
 ExecStart=/usr/sbin/shinken-scheduler -d -c /etc/shinken/daemons/schedulerd.ini
-KillMode=process
-TimeoutStopSec=3
+KillMode=mixed
+TimeoutStopSec=30
+PIDFile=/var/run/shinken/schedulerd.pid
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* KillMode and TimeoutStopExec: instead of just stopping or killing the
master process, try to stop the master process, then if it
does not stop all the sub processes, kill all the sub processes one by
one. Sub processes are tracked via cgroups.
* PIDFile: do not make systemd guess which process is the master, but
instead let Shinken tell which one it the master.
* Restart and RestartSec: if Shinken exits for a strange reason
(SIGKILL, exit with wrong exit code...) wait 30 sec and restart it.