### PR TITLE
Store config errors and warnings into Configuration attributes

### DIFF
--- a/shinken/daemons/arbiterdaemon.py
+++ b/shinken/daemons/arbiterdaemon.py
@@ -444,6 +444,9 @@ class Arbiter(Daemon):
         logger.info("Cutting the hosts and services into parts")
         self.confs = self.conf.cut_into_parts()
 
+        # Display warnings, no matter if config was correct or not
+        self.conf.show_warnings()
+
         # The conf can be incorrect here if the cut into parts see errors like
         # a realm with hosts and not schedulers for it
         if not self.conf.conf_is_correct:

--- a/shinken/objects/checkmodulation.py
+++ b/shinken/objects/checkmodulation.py
@@ -64,41 +64,37 @@ class CheckModulation(Item):
 
     # Should have all properties, or a void check_period
     def is_correct(self):
-        state = True
         cls = self.__class__
-
-        # Raised all previously saw errors like unknown commands or timeperiods
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.error("[item::%s] %s", self.get_name(), err)
 
         for prop, entry in cls.properties.items():
             if prop not in cls._special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.warning("[checkmodulation::%s] %s property not set",
-                                   self.get_name(), prop)
-                    state = False  # Bad boy...
+                    self.configuration_errors.append(
+                        "[checkmodulation::%s] %s property not set" % (
+                            self.get_name(), prop)
+                    )
 
         # Ok now we manage special cases...
         # Service part
         if not hasattr(self, 'check_command'):
-            logger.warning("[checkmodulation::%s] do not have any check_command defined",
-                           self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "[checkmodulation::%s] do not have any check_command defined" % (self.get_name())
+            )
         else:
             if self.check_command is None:
-                logger.warning("[checkmodulation::%s] a check_command is missing", self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    "[checkmodulation::%s] a check_command is missing" % (self.get_name())
+                )
             if not self.check_command.is_valid():
-                logger.warning("[checkmodulation::%s] a check_command is invalid", self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    "[checkmodulation::%s] a check_command is invalid" % (self.get_name())
+                )
 
         # Ok just put None as check_period, means 24x7
         if not hasattr(self, 'check_period'):
             self.check_period = None
 
-        return state
+        return not self.has_errors()
 
 
     # In the scheduler we need to relink the commandCall with

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -794,6 +794,7 @@ class Config(Item):
         random.seed(time.time())
         self.magic_hash = random.randint(1, 100000)
         self.configuration_errors = []
+        self.configuration_warnings = []
         self.triggers_dirs = []
         self.triggers = Triggers({})
         self.packs_dirs = []
@@ -819,10 +820,16 @@ class Config(Item):
             elts = elt.split('=', 1)
             if len(elts) == 1:  # error, there is no = !
                 self.conf_is_correct = False
-                logger.error("[config] the parameter %s is malformed! (no = sign)", elts[0])
+                self.configuration_errors.append(
+                    "[config] the parameter %s is malformed! (no = sign)" %
+                    elts[0]
+                )
             elif elts[1] == '':
                 self.conf_is_correct = False
-                logger.error("[config] the parameter %s is malformed! (no value after =)", elts[0])
+                self.configuration_errors.append(
+                    "[config] the parameter %s is malformed! "
+                    "(no value after =)" % elts[0]
+                )
             else:
                 clean_p[elts[0]] = elts[1]
 
@@ -837,14 +844,18 @@ class Config(Item):
             if key in self.properties:
                 val = self.properties[key].pythonize(clean_params[key])
             elif key in self.running_properties:
-                logger.warning("using a the running property %s in a config file", key)
+                self.configuration_warnings.append(
+                    "using a the running property %s in a config file" % key
+                )
                 val = self.running_properties[key].pythonize(clean_params[key])
             elif key.startswith('$') or key in ['cfg_file', 'cfg_dir']:
                 # it's a macro or a useless now param, we don't touch this
                 val = value
             else:
-                logger.warning("Guessing the property %s type because it is not in "
-                               "%s object properties", key, self.__class__.__name__)
+                self.configuration_warnings.append(
+                    "Guessing the property %s type because it is not in "
+                    "%s object properties" % (key, self.__class__.__name__)
+                )
                 val = ToGuessProp.pythonize(clean_params[key])
 
             setattr(self, key, val)
@@ -882,7 +893,11 @@ class Config(Item):
                 fd.close()
                 self.config_base_dir = os.path.dirname(file)
             except IOError, exp:
-                logger.error("[config] cannot open config file '%s' for reading: %s", file, exp)
+                self.configuration_errors.append(
+                    "[config] cannot open config file '%s' for reading: %s" % (
+                        file, exp
+                    )
+                )
                 # The configuration is invalid because we have a bad file!
                 self.conf_is_correct = False
                 continue
@@ -910,8 +925,11 @@ class Config(Item):
                         res.write(os.linesep)
                         fd.close()
                     except IOError, exp:
-                        logger.error("Cannot open config file '%s' for reading: %s",
-                                     cfg_file_name, exp)
+                        self.configuration_errors.append(
+                            "Cannot open config file '%s' for reading: %s" % (
+                                cfg_file_name, exp
+                            )
+                        )
                         # The configuration is invalid because we have a bad file!
                         self.conf_is_correct = False
                 elif re.search("^cfg_dir", line):
@@ -922,7 +940,10 @@ class Config(Item):
                         cfg_dir_name = os.path.join(self.config_base_dir, elts[1])
                     # Ok, look if it's really a directory
                     if not os.path.isdir(cfg_dir_name):
-                        logger.error("Cannot open config dir '%s' for reading", cfg_dir_name)
+                        self.configuration_errors.append(
+                            "Cannot open config dir '%s' for reading" %
+                            cfg_dir_name
+                        )
                         self.conf_is_correct = False
 
                     # Look for .pack file into it :)
@@ -944,8 +965,12 @@ class Config(Item):
                                     res.write(os.linesep)
                                     fd.close()
                                 except IOError, exp:
-                                    logger.error("Cannot open config file '%s' for reading: %s",
-                                                 os.path.join(root, file), exp)
+                                    self.configuration_errors.append(
+                                        "Cannot open config file '%s' for "
+                                        "reading: %s" % (
+                                            os.path.join(root, file), exp
+                                        )
+                                    )
                                     # The configuration is invalid
                                     # because we have a bad file!
                                     self.conf_is_correct = False
