### PR TITLE
Enh: Force problem/impact evaluation

### DIFF
--- a/doc/source/03_configuration/configmain.rst
+++ b/doc/source/03_configuration/configmain.rst
@@ -195,6 +195,26 @@ Default:
 This option is used to know if we apply or not the state change when a host or service is impacted by a root problem (like the service's host going down or a host's parent being down too). The state will be changed by UNKNONW for a service and UNREACHABLE for a host until their next schedule check. This state change do not count as a attempt, it's just for console so the users know that theses objects got problems and the previous states are not sure.
 
 
+.. _configuration/configmain#enable_problem_impacts_states_reprocessing:
+
+Enable problem/impacts states change
+-------------------------------------
+
+Format:
+
+::
+
+  enable_problem_impacts_states_reprocessing=<0/1>
+
+Default:
+
+::
+
+  enable_problem_impacts_states_reprocessing=0
+
+This option is used to enforce the reprocessing of the problem/impact state after the retention data has been loaded in the scheduler. I's off by default, meaning that the problem/impact related attributes only get modified when a new state change is detected (a new active or passive check result has arrived with a different state). When enabled, this feature walks through the entire objects dependency tree to re-evaluate the object state after the basic objects state has been restored.
+
+
 .. _configuration/configmain#disable_old_nagios_parameters_whining:
 
 Disable Old Nagios Parameters Whining

--- a/doc/source/09_architecture/problems-and-impacts.rst
+++ b/doc/source/09_architecture/problems-and-impacts.rst
@@ -1,11 +1,11 @@
 .. _architecture/problems-and-impacts:
 
 ============================================
-Problems and impacts correlation management 
+Problems and impacts correlation management
 ============================================
 
 
-What is this correlation ? 
+What is this correlation ?
 ===========================
 
 The main role of this feature is to allow users to have the same correlation views in the console than they got in the notifications.
@@ -29,10 +29,10 @@ It"s important to see that such state change do not interfere with the HARD/SOFT
 Here gateway is already in DOWN/HARD. We can see that all servers do not have an output: they are not already checked, but we already set the UNREACHABLE state. When they will be checks, there will be an output and they will keep this state.
 
 
-How to enable it? 
+How to enable it?
 ==================
 
-It's quite easy, all you need is to enable the parameter 
+It's quite easy, all you need is to enable the parameter
 
 ::
 
@@ -41,7 +41,7 @@ It's quite easy, all you need is to enable the parameter
 See :ref:`enable_problem_impacts_states_change <configuration/configmain#enable_problem_impacts_states_change>` for more information about it.
 
 
-Dynamic Business Impact 
+Dynamic Business Impact
 ========================
 
 There is a good thing about problems and impacts when you do not identify a parent devices Business Impact: your problem will dynamically inherit the maximum business impact of the failed child!
@@ -55,3 +55,15 @@ There are 2 nights:
   * the second night, the switch got a problem, but this time it impacts the production environment! This time, the computed impact is set at 5 (the one of the max impact, here the production application), so it's higher than the min_criticity of the contact, so the notification is send. The admin is awaken, and can solve this problem before too many users are impacted :)
 
 
+Enforce problem/impact state calculation
+=========================================
+
+The problem/impact calculation that defines if a failed check is the root cause of the problem or is an impact is done when a new check result arrives. When the scheduler restarts or receives a new configuration, it may save an restore the previous objects state from the retention data. There's situations where the problem/impact attributes can get back to their default value, even if an object state is not OK. By default, the attributes are only recalculated when a new check result arrives.
+
+It's possible to enforce the problem/impact processing of all the objects after the retention data has been loaded. To enable this feature you only have to enable the parameter
+
+::
+
+  enable_problem_impacts_states_reprocessing=1
+
+See :ref:`enable_problem_impacts_states_reprocessing <configuration/configmain#enable_problem_impacts_states_reprocessing>` for more information about it.

--- a/shinken/objects/config.py
+++ b/shinken/objects/config.py
@@ -567,6 +567,9 @@ class Config(Item):
         'enable_problem_impacts_states_change':
             BoolProp(default=False, class_inherit=[(Host, None), (Service, None)]),
 
+        'enable_problem_impacts_states_reprocessing':
+            BoolProp(default=False, class_inherit=[(Host, None), (Service, None)]),
+
         # More a running value in fact
         'resource_macros_names':
             ListProp(default=[]),

--- a/test/test_properties_defaults.py
+++ b/test/test_properties_defaults.py
@@ -209,6 +209,7 @@ class TestConfig(PropertiesTester, ShinkenTest):
         ('cleaning_queues_interval', 900),
         ('disable_old_nagios_parameters_whining', False),
         ('enable_problem_impacts_states_change', False),
+        ('enable_problem_impacts_states_reprocessing', False),
         ('resource_macros_names', []),
 
         # SSL part


### PR DESCRIPTION
When the retention data is saved by the scheduler, only the direct objects state is saved (last check time, state, state type, ...), but not the problem/impact related attributes (the associated data structure
is too complex).

This means that when the retention data is reloaded, the objects direct state is restored, but not the problem/impact related attributes, which come back to their default value. They only get recalculated when a new check result arrives arrives for a given host/service. Additionally, a Brok is only emitted if the objects have dependencies. This means that the broker isn't aware of the attribute change until a state change is triggered.

This patch adds the ability to force problem/impact evaluation on all the objects after the retention data has been reloaded. In such a situation, a Brok should not be emitted as the broker will request initial Broks soon after. The `send_brok` is there precisely to control the Broks emission in such a situation.

This feature is disabled by default, and can be enabled by setting the global parameter `enable_problem_impacts_states_reprocessing` parameter to `1` in addition to the `enable_problem_impacts_states_change` parameter in the Shinken main configuration file:

    enable_problem_impacts_states_change=1
    enable_problem_impacts_states_reprocessing=1

Some factorization has also been made in the retention data restoration routines to ease further maintenance.