### PR TITLE
Additional check for sons when "listing all elements"

### DIFF
--- a/shinken/dependencynode.py
+++ b/shinken/dependencynode.py
@@ -235,7 +235,9 @@ class DependencyNode(object):
             return [self.sons[0]]
 
         for s in self.sons:
-            r.extend(s.list_all_elements())
+            # check first if son is not None (valid conf file)
+            if s:
+                r.extend(s.list_all_elements())
 
         # and uniq the result
         return list(set(r))


### PR DESCRIPTION
We are facing a not managed exception when a manual error (human) is set in the configuration files. In particular when defining a service business process and applying it to a wrong hostname, and also when defining a valid hostgroup including a missing host member.

Current environment:
* OS: Ubuntu 14.04.5 LTS
* Shinken version 2.4.3 (via pip)

It must be checked if these objects' sons are valid or not (NoneType). This is a trace of the error:
<pre>
service shinken check

[...]
[1480336355] CRITICAL: [Shinken] Back trace of the error: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/arbiterdaemon.py", line 594, in main
    self.load_config_file()
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/arbiterdaemon.py", line 430, in load_config_file
    self.conf.create_business_rules_dependencies()
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/config.py", line 1285, in create_business_rules_dependencies
    self.hosts.create_business_rules_dependencies()
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/host.py", line 1274, in create_business_rules_dependencies
    h.create_business_rules_dependencies()
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/schedulingitem.py", line 1647, in create_business_rules_dependencies
    elts = self.business_rule.list_all_elements()
  File "/usr/local/lib/python2.7/dist-packages/shinken/dependencynode.py", line 240, in list_all_elements
    r.extend(s.list_all_elements())
AttributeError: 'NoneType' object has no attribute 'list_all_elements'
[...]
</pre>

When the check is applied, the errors are shown as normal:
<pre>
[1480336071] ERROR: [Shinken] [itemgroup::HG_test] as hostgroup, got unknown member host004
[1480336071] ERROR: [Shinken] [items] In HG_test is incorrect ; from /etc/shinken/hostgroups/hostgroups.cfg:10
[1480336071] ERROR: [Shinken] 	hostgroups conf incorrect!!

[1480336071] ERROR: [Shinken] The service 'BP_availability' got an unknown host_name 'host003'.
[1480336071] ERROR: [Shinken] [items] In availability is incorrect ; from /etc/shinken/services/service_bps.cfg:13
[1480336071] ERROR: [Shinken] 	services conf incorrect!!
</pre>

This is the config piece of related objects:
<pre>
(only exist host1 and host2)

define host {
    use                                    generic-host
    realm                                 All
    host_name                        host1
    address                             127.0.0.1
}

define host {
    use                                    generic-host
    realm                                 All
    host_name                        host2
    address                             127.0.0.1
}

define service {
    use                                          generic-service
    check_command                     bp_rule!(2,1,2of:host1|host2)
    host_name                              host3
    normal_check_interval            1
    business_impact                     3
    service_description                 BP_availability
}

define hostgroup {
    realm                                    All
    hostgroup_name                  HG_test
    members                              host1,host2,host4
}
</pre>