@@ -957,7 +982,10 @@ class Config(Item):
                         trig_dir_name = os.path.join(self.config_base_dir, elts[1])
                     # Ok, look if it's really a directory
                     if not os.path.isdir(trig_dir_name):
-                        logger.error("Cannot open triggers dir '%s' for reading", trig_dir_name)
+                        self.configuration_errors.append(
+                            "Cannot open triggers dir '%s' for reading" %
+                            trig_dir_name
+                        )
                         self.conf_is_correct = False
                         continue
                     # Ok it's a valid one, I keep it
@@ -1134,7 +1162,9 @@ class Config(Item):
         """ Prepare the arbiter for early operations """
 
         if len(self.arbiters) == 0:
-            logger.warning("There is no arbiter, I add one in localhost:7770")
+            self.configuration_warnings.append(
+                "There is no arbiter, I add one in localhost:7770"
+            )
             a = ArbiterLink({'arbiter_name': 'Default-Arbiter',
                              'host_name': socket.gethostname(),
                              'address': 'localhost', 'port': '7770',
@@ -1434,8 +1464,12 @@ class Config(Item):
             properties = self.__class__.properties
             for prop, entry in properties.items():
                 if isinstance(entry, UnusedProp):
-                    logger.warning("The parameter %s is useless and can be removed "
-                                   "from the configuration (Reason: %s)", prop, entry.text)
+                    self.configuration_warnings.append(
+                        "The parameter %s is useless and can be removed "
+                        "from the configuration (Reason: %s)" % (
+                            prop, entry.text
+                        )
+                    )
 
 
     # It's used to raise warning if the user got parameter
@@ -1452,14 +1486,18 @@ class Config(Item):
                 unmanaged.append(s)
         if len(unmanaged) != 0:
             mailing_list_uri = "https://lists.sourceforge.net/lists/listinfo/shinken-devel"
-            logger.warning("The following parameter(s) are not currently managed.")
+            self.configuration_warnings.append(
+                "The following parameter(s) are not currently managed."
+            )
 
             for s in unmanaged:
                 logger.info(s)
 
-            logger.warning("Unmanaged configuration statement, do you really need it?"
-                           "Ask for it on the developer mailinglist %s or submit a pull "
-                           "request on the Shinken github ", mailing_list_uri)
+            self.configuration_warnings.append(
+                "Unmanaged configuration statement, do you really need it?"
+                "Ask for it on the developer mailinglist %s or submit a pull "
+                "request on the Shinken github " % mailing_list_uri
+            )
 
 
     # Overrides specific instances properties
@@ -1616,7 +1654,9 @@ class Config(Item):
             # so all hosts without realm will be link with it
             default = Realm({'realm_name': 'Default', 'default': '1'})
             self.realms = Realms([default])
-            logger.warning("No realms defined, I add one at %s", default.get_name())
+            self.configuration_warnings.append(
+                "No realms defined, I add one at %s" % default.get_name()
+            )
             lists = [self.pollers, self.brokers, self.reactionners, self.receivers, self.schedulers]
             for l in lists:
                 for elt in l:
@@ -1629,22 +1669,30 @@ class Config(Item):
     # with defaults values
     def fill_default_satellites(self):
         if len(self.schedulers) == 0:
-            logger.warning("No scheduler defined, I add one at localhost:7768")
+            self.configuration_warnings.append(
+                "No scheduler defined, I add one at localhost:7768"
+            )
             s = SchedulerLink({'scheduler_name': 'Default-Scheduler',
                                'address': 'localhost', 'port': '7768'})
             self.schedulers = SchedulerLinks([s])
         if len(self.pollers) == 0:
-            logger.warning("No poller defined, I add one at localhost:7771")
+            self.configuration_warnings.append(
+                "No poller defined, I add one at localhost:7771"
+            )
             p = PollerLink({'poller_name': 'Default-Poller',
                             'address': 'localhost', 'port': '7771'})
             self.pollers = PollerLinks([p])
         if len(self.reactionners) == 0:
-            logger.warning("No reactionner defined, I add one at localhost:7769")
+            self.configuration_warnings.append(
+                "No reactionner defined, I add one at localhost:7769"
+            )
             r = ReactionnerLink({'reactionner_name': 'Default-Reactionner',
                                  'address': 'localhost', 'port': '7769'})
             self.reactionners = ReactionnerLinks([r])
         if len(self.brokers) == 0:
-            logger.warning("No broker defined, I add one at localhost:7772")
+            self.configuration_warnings.append(
+                "No broker defined, I add one at localhost:7772"
+            )
             b = BrokerLink({'broker_name': 'Default-Broker',
                             'address': 'localhost', 'port': '7772',
                             'manage_arbiters': '1'})
@@ -1804,18 +1852,26 @@ class Config(Item):
 
         # We add them to the brokers if we need it
         if mod_to_add != []:
-            logger.warning("I autogenerated some Broker modules, please look at your configuration")
+            self.configuration_warnings.append(
+                "I autogenerated some Broker modules, please look at your configuration"
+            )
             for m in mod_to_add:
-                logger.warning("The module %s is autogenerated", m.module_name)
+                self.configuration_warnings.append(
+                    "The module %s is autogenerated" % m.module_name
+                )
                 for b in self.brokers:
                     b.modules.append(m)
 
         # Then for schedulers
         if mod_to_add_to_schedulers != []:
-            logger.warning("I autogenerated some Scheduler modules, "
-                           "please look at your configuration")
+            self.configuration_warnings.append(
+                "I autogenerated some Scheduler modules, "
+                "please look at your configuration"
+            )
             for m in mod_to_add_to_schedulers:
-                logger.warning("The module %s is autogenerated", m.module_name)
+                self.configuration_warnings.append(
+                    "The module %s is autogenerated" % m.module_name
+                )
                 for b in self.schedulers:
                     b.modules.append(m)
 
@@ -1844,10 +1900,14 @@ class Config(Item):
 
         # We add them to the brokers if we need it
         if mod_to_add != []:
-            logger.warning("I autogenerated some Arbiter modules, "
-                           "please look at your configuration")
+            self.configuration_warnings.append(
+                "I autogenerated some Arbiter modules, "
+                "please look at your configuration"
+            )
             for (mod, data) in mod_to_add:
-                logger.warning("Module %s was autogenerated", data['module_name'])
+                self.configuration_warnings.append(
+                    "Module %s was autogenerated" % data['module_name']
+                )
                 for a in self.arbiters:
                     a.modules = getattr(a, 'modules', []) + [data['module_name']]
                 self.modules.add_item(mod)
@@ -1891,7 +1951,9 @@ class Config(Item):
     def check_error_on_hard_unmanaged_parameters(self):
         r = True
         if self.use_regexp_matching:
-            logger.error("use_regexp_matching parameter is not managed.")
+            self.configuration_errors.append(
+                "use_regexp_matching parameter is not managed."
+            )
             r &= False
         # if self.ochp_command != '':
         #      logger.error("ochp_command parameter is not managed.")
@@ -1916,7 +1978,7 @@ class Config(Item):
             logger.info('Checking global parameters...')
         if not self.check_error_on_hard_unmanaged_parameters():
             r = False
-            logger.error("Check global parameters failed")
+            self.configuration_errors.append("Check global parameters failed")
 
         for x in ('hosts', 'hostgroups', 'contacts', 'contactgroups', 'notificationways',
                   'escalations', 'services', 'servicegroups', 'timeperiods', 'commands',
@@ -1925,29 +1987,46 @@ class Config(Item):
                 logger.info('Checking %s...', x)
 
             cur = getattr(self, x)
+
+            self.configuration_warnings.extend(cur.configuration_warnings)
+            self.configuration_warnings = list(
+                set(self.configuration_warnings))
+
             if not cur.is_correct():
+                self.configuration_errors.extend(cur.configuration_errors)
+                self.configuration_errors = list(set(self.configuration_errors))
+
                 r = False
-                logger.error("\t%s conf incorrect!!", x)
+                self.configuration_errors.append("\t%s conf incorrect!!" % x)
             if self.read_config_silent == 0:
                 logger.info('\tChecked %d %s', len(cur), x)
 
         # Hosts got a special check for loops
         if not self.hosts.no_loop_in_parents("self", "parents"):
             r = False
-            logger.error("Hosts: detected loop in parents ; conf incorrect")
+            self.configuration_errors.append(
+                "Hosts: detected loop in parents ; conf incorrect"
+            )
 
         for x in ('servicedependencies', 'hostdependencies', 'arbiters', 'schedulers',
                   'reactionners', 'pollers', 'brokers', 'receivers', 'resultmodulations',
                   'discoveryrules', 'discoveryruns', 'businessimpactmodulations'):
             try:
                 cur = getattr(self, x)
+
+                self.configuration_warnings.extend(cur.configuration_warnings)
+                self.configuration_warnings = list(
+                    set(self.configuration_warnings))
             except AttributeError:
                 continue
             if self.read_config_silent == 0:
                 logger.info('Checking %s...', x)
             if not cur.is_correct():
+                self.configuration_errors.extend(cur.configuration_errors)
+                self.configuration_errors = list(set(self.configuration_errors))
+
                 r = False
-                logger.error("\t%s conf incorrect!!", x)
+                self.configuration_errors.append("\t%s conf incorrect!!" % x)
             if self.read_config_silent == 0:
                 logger.info('\tChecked %d %s', len(cur), x)
 
@@ -1957,8 +2036,6 @@ class Config(Item):
             rea = s.realm
             if rea:
                 if len(rea.potential_brokers) == 0:
-                    logger.error("The scheduler %s got no broker in its realm or upper",
-                                 s.get_name())
                     self.add_error("Error: the scheduler %s got no broker in its realm "
                                    "or upper" % s.get_name())
                     r = False
@@ -1977,13 +2054,11 @@ class Config(Item):
                 pollers_tag.add(t)
         if not hosts_tag.issubset(pollers_tag):
             for tag in hosts_tag.difference(pollers_tag):
-                logger.error("Hosts exist with poller_tag %s but no poller got this tag", tag)
                 self.add_error("Error: hosts exist with poller_tag %s but no poller "
                                "got this tag" % tag)
                 r = False
         if not services_tag.issubset(pollers_tag):
             for tag in services_tag.difference(pollers_tag):
-                logger.error("Services exist with poller_tag %s but no poller got this tag", tag)
                 self.add_error("Error: services exist with poller_tag %s but no poller "
                                "got this tag" % tag)
                 r = False
@@ -2005,15 +2080,12 @@ class Config(Item):
                             continue
                         elt_r = elt.get_realm().realm_name
                         if not elt_r == e_r:
-                            logger.error("Business_rule '%s' got hosts from another realm: %s",
-                                         e.get_full_name(), elt_r)
                             self.add_error("Error: Business_rule '%s' got hosts from another "
                                            "realm: %s" % (e.get_full_name(), elt_r))
                             r = False
 
         if len([realm for realm in self.realms if hasattr(realm, 'default') and realm.default]) > 1:
             err = "Error : More than one realm are set to the default realm"
-            logger.error(err)
             self.add_error(err)
             r = False
 
@@ -2058,6 +2130,9 @@ class Config(Item):
         for err in self.configuration_errors:
             logger.error(err)
 
+    def show_warnings(self):
+        for warn in self.configuration_warnings:
+            logger.warning(warn)
 
     # Create packs of hosts and services so in a pack,
     # all dependencies are resolved
@@ -2264,11 +2339,10 @@ class Config(Item):
         logger.info("Total number of hosts : %d",
                     nb_elements_all_realms)
         if len(self.hosts) != nb_elements_all_realms:
-            logger.warning("There are %d hosts defined, and %d hosts dispatched in the realms. "
-                           "Some hosts have been ignored", len(self.hosts), nb_elements_all_realms)
-            self.add_error("There are %d hosts defined, and %d hosts dispatched in the realms. "
-                           "Some hosts have been "
-                           "ignored" % (len(self.hosts), nb_elements_all_realms))
+            self.configuration_warnings.append(
+                "There are %d hosts defined, and %d hosts dispatched in the realms. "
+                "Some hosts have been "
+                "ignored" % (len(self.hosts), nb_elements_all_realms))
 
 
     # Use the self.conf and make nb_parts new confs.

--- a/shinken/objects/contact.py
+++ b/shinken/objects/contact.py
@@ -170,35 +170,41 @@ class Contact(Item):
     # Check is required prop are set:
     # contacts OR contactgroups is need
     def is_correct(self):
-        state = True
         cls = self.__class__
 
         # All of the above are checks in the notificationways part
         for prop, entry in cls.properties.items():
             if prop not in _special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.error("[contact::%s] %s property not set", self.get_name(), prop)
-                    state = False  # Bad boy...
+                    self.configuration_errors.append(
+                        "[contact::%s] %s property not set" % (
+                            self.get_name(), prop
+                        )
+                    )
 
         # There is a case where there is no nw: when there is not special_prop defined
         # at all!!
         if self.notificationways == []:
             for p in _special_properties:
                 if not hasattr(self, p):
-                    logger.error("[contact::%s] %s property is missing", self.get_name(), p)
-                    state = False
+                    self.configuration_errors.append(
+                        "[contact::%s] %s property is missing" % (
+                            self.get_name(), p
+                        )
+                    )
 
         if hasattr(self, 'contact_name'):
             for c in cls.illegal_object_name_chars:
                 if c in self.contact_name:
-                    logger.error("[contact::%s] %s character not allowed in contact_name",
-                                 self.get_name(), c)
-                    state = False
+                    self.configuration_errors.append(
+                        "[contact::%s] %s character not allowed in "
+                        "contact_name" % (self.get_name(), c)
+                    )
         else:
             if hasattr(self, 'alias'):  # take the alias if we miss the contact_name
                 self.contact_name = self.alias
 
-        return state
+        return not self.has_errors()
 
     # Raise a log entry when a downtime begins
     # CONTACT DOWNTIME ALERT:

--- a/shinken/objects/contactgroup.py
+++ b/shinken/objects/contactgroup.py
@@ -79,8 +79,10 @@ class Contactgroup(Itemgroup):
         # so if True here, it must be a loop in HG
         # calls... not GOOD!
         if self.rec_tag:
-            logger.error("[contactgroup::%s] got a loop in contactgroup definition",
-                         self.get_name())
+            self.configuration_errors.append(
+                "[contactgroup::%s] got a loop in contactgroup definition" % (
+                    self.get_name())
+            )
             if self.has('members'):
                 return self.members
             else:

--- a/shinken/objects/escalation.py
+++ b/shinken/objects/escalation.py
@@ -142,7 +142,6 @@ class Escalation(Item):
     # template are always correct
     # contacts OR contactgroups is need
     def is_correct(self):
-        state = True
         cls = self.__class__
 
         # If we got the _time parameters, we are time based. Unless, we are not :)
@@ -155,37 +154,48 @@ class Escalation(Item):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.info('%s: I do not have %s', self.get_name(), prop)
-                    state = False  # Bad boy...
+                    self.configuration_errors.append(
+                        '%s: I do not have %s' % (self.get_name(), prop)
+                    )
 
-        # Raised all previously saw errors like unknown contacts and co
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.info(err)
 
         # Ok now we manage special cases...
         if not hasattr(self, 'contacts') and not hasattr(self, 'contact_groups'):
-            logger.info('%s: I do not have contacts nor contact_groups', self.get_name())
-            state = False
+            self.configuration_errors.append(
+                '%s: I do not have contacts nor contact_groups' % (
+                    self.get_name()
+                )
+            )
 
         # If time_based or not, we do not check all properties
         if self.time_based:
             if not hasattr(self, 'first_notification_time'):
-                logger.info('%s: I do not have first_notification_time', self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    '%s: I do not have first_notification_time' % (
+                        self.get_name()
+                    )
+                )
             if not hasattr(self, 'last_notification_time'):
-                logger.info('%s: I do not have last_notification_time', self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    '%s: I do not have last_notification_time' % (
+                        self.get_name()
+                    )
+                )
         else:  # we check classical properties
             if not hasattr(self, 'first_notification'):
-                logger.info('%s: I do not have first_notification', self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    '%s: I do not have first_notification' % (
+                        self.get_name()
+                    )
+                )
             if not hasattr(self, 'last_notification'):
-                logger.info('%s: I do not have last_notification', self.get_name())
-                state = False
+                self.configuration_errors.append(
+                    '%s: I do not have last_notification' % (
+                        self.get_name()
+                    )
+                )
 
-        return state
+        return not self.has_errors()
 
 
 class Escalations(Items):

--- a/shinken/objects/host.py
+++ b/shinken/objects/host.py
@@ -682,7 +682,6 @@ class Host(SchedulingItem):
     # Check is required prop are set:
     # contacts OR contactgroups is need
     def is_correct(self):
-        state = True
         cls = self.__class__
 
         source = getattr(self, 'imported_from', 'unknown')
@@ -692,54 +691,50 @@ class Host(SchedulingItem):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.error("[host::%s] %s property not set", self.get_name(), prop)
-                    state = False  # Bad boy...
-
-        # Then look if we have some errors in the conf
-        # Juts print warnings, but raise errors
-        for err in self.configuration_warnings:
-            logger.warning("[host::%s] %s", self.get_name(), err)
-
-        # Raised all previously saw errors like unknown contacts and co
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.error("[host::%s] %s", self.get_name(), err)
+                    self.configuration_errors.append(
+                        "[host::%s] %s property not set" % (self.get_name(), prop)
+                    )
 
         if not hasattr(self, 'notification_period'):
             self.notification_period = None
 
         # Ok now we manage special cases...
         if self.notifications_enabled and self.contacts == []:
-            logger.warning("The host %s has no contacts nor contact_groups in (%s)",
-                           self.get_name(), source)
+            self.configuration_warnings.append(
+                "The host %s has no contacts nor contact_groups in (%s)" % (
+                    self.get_name(), source)
+            )
 
         if getattr(self, 'event_handler', None) and not self.event_handler.is_valid():
-            logger.error("%s: my event_handler %s is invalid",
-                         self.get_name(), self.event_handler.command)
-            state = False
+            self.configuration_errors.append(
+                "%s: my event_handler %s is invalid" % (self.get_name(),
+                                                        self.event_handler.command)
+            )
 
         if getattr(self, 'check_command', None) is None:
-            logger.error("%s: I've got no check_command", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "%s: I've got no check_command" % (self.get_name()))
         # Ok got a command, but maybe it's invalid
         else:
             if not self.check_command.is_valid():
-                logger.error("%s: my check_command %s is invalid",
-                             self.get_name(), self.check_command.command)
-                state = False
+                self.configuration_errors.append(
+                    "%s: my check_command %s is invalid" % (self.get_name(),
+                                                            self.check_command.command)
+                )
             if self.got_business_rule:
                 if not self.business_rule.is_valid():
-                    logger.error("%s: my business rule is invalid", self.get_name(),)
+                    self.configuration_errors.append(
+                        "%s: my business rule is invalid" % (self.get_name()))
                     for bperror in self.business_rule.configuration_errors:
-                        logger.error("[host::%s] %s", self.get_name(), bperror)
-                    state = False
+                        self.configuration_errors.append(
+                            "[host::%s] %s" % (self.get_name(), bperror))
 
         if (not hasattr(self, 'notification_interval') and
                 self.notifications_enabled is True):
-            logger.error("%s: I've got no notification_interval but "
-                         "I've got notifications enabled", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                ("%s: I've got no notification_interval but "
+                 "I've got notifications enabled" % (self.get_name()))
+            )
 
         # if no check_period, means 24x7, like for services
         if not hasattr(self, 'check_period'):
@@ -748,11 +743,11 @@ class Host(SchedulingItem):
         if hasattr(self, 'host_name'):
             for c in cls.illegal_object_name_chars:
                 if c in self.host_name:
-                    logger.error("%s: My host_name got the character %s that is not allowed.",
-                                 self.get_name(), c)
-                    state = False
+                    self.configuration_errors.append(
+                        ("%s: My host_name got the character "
+                        "%s that is not allowed." % (self.get_name(), c)))
 
-        return state
+        return not self.has_errors()
 
 
     # Search in my service if I've got the service
@@ -1086,12 +1081,13 @@ class Host(SchedulingItem):
     # Warning: The results of host 'Server' are stale by 0d 0h 0m 58s (threshold=0d 1h 0m 0s).
     # I'm forcing an immediate check of the host.
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
-        logger.warning("The results of host '%s' are stale by %s "
-                       "(threshold=%s).  I'm forcing an immediate check "
-                       "of the host.",
-                       self.get_name(),
-                       format_t_into_dhms_format(t_stale_by),
-                       format_t_into_dhms_format(t_threshold))
+        self.configuration_warnings.append(
+            "The results of host '%s' are stale by %s "
+            "(threshold=%s).  I'm forcing an immediate check "
+            "of the host." % (self.get_name(),
+            format_t_into_dhms_format(t_stale_by),
+            format_t_into_dhms_format(t_threshold))
+        )
 
 
     # Raise a log entry with a Notification alert like
@@ -1156,9 +1152,9 @@ class Host(SchedulingItem):
 
     # If there is no valid time for next check, raise a log entry
     def raise_no_next_check_log_entry(self):
-        logger.warning("I cannot schedule the check for the host '%s' "
-                       "because there is not future valid time",
-                       self.get_name())
+        self.configuration_warnings.append(
+            "I cannot schedule the check for the host '%s' "
+            "because there is not future valid time" % (self.get_name()))
 
 
     # Raise a log entry when a downtime begins

--- a/shinken/objects/hostdependency.py
+++ b/shinken/objects/hostdependency.py
@@ -165,7 +165,9 @@ class Hostdependencies(Items):
                 tp = timeperiods.find_by_name(tp_name)
                 hd.dependency_period = tp
             except AttributeError, exp:
-                logger.error("[hostdependency] fail to linkify by timeperiod: %s", exp)
+                hd.configuration_errors.append(
+                    "[hostdependency] fail to linkify by timeperiod: %s" % exp
+                )
 
     # We backport host dep to host. So HD is not need anymore
     def linkify_h_by_hd(self):

--- a/shinken/objects/hostextinfo.py
+++ b/shinken/objects/hostextinfo.py
@@ -96,10 +96,7 @@ class HostExtInfo(Item):
     # Check is required prop are set:
     # host_name is needed
     def is_correct(self):
-        state = True
-        cls = self.__class__
-
-        return state
+        return True
 
     # For get a nice name
     def get_name(self):

--- a/shinken/objects/hostgroup.py
+++ b/shinken/objects/hostgroup.py
@@ -82,7 +82,11 @@ class Hostgroup(Itemgroup):
         # so if True here, it must be a loop in HG
         # calls... not GOOD!
         if self.rec_tag:
-            logger.error("[hostgroup::%s] got a loop in hostgroup definition", self.get_name())
+            self.configuration_errors.append(
+                "[hostgroup::%s] got a loop in hostgroup definition" % (
+                    self.get_name()
+                )
+            )
             return self.get_hosts()
 
         # Ok, not a loop, we tag it and continue
@@ -181,8 +185,12 @@ class Hostgroups(Itemgroups):
                     h.realm = hg.realm
                 else:
                     if h.realm != hg.realm:
-                        logger.warning("[hostgroups] host %s it not in the same realm than it's "
-                                       "hostgroup %s", h.get_name(), hg.get_name())
+                        self.configuration_warnings.append(
+                            "[hostgroups] host %s it not in the same realm "
+                            "than it's hostgroup %s" % (
+                                h.get_name(), hg.get_name()
+                            )
+                        )
 
     # Add a host string to a hostgroup member
     # if the host group do not exist, create it

--- a/shinken/objects/itemgroup.py
+++ b/shinken/objects/itemgroup.py
@@ -126,20 +126,15 @@ class Itemgroup(Item):
     # a item group is correct if all members actually exists,
     # so if unknown_members is still []
     def is_correct(self):
-        res = True
-
         if self.unknown_members:
             for m in self.unknown_members:
-                logger.error("[itemgroup::%s] as %s, got unknown member %s",
-                             self.get_name(), self.__class__.my_type, m)
-            res = False
+                self.configuration_errors.append(
+                    "[itemgroup::%s] as %s, got unknown member %s" % (
+                        self.get_name(), self.__class__.my_type, m
+                    )
+                )
 
-        if self.configuration_errors != []:
-            for err in self.configuration_errors:
-                logger.error("[itemgroup] %s", err)
-            res = False
-
-        return res
+        return not self.has_errors()
 
 
     def has(self, prop):

--- a/shinken/objects/macromodulation.py
+++ b/shinken/objects/macromodulation.py
@@ -61,28 +61,22 @@ class MacroModulation(Item):
 
     # Should have all properties, or a void macro_period
     def is_correct(self):
-        state = True
         cls = self.__class__
-
-        # Raised all previously saw errors like unknown commands or timeperiods
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.error("[item::%s] %s", self.get_name(), err)
 
         for prop, entry in cls.properties.items():
             if prop not in cls._special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.warning(
-                        "[macromodulation::%s] %s property not set", self.get_name(), prop
+                    self.configuration_errors.append(
+                        "[macromodulation::%s] %s property not set" % (
+                            self.get_name(), prop
+                        )
                     )
-                    state = False  # Bad boy...
 
         # Ok just put None as modulation_period, means 24x7
         if not hasattr(self, 'modulation_period'):
             self.modulation_period = None
 
-        return state
+        return not self.has_errors()
 
 
 class MacroModulations(Items):

--- a/shinken/objects/notificationway.py
+++ b/shinken/objects/notificationway.py
@@ -160,15 +160,7 @@ class NotificationWay(Item):
     # Check is required prop are set:
     # contacts OR contactgroups is need
     def is_correct(self):
-        state = True
         cls = self.__class__
-
-        # Raised all previously saw errors like unknown commands or timeperiods
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.error("[item::%s] %s", self.get_name(), err)
-
 
         # A null notif way is a notif way that will do nothing (service = n, hot =n)
         is_null_notifway = False
@@ -182,54 +174,64 @@ class NotificationWay(Item):
         for prop, entry in cls.properties.items():
             if prop not in _special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.warning("[notificationway::%s] %s property not set",
-                                   self.get_name(), prop)
-                    state = False  # Bad boy...
+                    self.configuration_errors.append(
+                        "[notificationway::%s] %s property not set" % (
+                            self.get_name(), prop
+                        )
+                    )
 
         # Ok now we manage special cases...
         # Service part
         if not hasattr(self, 'service_notification_commands'):
-            logger.warning("[notificationway::%s] do not have any "
-                           "service_notification_commands defined", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "[notificationway::%s] do not have any "
+                "service_notification_commands defined" % self.get_name()
+            )
         else:
             for cmd in self.service_notification_commands:
                 if cmd is None:
-                    logger.warning("[notificationway::%s] a "
-                                   "service_notification_command is missing", self.get_name())
-                    state = False
+                    self.configuration_errors.append(
+                        "[notificationway::%s] a service_notification_command"
+                        "is missing" % self.get_name()
+                    )
                 if not cmd.is_valid():
-                    logger.warning("[notificationway::%s] a "
-                                   "service_notification_command is invalid", self.get_name())
-                    state = False
+                    self.configuration_errors.append(
+                        "[notificationway::%s] a service_notification_command"
+                        "is invalid" % self.get_name()
+                    )
 
         if getattr(self, 'service_notification_period', None) is None:
-            logger.warning("[notificationway::%s] the "
-                           "service_notification_period is invalid", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "[notificationway::%s] the service_notification_period "
+                "is invalid" % self.get_name()
+            )
 
         # Now host part
         if not hasattr(self, 'host_notification_commands'):
-            logger.warning("[notificationway::%s] do not have any "
-                           "host_notification_commands defined", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "[notificationway::%s] do not have any "
+                "host_notification_commands defined" % self.get_name()
+            )
         else:
             for cmd in self.host_notification_commands:
                 if cmd is None:
-                    logger.warning("[notificationway::%s] a "
-                                   "host_notification_command is missing", self.get_name())
-                    state = False
+                    self.configuration_errors.append(
+                        "[notificationway::%s] a host_notification_command "
+                        "is missing" % self.get_name()
+                    )
                 if not cmd.is_valid():
-                    logger.warning("[notificationway::%s] a host_notification_command "
-                                   "is invalid (%s)", cmd.get_name(), str(cmd.__dict__))
-                    state = False
+                    self.configuration_errors.append(
+                        "[notificationway::%s] a host_notification_command "
+                        "is invalid (%s)" % (cmd.get_name(), str(cmd.__dict__))
+                    )
 
         if getattr(self, 'host_notification_period', None) is None:
-            logger.warning("[notificationway::%s] the host_notification_period "
-                           "is invalid", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "[notificationway::%s] the host_notification_period "
+                "is invalid" % self.get_name()
+            )
 
-        return state
+        return not self.has_errors()
 
 
     # In the scheduler we need to relink the commandCall with

--- a/shinken/objects/pack.py
+++ b/shinken/objects/pack.py
@@ -78,13 +78,16 @@ class Packs(Items):
     # Create a pack from the string buf, and get a real object from it
     def create_pack(self, buf, name):
         if not json:
-            logger.warning("[Pack] cannot load the pack file '%s': missing json lib", name)
+            self.configuration_warnings.append(
+                "[Pack] cannot load the pack file '%s': missing json lib" % name
+            )
             return
         # Ok, go compile the code
         try:
             d = json.loads(buf)
             if 'name' not in d:
-                logger.error("[Pack] no name in the pack '%s'", name)
+                self.configuration_errors.append(
+                    "[Pack] no name in the pack '%s'" % (name))
                 return
             p = Pack({})
             p.pack_name = d['name']
@@ -100,4 +103,5 @@ class Packs(Items):
             # Ok, add it
             self[p.id] = p
         except ValueError, exp:
-            logger.error("[Pack] error in loading pack file '%s': '%s'", name, exp)
+            self.configuration_errors.append("[Pack] error in loading pack "
+                                             "file '%s': '%s'" % (name, exp))

--- a/shinken/objects/satellitelink.py
+++ b/shinken/objects/satellitelink.py
@@ -129,7 +129,10 @@ class SatelliteLink(Item):
             return True
         except HTTPExceptions, exp:
             self.con = None
-            logger.error("Failed sending configuration for %s: %s", self.get_name(), str(exp))
+            self.configuration_errors.append(
+                "Failed sending configuration for %s: %s" % (self.get_name(),
+                                                             str(exp))
+            )
             return False
 
 
@@ -163,7 +166,9 @@ class SatelliteLink(Item):
         # We are dead now. Must raise
         # a brok to say it
         if was_alive:
-            logger.warning("Setting the satellite %s to a dead state.", self.get_name())
+            self.configuration_warnings.append(
+                "Setting the satellite %s to a dead state." % self.get_name()
+            )
             b = self.get_update_status_brok()
             self.broks.append(b)
 
@@ -176,8 +181,12 @@ class SatelliteLink(Item):
         self.attempt = min(self.attempt, self.max_check_attempts)
         # Don't need to warn again and again if the satellite is already dead
         if self.alive:
-            logger.warning("Add failed attempt to %s (%d/%d) %s",
-                           self.get_name(), self.attempt, self.max_check_attempts, reason)
+            self.configuration_warnings.append(
+                "Add failed attempt to %s (%d/%d) %s" % (
+                    self.get_name(),
+                    self.attempt,
+                    self.max_check_attempts, reason)
+            )
 
         # check when we just go HARD (dead)
         if self.attempt == self.max_check_attempts:

--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -652,7 +652,6 @@ class Service(SchedulingItem):
     # template are always correct
     # contacts OR contactgroups is need
     def is_correct(self):
-        state = True
         cls = self.__class__
 
         source = getattr(self, 'imported_from', 'unknown')
@@ -666,19 +665,11 @@ class Service(SchedulingItem):
         for prop, entry in cls.properties.items():
             if prop not in special_properties:
                 if not hasattr(self, prop) and entry.required:
-                    logger.error("The service %s on host '%s' does not have %s", desc, hname, prop)
-                    state = False  # Bad boy...
-
-        # Then look if we have some errors in the conf
-        # Juts print warnings, but raise errors
-        for err in self.configuration_warnings:
-            logger.warning("[service::%s] %s", desc, err)
-
-        # Raised all previously saw errors like unknown contacts and co
-        if self.configuration_errors != []:
-            state = False
-            for err in self.configuration_errors:
-                logger.error("[service::%s] %s", self.get_full_name(), err)
+                    self.configuration_errors.append(
+                        "The service %s on host '%s' does not have %s" % (
+                            desc, hname, prop
+                        )
+                    )
 
         # If no notif period, set it to None, mean 24x7
         if not hasattr(self, 'notification_period'):
@@ -686,8 +677,10 @@ class Service(SchedulingItem):
 
         # Ok now we manage special cases...
         if self.notifications_enabled and self.contacts == []:
-            logger.warning("The service '%s' in the host '%s' does not have "
-                           "contacts nor contact_groups in '%s'", desc, hname, source)
+            self.configuration_warnings.append(
+                "The service '%s' in the host '%s' does not have "
+                "contacts nor contact_groups in '%s'" % (desc, hname, source)
+            )
 
         # Set display_name if need
         if getattr(self, 'display_name', '') == '':
@@ -695,46 +688,58 @@ class Service(SchedulingItem):
 
         # If we got an event handler, it should be valid
         if getattr(self, 'event_handler', None) and not self.event_handler.is_valid():
-            logger.error("%s: my event_handler %s is invalid",
-                         self.get_name(), self.event_handler.command)
-            state = False
+            self.configuration_errors.append(
+                "%s: my event_handler %s is invalid" % (
+                    self.get_name(), self.event_handler.command)
+            )
 
         if not hasattr(self, 'check_command'):
-            logger.error("%s: I've got no check_command", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "%s: I've got no check_command" % (self.get_name())
+            )
+
         # Ok got a command, but maybe it's invalid
         else:
             if not self.check_command.is_valid():
-                logger.error("%s: my check_command %s is invalid",
-                             self.get_name(), self.check_command.command)
-                state = False
+                self.configuration_errors.append(
+                    "%s: my check_command %s is invalid" % (
+                        self.get_name(), self.check_command.command)
+                )
             if self.got_business_rule:
                 if not self.business_rule.is_valid():
-                    logger.error("%s: my business rule is invalid", self.get_name(),)
+                    self.configuration_errors.append(
+                        "%s: my business rule is invalid" % (self.get_name())
+                    )
                     for bperror in self.business_rule.configuration_errors:
-                        logger.error("%s: %s", self.get_name(), bperror)
-                    state = False
+                        self.configuration_errors.append("%s: %s" % (self.get_name(), bperror))
         if not hasattr(self, 'notification_interval') \
                 and self.notifications_enabled is True:
-            logger.error("%s: I've got no notification_interval but "
-                         "I've got notifications enabled", self.get_name())
-            state = False
+            self.configuration_errors.append(
+                "%s: I've got no notification_interval but "
+                "I've got notifications enabled" % (self.get_name())
+            )
         if not self.host_name:
-            logger.error("The service '%s' is not bound do any host.", desc)
-            state = False
+            self.configuration_errors.append(
+                "The service '%s' is not bound do any host." % (desc)
+            )
         elif self.host is None:
-            logger.error("The service '%s' got an unknown host_name '%s'.", desc, self.host_name)
-            state = False
+            self.configuration_errors.append(
+                "The service '%s' got an unknown host_name '%s'." % (
+                    desc, self.host_name
+                )
+            )
 
         if not hasattr(self, 'check_period'):
             self.check_period = None
         if hasattr(self, 'service_description'):
             for c in cls.illegal_object_name_chars:
                 if c in self.service_description:
-                    logger.error("%s: My service_description got the "
-                                 "character %s that is not allowed.", self.get_name(), c)
-                    state = False
-        return state
+                    self.configuration_errors.append(
+                        "%s: My service_description got the "
+                        "character %s that is not allowed." % (self.get_name(), c)
+                    )
+
+        return not self.has_errors()
 
     # The service is dependent of his father dep
     # Must be AFTER linkify
@@ -863,19 +868,16 @@ class Service(SchedulingItem):
             if errcode == GET_KEY_VALUE_SEQUENCE_ERROR_SYNTAX:
                 err = "The custom property '%s' of the host '%s' is not a valid entry %s for a service generator" % \
                       (self.duplicate_foreach.strip(), host.get_name(), entry)
-                logger.warning(err)
                 host.configuration_errors.append(err)
             elif errcode == GET_KEY_VALUE_SEQUENCE_ERROR_NODEFAULT:
                 err = "The custom property '%s 'of the host '%s' has empty " \
                       "values %s but the service %s has no default_value" % \
                       (self.duplicate_foreach.strip(),
                        host.get_name(), entry, self.service_description)
-                logger.warning(err)
                 host.configuration_errors.append(err)
             elif errcode == GET_KEY_VALUE_SEQUENCE_ERROR_NODE:
                 err = "The custom property '%s' of the host '%s' has an invalid node range %s" % \
                       (self.duplicate_foreach.strip(), host.get_name(), entry)
-                logger.warning(err)
                 host.configuration_errors.append(err)
 
         return duplicates
@@ -1019,12 +1021,14 @@ class Service(SchedulingItem):
     # Warning: The results of host 'Server' are stale by 0d 0h 0m 58s (threshold=0d 1h 0m 0s).
     # I'm forcing an immediate check of the host.
     def raise_freshness_log_entry(self, t_stale_by, t_threshold):
-        logger.warning("The results of service '%s' on host '%s' are stale "
-                       "by %s (threshold=%s).  I'm forcing an immediate check "
-                       "of the service.",
-                       self.get_name(), self.host.get_name(),
-                       format_t_into_dhms_format(t_stale_by),
-                       format_t_into_dhms_format(t_threshold))
+        self.configuration_warnings.append(
+            "The results of service '%s' on host '%s' are stale "
+            "by %s (threshold=%s).  I'm forcing an immediate check "
+            "of the service." % (self.get_name(),
+                                 self.host.get_name(),
+                                 format_t_into_dhms_format(t_stale_by),
+                                 format_t_into_dhms_format(t_threshold))
+        )
 
     # Raise a log entry with a Notification alert like
     # SERVICE NOTIFICATION: superadmin;server;Load;OK;notify-by-rss;no output
@@ -1085,9 +1089,12 @@ class Service(SchedulingItem):
 
     # If there is no valid time for next check, raise a log entry
     def raise_no_next_check_log_entry(self):
-        logger.warning("I cannot schedule the check for the service '%s' on "
-                       "host '%s' because there is not future valid time",
-                       self.get_name(), self.host.get_name())
+        self.configuration_warnings.append(
+            "I cannot schedule the check for the service '%s' on "
+            "host '%s' because there is not future valid time" % (
+                self.get_name(), self.host.get_name()
+            )
+        )
 
     # Raise a log entry when a downtime begins
     # SERVICE DOWNTIME ALERT: test_host_0;test_ok_0;STARTED;

--- a/shinken/objects/servicedependency.py
+++ b/shinken/objects/servicedependency.py
@@ -254,7 +254,11 @@ class Servicedependencies(Items):
                 sd.service_description = s
 
             except AttributeError as err:
-                logger.error("[servicedependency] fail to linkify by service %s: %s", sd, err)
+                self.configuration_errors.append(
+                    "[servicedependency] fail to linkify by service %s: %s" % (
+                        sd, err
+                    )
+                )
                 to_del.append(sd)
 
         for sd in to_del:
@@ -269,7 +273,9 @@ class Servicedependencies(Items):
                 tp = timeperiods.find_by_name(tp_name)
                 sd.dependency_period = tp
             except AttributeError, exp:
-                logger.error("[servicedependency] fail to linkify by timeperiods: %s", exp)
+                self.configuration_errors.append(
+                    "[servicedependency] fail to linkify by timeperiods: %s" % exp
+                )
 
     # We backport service dep to service. So SD is not need anymore
     def linkify_s_by_sd(self):

--- a/shinken/objects/serviceextinfo.py
+++ b/shinken/objects/serviceextinfo.py
@@ -89,10 +89,7 @@ class ServiceExtInfo(Item):
     # Check is required prop are set:
     # host_name is needed
     def is_correct(self):
-        state = True
-        cls = self.__class__
-
-        return state
+        return True
 
     # For get a nice name
     def get_name(self):

--- a/shinken/objects/servicegroup.py
+++ b/shinken/objects/servicegroup.py
@@ -81,8 +81,11 @@ class Servicegroup(Itemgroup):
         # so if True here, it must be a loop in HG
         # calls... not GOOD!
         if self.rec_tag:
-            logger.error("[servicegroup::%s] got a loop in servicegroup definition",
-                         self.get_name())
+            self.configuration_errors.append(
+                "[servicegroup::%s] got a loop in servicegroup definition" % (
+                    self.get_name()
+                )
+            )
             if self.has('members'):
                 return self.members
             else:

--- a/shinken/objects/timeperiod.py
+++ b/shinken/objects/timeperiod.py
@@ -443,17 +443,20 @@ class Timeperiod(Item):
     # We are correct only if our daterange are
     # and if we have no unmatch entries
     def is_correct(self):
-        b = True
         for dr in self.dateranges:
             d = dr.is_correct()
             if not d:
-                logger.error("[timeperiod::%s] invalid daterange ", self.get_name())
-            b &= d
+                self.configuration_errors.append(
+                    "[timeperiod::%s] invalid daterange " % self.get_name()
+                )
 
         # Warn about non correct entries
         for e in self.invalid_entries:
-            logger.warning("[timeperiod::%s] invalid entry '%s'", self.get_name(), e)
-        return b
+            self.configuration_warnings.append(
+                "[timeperiod::%s] invalid entry '%s'" % (self.get_name(), e)
+            )
+
+        return not self.has_errors()
 
     def __str__(self):
         s = ''
@@ -747,12 +750,18 @@ class Timeperiod(Item):
                 if tp is not None:
                     new_exclude.append(tp)
                 else:
-                    logger.error("[timeentry::%s] unknown %s timeperiod", self.get_name(), tp_name)
+                    self.configuration_errors.append(
+                        "[timeentry::%s] unknown %s timeperiod" % (
+                            self.get_name(), tp_name
+                        )
+                    )
         self.exclude = new_exclude
 
     def check_exclude_rec(self):
         if self.rec_tag:
-            logger.error("[timeentry::%s] is in a loop in exclude parameter", self.get_name())
+            self.configuration_errors.append(
+                "[timeentry::%s] is in a loop in exclude parameter" % self.get_name()
+            )
             return False
         self.rec_tag = True
         for tp in self.exclude:


### PR DESCRIPTION
Both @mgarcian and me modified all classes regarding to Shinken object definitions in order to store configuration errors and warnings into instances of these classes. These errors are lifted up to `Configuration` instances so they are gathered up together into a single place.

Users are now capable of validating Shinken configurations by spawning `Arbiter` instances in a programmatic manner and collect config errors and warnings to perform some sort of post-processing over them.