### PR TITLE
Update link_vmware_host_vm.py

### DIFF
--- a/libexec/link_vmware_host_vm.py
+++ b/libexec/link_vmware_host_vm.py
@@ -63,6 +63,9 @@ def get_vmware_hosts(check_esx_path, vcenter, user, password):
     output = Popen(list_host_cmd, stdout=PIPE).communicate()
 
     parts = output[0].split(':')
+    if len(parts) < 2:
+        return []
+    
     hsts_raw = parts[1].split('|')[0]
     hsts_raw_lst = hsts_raw.split(',')
 


### PR DESCRIPTION
Fix error triggering if message "CRITICAL - There are no VMs" is sent by ESX.