### PR TITLE
Fix: Typo that does not reload downtimes after retention load

### DIFF
--- a/shinken/objects/schedulingitem.py
+++ b/shinken/objects/schedulingitem.py
@@ -919,9 +919,9 @@ class SchedulingItem(Item):
             if dt.in_scheduled_downtime():
                 self.scheduled_downtime_depth += 1
         if self.scheduled_downtime_depth > 0:
-            self.is_in_scheduled_downtime = True
+            self.in_scheduled_downtime = True
         else:
-            self.is_in_scheduled_downtime = False
+            self.in_scheduled_downtime = False
         if getattr(self, "acknowledgement", None) is not None:
             self.problem_has_been_acknowledged = True
         else:


### PR DESCRIPTION
Since Shinken 2.4.4 (and exactly since 5f3525f1632c1feda744f66f48e9aa3eb72ebc91), hosts and services downtimes are lost after arbiter/scheduler restarts. 

Shinken 2.4.4 removes the retention of `in_scheduled_downtime` and uses a new method after retention load to re-compute the variable by looking at `downtimes` list. BUT it computes `is_in_scheduled_downtime` instead of `in_scheduled_downtime`, so the rest does not work (at least in mod_webui, but I can't see how it could work anywhere).

This PR fixes the typo.