### PR TITLE
Fix #1866: multiple notification way when using a contact template

### DIFF
--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -297,4 +297,5 @@ class Contacts(Items):
                 if not hasattr(c, 'notificationways'):
                     c.notificationways = [nw_name]
                 else:
+                    c.notificationways = list(c.notificationways)
                     c.notificationways.append(nw_name)

--- a/test/etc/notif_way/commands.cfg
+++ b/test/etc/notif_way/commands.cfg
@@ -27,6 +27,16 @@ define command{
     #command_line    sleep 1 && /bin/true
 }
 define command{
+    command_name    notify-host-work
+    #command_line    sleep 1 && /bin/true
+    command_line    $USER1$/notifier.pl --hostname $HOSTNAME$ --notificationtype $NOTIFICATIONTYPE$ --hoststate $HOSTSTATE$ --hostoutput $HOSTOUTPUT$ --longdatetime $LONGDATETIME$ --hostattempt $HOSTATTEMPT$ --hoststatetype $HOSTSTATETYPE$
+}
+define command{
+    command_name    notify-service-work
+    command_line    $USER1$/notifier.pl --hostname $HOSTNAME$ --servicedesc $SERVICEDESC$ --notificationtype $NOTIFICATIONTYPE$ --servicestate $SERVICESTATE$ --serviceoutput $SERVICEOUTPUT$ --longdatetime $LONGDATETIME$ --serviceattempt $SERVICEATTEMPT$ --servicestatetype $SERVICESTATETYPE$
+    #command_line    sleep 1 && /bin/true
+}
+define command{
     command_name    check_service
     command_line    $USER1$/test_servicecheck.pl --type=$ARG1$ --failchance=5% --previous-state=$SERVICESTATE$ --state-duration=$SERVICEDURATIONSEC$ --total-critical-on-host=$TOTALHOSTSERVICESCRITICAL$ --total-warning-on-host=$TOTALHOSTSERVICESWARNING$ --hostname $HOSTNAME$ --servicedesc $SERVICEDESC$
 }

--- a/test/etc/notif_way/contacts.cfg
+++ b/test/etc/notif_way/contacts.cfg
@@ -4,6 +4,22 @@ define contactgroup{
     members                 test_contact
 }
 
