### PR TITLE
Fixes #1935 -- CherryPy >= 3 required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CherryPy
+CherryPy>=3
 pycurl
 importlib
 pbr

--- a/shinken/http_daemon.py
+++ b/shinken/http_daemon.py
@@ -299,6 +299,7 @@ class HTTPDaemon(object):
                 self.srv = CherryPyBackend(host, port, use_ssl, ca_cert, ssl_key,
                                            ssl_cert, hard_ssl_name_check, daemon_thread_pool_size)
             else:
+                logger.warning('Loading the old WSGI Backend. CherryPy >= 3 is recommanded instead')
                 self.srv = WSGIREFBackend(host, port, use_ssl, ca_cert, ssl_key,
                                           ssl_cert, hard_ssl_name_check, daemon_thread_pool_size)
 


### PR DESCRIPTION
CherryPy at least version 3 and better is required for Shinken to works properly.
To completely fix #1935, we should remove the old WSGI Backend to avoid communication problems.