### PR TITLE
Enh: better objects balancing between schedulers

### DIFF
--- a/shinken/objects/service.py
+++ b/shinken/objects/service.py
@@ -1505,10 +1505,10 @@ class Services(Items):
                 # Looks for corresponding services
                 services = self.get_ovr_services_from_expression(host, sdescr)
                 if not services:
-                    err = "Error: trying to override property '%s' on " \
+                    err = "Warn: trying to override property '%s' on " \
                           "service identified by '%s' " \
                           "but it's unknown for this host" % (prop, sdescr)
-                    host.configuration_errors.append(err)
+                    host.configuration_warnings.append(err)
                     continue
                 value = Service.properties[prop].pythonize(value)
                 for service in services:

--- a/test/test_property_override.py
+++ b/test/test_property_override.py
@@ -108,8 +108,8 @@ class TestConfigBroken(ShinkenTest):
         [b.prepare() for b in self.broks]
         logs = [b.data['log'] for b in self.broks if b.type == 'log']
         self.assertEqual(1, len([log for log in logs if re.search('Error: invalid service override syntax: fake', log)]) )
-        self.assertEqual(1, len([log for log in logs if re.search("Error: trying to override property 'retry_interval' on service identified by 'fakesrv' but it's unknown for this host", log)]) )
-        self.assertEqual(1, len([log for log in logs if re.search("Error: trying to override 'host_name', a forbidden property for service 'proc proc2'", log)]) )
+        self.assertEqual(1, len([log for log in logs if re.search("Warn: trying to override property 'retry_interval' on service identified by 'fakesrv' but it's unknown for this host", log)]) )
+        self.assertEqual(1, len([log for log in logs if re.search("Warn: trying to override 'host_name', a forbidden property for service 'proc proc2'", log)]) )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current balancing strategy spreading objects between schedulers is a simple round robin.

This is sufficient for configurations with homogeneous pack sizes, but with heterogeneous configuration with host/service groups of different sizes, complex service dependencies or large business rules, this can result sometimes in a greatly unbalanced dispatching.

This patch introduce a routine that selects the scheduler managing the lowest amount of objects for each pack. The result is a more evenly balanced load across the schedulers.

Also, modifies the behavior of `service_overrides` property when overriding a parameter for an unknown service. The previous behavior raised an error. The new one only raises a warning. This is way more convenient when dealing with portion of configuration that are enabled or disabled.