+define contactgroup{
+    contactgroup_name       test_contact_template
+    alias                   test_contacts_template
+    members                 test_contact_template_1,test_contact_template_2
+}
+
+define contact{
+        name                            contact_template
+        host_notifications_enabled      1
+        service_notifications_enabled   1
+        email                           shinken@localhost
+        notificationways                email_in_work
+        can_submit_commands             1
+        register                        0
+}
+
 define contact{
     contact_name                    test_contact
     alias                           test_contact_alias
@@ -28,7 +44,33 @@ define contact{
     can_submit_commands             1
 }
 
+define contact{
+    use                             contact_template
+    contact_name                    test_contact_template_1
+    alias                           test_contact_alias_3
+    service_notification_period     24x7
+    host_notification_period        24x7
+    service_notification_options    w,u,c,r,f
+    host_notification_options       d,u,r,f,s
+    service_notification_commands   notify-service
+    host_notification_commands      notify-host
+    email                           nobody@localhost
+    can_submit_commands             1
+}
 
+define contact{
+    use                             contact_template
+    contact_name                    test_contact_template_2
+    alias                           test_contact_alias_4
+    service_notification_period     24x7
+    host_notification_period        24x7
+    service_notification_options    w,u,c,r,f
+    host_notification_options       d,u,r,f,s
+    service_notification_commands   notify-service-sms
+    host_notification_commands      notify-host-sms
+    email                           nobody@localhost
+    can_submit_commands             1
+}
 
 #EMail the whole 24x7 is ok
 define notificationway{
@@ -55,3 +97,12 @@ define notificationway{
 }
 
 
+define notificationway{
+       notificationway_name	email_in_work
+       service_notification_period     work
+       host_notification_period        work
+       service_notification_options    w,u,c,r,f
+       host_notification_options       d,u,r,f,s
+       service_notification_commands   notify-service-work
+       host_notification_commands      notify-host-work
+}

--- a/test/etc/notif_way/hosts.cfg
+++ b/test/etc/notif_way/hosts.cfg
@@ -45,3 +45,24 @@ define host{
   use                            generic-host
 }
 
+define host{
+  check_interval                 1
+  check_period                   24x7
+  contact_groups                 test_contact_template
+  event_handler_enabled          1
+  failure_prediction_enabled     1
+  flap_detection_enabled         1
+  max_check_attempts             3
+  host_name                      test_host_contact_template
+  notification_interval          1
+  notification_options           d,u,r,f,s
+  notification_period            24x7
+  notifications_enabled          1
+  process_perf_data              1
+  retain_nonstatus_information   1
+  retain_status_information      1
+  retry_interval                 1
+  notes_url                      /shinken/wiki/doku.php/$HOSTNAME$
+  action_url                     /shinken/pnp/index.php?host=$HOSTNAME$
+  check_command                  check-host-alive-parent!up!$HOSTSTATE:test_router_0$
+}

--- a/test/etc/notif_way/services.cfg
+++ b/test/etc/notif_way/services.cfg
@@ -41,3 +41,19 @@ define service{
   event_handler                  eventhandler
 }
 
+define service{
+  action_url                     http://search.cpan.org/dist/Monitoring-Generator-TestConfig/
+  active_checks_enabled          1
+  check_command                  check_service!ok
+  check_interval                 1
+  host_name                      test_host_contact_template
+  icon_image                     ../../docs/images/tip.gif
+  icon_image_alt                 icon alt string
+  notes                          just a notes string
+  notes_url                      http://search.cpan.org/dist/Monitoring-Generator-TestConfig/README
+  retry_interval                 1
+  service_description            test_ok_contact_template
+  servicegroups                  servicegroup_01,ok
+  use                            generic-service
+  event_handler                  eventhandler
+}

--- a/test/etc/notif_way/timeperiods.cfg
+++ b/test/etc/notif_way/timeperiods.cfg
@@ -22,3 +22,15 @@ define timeperiod{
     friday          00:00-07:30
     saturday        00:00-07:30
 }
+
+define timeperiod{
+    timeperiod_name work
+    alias           work
+    sunday          07:00-17:30
+    monday          07:00-17:30
+    tuesday         07:00-17:30
+    wednesday       07:00-17:30
+    thursday        07:00-17:30
+    friday          07:00-17:30
+    saturday        07:00-17:30
+}

--- a/test/test_notifway.py
+++ b/test/test_notifway.py
@@ -104,7 +104,23 @@ class TestConfig(ShinkenTest):
         # We take the EMAIL test because SMS got the night ony, so we take a very low value for criticity here
         self.assertEqual(False, email_in_day.want_service_notification(now, 'WARNING', 'PROBLEM', -1) )
 
+        # Test the heritage for notification ways
+        host_template = self.sched.hosts.find_by_name("test_host_contact_template")
+        commands_contact_template_1 = host_template.contacts[0].get_notification_commands('host')
+        commands_contact_template_2 = host_template.contacts[1].get_notification_commands('host')
 
+        resp = sorted([sorted([command.get_name() for command in commands_contact_template_1]),
+                       sorted([command.get_name() for command in commands_contact_template_2])])
 
+        self.assertEqual([['notify-host', 'notify-host-work'], ['notify-host-sms', 'notify-host-work']], resp)
+
+        commands_contact_template_1 = host_template.contacts[0].get_notification_commands('service')
+        commands_contact_template_2 = host_template.contacts[1].get_notification_commands('service')
+
+        resp = sorted([sorted([command.get_name() for command in commands_contact_template_1]),
+                       sorted([command.get_name() for command in commands_contact_template_2])])
+
+        self.assertEqual([['notify-service', 'notify-service-work'], ['notify-service-sms', 'notify-service-work']],
+                         resp)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fix a problem when 2 or more contacts ( C1, C2, ...)  with information about notification (notification period, notification commands,...) use the same contact template with a notification way. 

The problem is C1 contain notification way from the template, from C2 and from itself (Same problem for C2).
