### PR TITLE
Fixes --profile parameter

### DIFF
--- a/bin/shinken-arbiter
+++ b/bin/shinken-arbiter
@@ -123,7 +123,7 @@ def main():
     else:
         # For perf tuning:
         import cProfile
-        cProfile.run('''daemon.main()''', opts.profile)
+        cProfile.runctx('''daemon.main()''', globals(), locals(), opts.profile)
 
 
 if __name__ == '__main__':

--- a/bin/shinken-broker
+++ b/bin/shinken-broker
@@ -91,7 +91,7 @@ def main():
     else:
         # For perf tuning:
         import cProfile
-        cProfile.run('''daemon.main()''', opts.profile)
+        cProfile.runctx('''daemon.main()''', globals(), locals(), opts.profile)
 
 
 if __name__ == '__main__':

--- a/bin/shinken-poller
+++ b/bin/shinken-poller
@@ -92,7 +92,7 @@ def main():
     else:
         # For perf tuning:
         import cProfile
-        cProfile.run('''daemon.main()''', opts.profile)
+        cProfile.runctx('''daemon.main()''', globals(), locals(), opts.profile)
 
 
 if __name__ == '__main__':

--- a/bin/shinken-scheduler
+++ b/bin/shinken-scheduler
@@ -138,7 +138,7 @@ def main():
     else:
         # For perf running:
         import cProfile
-        cProfile.run('''daemon.main()''', opts.profile)
+        cProfile.runctx('''daemon.main()''', globals(), locals(), opts.profile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While attempting to debug some issue we found in our environment, I tried to make use of the --profile flag of shinken-broker. Unfortunately, this feature is broken because the context in which shinken runs doesn't have access to local or global variables, so this error is spit out:

```
Traceback (most recent call last):                                                  
  File "bin/shinken-poller", line 99, in <module>
    main()                                                                          
  File "bin/shinken-poller", line 95, in main
    cProfile.run('''daemon.main()''', opts.profile)                                                                                                                                              
  File "/usr/lib/python2.7/cProfile.py", line 29, in run                                                                                                                                         
    prof = prof.run(statement)                       
  File "/usr/lib/python2.7/cProfile.py", line 135, in run
    return self.runctx(cmd, dict, dict)
  File "/usr/lib/python2.7/cProfile.py", line 140, in runctx
    exec cmd in globals, locals
  File "<string>", line 1, in <module>
NameError: name 'daemon' is not defined
```

This PR uses cProfile.runctx instead of cProfile.run in order to provide cProfile our locals and our globals so that it finds the daemon and is able to spawn a profile environment. It fixes this error.