### PR TITLE
Pin CherryPy dependency < 9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-CherryPy>=3
+CherryPy >= 3, < 9
 pycurl
 importlib
 pbr


### PR DESCRIPTION
Pinned `cherrypy` python dependency to 8.9.1 version, the latest version which provides `wsgiserver`, used in `http_daemon.py` for all shinken daemons.

More info about this breaking change in cherrypy changelog:
http://docs.cherrypy.org/en/latest/history.html#v9-0-0

If an appropiate version of cherrypy isn't specified, bottle is used instead, which has very-well known performance limitations.