### PR TITLE
Add instructions to use --install-scripts in pip

### DIFF
--- a/doc/source/02_gettingstarted/installations/shinken-installation.rst
+++ b/doc/source/02_gettingstarted/installations/shinken-installation.rst
@@ -64,6 +64,8 @@ You can download the tarball and execute the setup.py or just use the pip comman
   pip install shinken
 
 
+.. notice:: Depending on your distribution, you may need to explicitly tell pip where to install the executables. For example on Ubuntu you should use ``pip install shinken --install-option="--install-scripts=/usr/local/bin"``.
+
 Method 2: Packages 
 -------------------
 


### PR DESCRIPTION
At least on Ubuntu Precise and Xenial, ``pip install shinken`` does not install the executables in the search path.
We have to add ``--install-option="--install-scripts=/usr/local/bin"`` to make it install to the expected directory.