### PR TITLE
Fix trace on sening messages

### DIFF
--- a/libexec/notify_by_email.py
+++ b/libexec/notify_by_email.py
@@ -290,10 +290,10 @@ th.customer {width: 600px; background-color: #004488; color: #ffffff;}\r
     for k,v in sorted(shinken_var.iteritems()):
         logging.debug('type %s : %s' % (k, type(v)))
         if odd:
-            html_content.append('<tr><th class="odd">' + k + '</th><td class="odd">' + v + '</td></tr>')
+            html_content.append('<tr><th class="odd">' + str(k) + '</th><td class="odd">' + str(v) + '</td></tr>')
             odd=False
         else:
-            html_content.append('<tr><th class="even">' + k + '</th><td class="even">' + v + '</td></tr>')
+            html_content.append('<tr><th class="even">' + str(k) + '</th><td class="even">' + str(v) + '</td></tr>')
             odd=True
 
     html_content.append('</table>')


### PR DESCRIPTION
We have this trace happens occasionally. Command line to cause trace was: `/var/lib/shinken/libexec/notify_by_email.py -n host -S localhost -r user@domain.com -f html -c "PROBLEM,,app,,app.internal,,Mon 29 May 10:27:17 UTC 2017"" -o ""DOWN,,00h 00m 24s" -d "" -i ""
`

Trace:

```
Traceback (most recent call last):
  File "/var/lib/shinken/libexec/notify_by_email.py", line 370, in <module>
    mail = create_html_message(mail)
  File "/var/lib/shinken/libexec/notify_by_email.py", line 213, in create_html_message
    html_content.append('<tr><th class="odd">' + k + '</th><td class="odd">' + v + '</td></tr>')
TypeError: cannot concatenate 'str' and 'NoneType' objects
```

This pull request does not fix underlaying cause but will make `notify_by_email.py` more resilient to bugs in other pieces of code.