### PR TITLE
Fix: fixed unicode string parisng in shinken cmdline

### DIFF
--- a/shinken/misc/termcolor.py
+++ b/shinken/misc/termcolor.py
@@ -131,6 +131,8 @@ def cprint(text, color=None, on_color=None, attrs=None, **kwargs):
     It accepts arguments of print function.
     """
 
+    if isinstance(text, unicode):
+        text = text.encode("utf-8")
     print((colored(text, color, on_color, attrs)), **kwargs)
 
 


### PR DESCRIPTION
The `cprint` function in the `termcolor` library in the shinken cli does not correctly handle unicode strings, and raises an UnicodeEncodeError. See https://github.com/naparuba/shinken/issues/1907 for details.

This patch checks and encodes unicode strings to prevent this bug.