### PR TITLE
modules_manager: ignore '.git' dir when load modules.

### DIFF
--- a/shinken/modulesmanager.py
+++ b/shinken/modulesmanager.py
@@ -152,6 +152,10 @@ class ModulesManager(object):
 
         del self.imported_modules[:]
         for mod_name in modules_files:
+            # No look to .git folder
+            if mod_name == ".git":
+                logger.info("Found '.git' directory in modules, skip it.")
+                continue
             mod_file = abspath(join(self.modules_path, mod_name, 'module.py'))
             mod_dir = os.path.normpath(os.path.dirname(mod_file))
             mod = self.try_load(mod_name, mod_dir)


### PR DESCRIPTION
For backup & manage purposes used git.

Git for Shinken configuration - okay.
Git for Shinken libexec - okay.
Git for modules - why not?

```python
[1481512665] INFO: [Shinken] And arbiter is launched with the hostname:mon from an arbiter point of view of addr:mon.opentech.local
[1481512665] INFO: [Shinken] I am the master Arbiter: arbiter-master
[1481512665] INFO: [Shinken] My own modules: mongodb
[1481512665] INFO: [Shinken] Modules directory: /var/lib/shinken/modules
[1481512665] INFO: [Shinken] Modules directory: /var/lib/shinken/modules
[1481512665] INFO: [Shinken] Correctly loaded mod-mongodb as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded dummy_broker as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded dummy_arbiter as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded webui as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded mod-influxdb as a very-new-style shinken module :)
[1481512665] INFO: [Shinken] Correctly loaded logstore-mongodb as an old-new-style shinken module :|
[1481512665] WARNING: [Shinken] Cannot import .git : relative imports require the 'package' argument
[1481512665] WARNING: [Shinken] Cannot import .git..module : Empty module name
[1481512665] WARNING: [Shinken] Trying to load u'/var/lib/shinken/modules/.git' as an (very-)old-style shinken "module" : by adding its path to sys.pa
th. This can be (very) bad in case of name conflicts within the files part of /var/lib/shinken/modules/.git and others top-level python modules; I'll 
try to limit that.
[1481512665] ERROR: [Shinken] Could not import bare 'module.py' from /var/lib/shinken/modules/.git : No module named module
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/shinken/modulesmanager.py", line 114, in try_very_bad_load
    return importlib.import_module('module')
  File "/usr/lib64/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named module
[1481512665] INFO: [Shinken] Correctly loaded livestatus as a very-new-style shinken module :)
[1481512665] INFO: [Shinken] Correctly loaded dummy_broker_external as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded graphite as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded dummy_poller as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded dummy_scheduler as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded ws-arbiter as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded booster-nrpe as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Correctly loaded retention-mongodb as an old-new-style shinken module :|
[1481512665] INFO: [Shinken] Trying to init module: mongodb
```

'.git' is not a module, skip it.

```python
[1481512727] INFO: [Shinken] And arbiter is launched with the hostname:mon from an arbiter point of view of addr:mon.opentech.local
[1481512727] INFO: [Shinken] I am the master Arbiter: arbiter-master
[1481512727] INFO: [Shinken] My own modules: mongodb
[1481512727] INFO: [Shinken] Modules directory: /var/lib/shinken/modules
[1481512727] INFO: [Shinken] Modules directory: /var/lib/shinken/modules
[1481512727] INFO: [Shinken] Correctly loaded mod-mongodb as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded dummy_broker as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded dummy_arbiter as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded webui as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded mod-influxdb as a very-new-style shinken module :)
[1481512727] INFO: [Shinken] Correctly loaded logstore-mongodb as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Found '.git' directory in modules, skip it.
[1481512727] INFO: [Shinken] Correctly loaded livestatus as a very-new-style shinken module :)
[1481512727] INFO: [Shinken] Correctly loaded dummy_broker_external as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded graphite as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded dummy_poller as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded dummy_scheduler as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded ws-arbiter as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded booster-nrpe as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Correctly loaded retention-mongodb as an old-new-style shinken module :|
[1481512727] INFO: [Shinken] Trying to init module: mongodb
```