### PR TITLE
Enh: extend duplicate_foreach to host/hostgroups

### DIFF
--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -820,6 +820,9 @@ class Service(SchedulingItem):
                     continue
                 value = key_value['VALUE']
                 new_s = self.copy()
+                # The copied service is not a duplicate_foreach, but a final
+                # object
+                new_s.duplicate_foreach = ""
                 new_s.host_name = host.get_name()
                 if self.is_tpl():  # if template, the new one is not
                     new_s.register = 1
@@ -1344,7 +1347,9 @@ class Services(Items):
             mesg = "a %s has been defined without host_name nor " \
                    "hostgroups%s" % (objcls, in_file)
             item.configuration_errors.append(mesg)
-        if index is True:
+        # Do not index `duplicate_foreach` services, they have to be expanded
+        # during `explode` phase, similarly to what's done with templates
+        if index is True and not item.is_duplicate():
             if hname and sdesc:
                 item = self.index_item(item)
             else:
@@ -1658,10 +1663,7 @@ class Services(Items):
         new_s = service.copy()
         new_s.host_name = host_name
         new_s.register = 1
-        if new_s.is_duplicate():
-            self.add_item(new_s, index=False)
-        else:
-            self.add_item(new_s)
+        self.add_item(new_s)
         return new_s
 
 
@@ -1791,14 +1793,6 @@ class Services(Items):
             self.explode_contact_groups_into_contacts(t, contactgroups)
             self.explode_services_from_templates(hosts, t)
 
-        # Explode services that have a duplicate_foreach clause
-        duplicates = [s.id for s in self if s.is_duplicate()]
-        for id in duplicates:
-            s = self.items[id]
-            self.explode_services_duplicates(hosts, s)
-            if not s.configuration_errors:
-                self.remove_item(s)
-
         # Then for every host create a copy of the service with just the host
         # because we are adding services, we can't just loop in it
         for s in self.items.values():
@@ -1816,13 +1810,22 @@ class Services(Items):
             # We will duplicate if we have multiple host_name
             # or if we are a template (so a clean service)
             if len(hnames) == 1:
-                self.index_item(s)
+                if not s.is_duplicate():
+                    self.index_item(s)
             else:
                 if len(hnames) >= 2:
                     self.explode_services_from_hosts(hosts, s, hnames)
                 # Delete expanded source service
                 if not s.configuration_errors:
                     self.remove_item(s)
+
+        # Explode services that have a duplicate_foreach clause
+        duplicates = [s.id for s in self if s.is_duplicate()]
+        for id in duplicates:
+            s = self.items[id]
+            self.explode_services_duplicates(hosts, s)
+            if not s.configuration_errors:
+                self.remove_item(s)
 
         to_remove = []
         for service in self:

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+
+# Local test suites
+etc/local
+etc/shinken_local.cfg
+test_local.py

--- a/test/etc/service_generators/hostgroups.cfg
+++ b/test/etc/service_generators/hostgroups.cfg
@@ -1,0 +1,4 @@
+define hostgroup {
+    hostgroup_name          test_df_expand
+    alias                   Duplicate foreach expansion test hostgroup
+}

--- a/test/etc/service_generators/hosts.cfg
+++ b/test/etc/service_generators/hosts.cfg
@@ -119,11 +119,15 @@ define host{
 define host{
   use                            test_host
   host_name                      test_host_1
+  hostgroups                     hostgroup_01,up,test_df_expand
   _sdescr1                       Generated Service H, Generated Service I
+  _sdescr3                       Generated Service L, Generated Service M
 }
 
 define host{
   use                            test_host
   host_name                      test_host_2
+  hostgroups                     hostgroup_01,up,test_df_expand
   _sdescr2                       Generated Service J, Generated Service K
+  _sdescr3                       Generated Service L, Generated Service M
 }

--- a/test/etc/service_generators/services.cfg
+++ b/test/etc/service_generators/services.cfg
@@ -131,3 +131,12 @@ define service{
   default_value		         38%!24%
   register                       0
 }
+
+define service{
+  check_command                  check_service!$KEY$!$VALUE$
+  hostgroup_name                 test_df_expand
+  service_description            $KEY$
+  servicegroups                  servicegroup_01,ok
+  use                            generic-service
+  duplicate_foreach              _sdescr3
+}

--- a/test/etc/shinken_service_generators.cfg
+++ b/test/etc/shinken_service_generators.cfg
@@ -14,6 +14,7 @@ cfg_file=standard/contacts.cfg
 cfg_file=standard/commands.cfg
 cfg_file=standard/timeperiods.cfg
 cfg_file=standard/hostgroups.cfg
+cfg_file=service_generators/hostgroups.cfg
 cfg_file=service_generators/servicegroups.cfg
 cfg_file=service_generators/shinken-specific.cfg
 check_external_commands=1

--- a/test/test_service_generators.py
+++ b/test/test_service_generators.py
@@ -163,11 +163,19 @@ class TestConfig(ShinkenTest):
         svc_i = self.sched.services.find_srv_by_name_and_hostname("test_host_1", "Generated Service I")
         svc_j = self.sched.services.find_srv_by_name_and_hostname("test_host_2", "Generated Service J")
         svc_k = self.sched.services.find_srv_by_name_and_hostname("test_host_2", "Generated Service K")
+        svc_l1 = self.sched.services.find_srv_by_name_and_hostname("test_host_1", "Generated Service L")
+        svc_m1 = self.sched.services.find_srv_by_name_and_hostname("test_host_1", "Generated Service M")
+        svc_l2 = self.sched.services.find_srv_by_name_and_hostname("test_host_2", "Generated Service L")
+        svc_m2 = self.sched.services.find_srv_by_name_and_hostname("test_host_2", "Generated Service M")
 
         self.assertIsNotNone(svc_h)
         self.assertIsNotNone(svc_i)
         self.assertIsNotNone(svc_j)
         self.assertIsNotNone(svc_k)
+        self.assertIsNotNone(svc_l1)
+        self.assertIsNotNone(svc_m1)
+        self.assertIsNotNone(svc_l2)
+        self.assertIsNotNone(svc_m2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch moves the phase where `duplicate_foreach` services are expanded in order to open the use of `duplicate_foreach` clause to hosts and hostgroups bound services, not only to service templates.

The parameter can be configured on services directly attached to hosts and hostgroups:

    define service {
        use                    generic-service
        service_description    Disk %KEY%
        command                check_disk!$KEY$
        duplicate_foreach      _disks
        host_name              test_host_1
        hostgroups             test_hostgroup_1
    }