### PR TITLE
Enh: Made memory free an opt-in option

### DIFF
--- a/doc/source/03_configuration/configmain.rst
+++ b/doc/source/03_configuration/configmain.rst
@@ -651,3 +651,19 @@ Default:
 
 
 Maximum delay to wait for parent configuration before giving up in a newly gracefully spawned daemon. This option has to be set in the daemon local \*d.ini files.
+
+Aggressive memory management
+----------------------------
+
+::
+
+  aggressive_memory_management=[0/1]
+
+Default:
+
+::
+
+  aggressive_memory_management=0
+
+
+On some distributions, dealing with large configuration can result in memory leaks when the new configuration is sent, because of an inneficient memory cleanup in the python interpreter. This options enables a more aggressive memory routine that forces unused memory to be freed.

--- a/shinken/daemon.py
+++ b/shinken/daemon.py
@@ -245,6 +245,7 @@ class Daemon(object):
         'idontcareaboutsecurity': BoolProp(default=False),
         'daemon_enabled': BoolProp(default=True),
         'graceful_enabled': BoolProp(default=False),
+        'aggressive_memory_management': BoolProp(default=False),
         'spare':         BoolProp(default=False),
         'max_queue_size': IntegerProp(default=0),
         'daemon_thread_pool_size': IntegerProp(default=16),

--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -656,7 +656,8 @@ class Arbiter(Daemon):
         self.new_conf = None
         self.cur_conf = conf
         self.conf = conf
-        free_memory()
+        if self.aggressive_memory_management:
+            free_memory()
         for arb in self.conf.arbiters:
             if (arb.address, arb.port) == (self.host, self.port):
                 self.me = arb

--- a/shinken/daemons/brokerdaemon.py
+++ b/shinken/daemons/brokerdaemon.py
@@ -419,7 +419,8 @@ class Broker(BaseSatellite):
         else:
             self.raw_conf = None
         self.new_conf = None
-        free_memory()
+        if self.aggressive_memory_management:
+            free_memory()
         # We got a name so we can update the logger and the stats global objects
         logger.load_obj(self, name)
         statsmgr.register(self, name, 'broker',

--- a/shinken/daemons/receiverdaemon.py
+++ b/shinken/daemons/receiverdaemon.py
@@ -195,7 +195,8 @@ class Receiver(Satellite):
         else:
             self.raw_conf = None
         self.new_conf = None
-        free_memory()
+        if self.aggressive_memory_management:
+            free_memory()
 
         statsmgr.register(self, self.name, 'receiver',
                           api_key=self.api_key,

--- a/shinken/daemons/schedulerdaemon.py
+++ b/shinken/daemons/schedulerdaemon.py
@@ -408,7 +408,8 @@ class Shinken(BaseSatellite):
         else:
             self.raw_conf = None
         self.new_conf = None
-        free_memory()
+        if self.aggressive_memory_management:
+            free_memory()
 
         # Tag the conf with our data
         self.conf = conf

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -536,7 +536,10 @@ class Config(Item):
             BoolProp(default=True),  # Put to 0 to disable the arbiter to run
 
         'graceful_enabled':
-            BoolProp(default=False),  # Put to 0 to disable the arbiter to run
+            BoolProp(default=False),
+
+        'aggressive_memory_management':
+            BoolProp(default=False),
 
         'daemon_thread_pool_size':
             IntegerProp(default=16),

--- a/shinken/satellite.py
+++ b/shinken/satellite.py
@@ -1018,7 +1018,8 @@ class Satellite(BaseSatellite):
         else:
             self.raw_conf = None
         self.new_conf = None
-        free_memory()
+        if self.aggressive_memory_management:
+            free_memory()
 
         # we got a name, we can now say it to our statsmgr
         statsmgr.register(self, self.name, service,

--- a/shinken/util.py
+++ b/shinken/util.py
@@ -28,6 +28,7 @@ import sys
 import os
 import json
 import platform
+import traceback
 
 try:
     from ClusterShell.NodeSet import NodeSet, NodeSetParseRangeError
@@ -944,7 +945,12 @@ def free_memory():
 
     This function forces memory to be freed.
     """
-    if platform.system() == "Linux":
-        import ctypes
-        libc6 = ctypes.CDLL('libc.so.6')
-        libc6.malloc_trim(0)
+    try:
+        if platform.system() == "Linux":
+            logger.debug("Forcing memory free")
+            import ctypes
+            libc6 = ctypes.CDLL('libc.so.6')
+            libc6.malloc_trim(0)
+    except Exception:
+        logger.error("Failed to free memory")
+        logger.debug(traceback.format_exc())

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -198,6 +198,7 @@ class TestConfig(PropertiesTester, ShinkenTest):
         ('modified_attributes', 0L),
         ('daemon_enabled', True),
         ('graceful_enabled', False),
+        ('aggressive_memory_management', False),
 
         # Shinken specific
         ('idontcareaboutsecurity', False),


### PR DESCRIPTION
PR https://github.com/naparuba/shinken/pull/1828 added a routine to explicitly free memory when a new configuration is loaded.

As I'm not totally sure that freeing memory using low level `libc6` calls will work on all distributions, I prefer to let the user decide whether or not to use it.

The call to `memory_free()` is now disabled by default, and may be activated by setting the `aggressive_memory_management` option to `1` in the daemons ini configuration file.

For instance, in `schedulerd.ini`:

    ...
    port=7768
    daemon_enabled=1
    aggressive_memory_management=1
    ...