### PR TITLE
Fix mod-livestatus issue #74

### DIFF
--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -227,8 +227,8 @@ class Contacts(Items):
     inner_class = Contact
 
     def linkify(self, timeperiods, commands, notificationways):
-        # self.linkify_with_timeperiods(timeperiods, 'service_notification_period')
-        # self.linkify_with_timeperiods(timeperiods, 'host_notification_period')
+        self.linkify_with_timeperiods(timeperiods, 'service_notification_period')
+        self.linkify_with_timeperiods(timeperiods, 'host_notification_period')
         # self.linkify_command_list_with_commands(commands, 'service_notification_commands')
         # self.linkify_command_list_with_commands(commands, 'host_notification_commands')
         self.linkify_with_notificationways(notificationways)


### PR DESCRIPTION
mod-livestatus was unable to retrieve a contact's host notification period and service notification period, and consequently, was also unable to determine if a timestamp fell within those periods.

This fix uncomments the two linkify calls in contact.py, which allows livestatus to get the notification periods from the Contact object.